### PR TITLE
Weather conditions for "shading in" are optional

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2040,7 +2040,10 @@ action:
           - or:
               - "{{ ( shading_forecast_sensor == [] ) and (shading_temperatur_sensor1 == [] ) }}"
               - "{{ ( shading_forecast_sensor != [] ) and (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) >= shading_forecast_temp ) }}"
-          - "{{ ( shading_forecast_sensor == [] ) or (states(shading_forecast_sensor) in shading_weather_conditions) }}"
+          - or:
+              - "{{ shading_forecast_sensor == [] }}"
+              - "{{ shading_weather_conditions == [] }}"
+              - "{{ states(shading_forecast_sensor) in shading_weather_conditions }}"
 
         sequence:
           - if: # Check helper or if cover is higher than ventilate position. In this case we consider cover position like open and therefor we want to use the delay timer


### PR DESCRIPTION
Hi,

the description of `shading_weather_conditions` says _Optional_, as it should be. But leaving the conditions empty when using `shading_forecast_sensor`  for only `shading_forecast_temp` results the condition `Check for shading in` to always become `False`.

This example in the template editor shows the difference:
```
{% set shading_weather_conditions = [] %}
{% set shading_forecast_sensor = 'weather.forecast_home' %}

{{ shading_forecast_sensor == [] or states(shading_forecast_sensor) in shading_weather_conditions }}
{{ shading_forecast_sensor == [] or shading_weather_conditions == [] or states(shading_forecast_sensor) in shading_weather_conditions }}
```
Resolves to:
```
False
True
```

You may edit my change suggestion of course.
