### PR TITLE
Trigger reduction

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.03.19-01
+    **Version**: 2024.03.20-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -96,7 +96,7 @@ blueprint:
       - Fixed: Ventilation mode could always be started by mistake.
       - Fixing helper length check. Thx to crandler.
 
-    2024.03.19-01:
+    2024.03.20-01:
       - New: Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
       - New: Added possibility to disable the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions
       - Fixed: Shading Forecast Weather Conditions
@@ -104,6 +104,7 @@ blueprint:
       - Fixed: Added the ventilation mode activation on closing down again
       - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
       - Try to avoid overlaps in the execution of the automation if several triggers are triggered shortly after each other.
+      - Fixed: Optional weather conditions for "shading in" #41
 
     </details>
 
@@ -213,7 +214,7 @@ blueprint:
         </details>
         <br />
         <details>
-        <summary><code><strong>CLICK HERE:</strong> Important information since version 2024.03.19-01</code></summary>
+        <summary><code><strong>CLICK HERE:</strong> Important information since version 2024.03.20-01</code></summary>
 
 
         It is not possible to find out more about the status of the schedule helper in Home Assistant.
@@ -1229,7 +1230,7 @@ mode: restart #queued
 max_exceeded: silent
 
 variables:
-  version: "2024.03.19-01"
+  version: "2024.03.20-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1703,78 +1704,93 @@ trigger:
   # Triggers for shading in
   ########################################
 
-  #  TODO: Combine into one trigger
-  # - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
-  # - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
-  # - "{{ current_position | int(default=101) > shading_position }}"
-
-  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
+  - platform: template # Mandatory and optional triggers
     value_template: >-
       {{
         is_shading_enabled and
-        shading_temperatur_sensor1 != [] and
-        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 and
-        state_attr(blind, 'current_position') | int(default=110) != close_position and
-        state_attr(blind, 'current_position') | int(default=101) > shading_position
+        default_sun_sensor != [] and
+        state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
+        state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
+        state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
+        (shading_brightness_sensor == [] or states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start) and
+        (shading_temperatur_sensor1 == [] or states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1) and
+        (shading_temperatur_sensor2 == [] or states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2)
       }}
     for: "00:00:05"
     id: "t_si_1"
 
-  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
-    value_template: >-
-      {{
-        is_shading_enabled and
-        shading_temperatur_sensor2 != [] and
-        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 and
-        state_attr(blind, 'current_position') | int(default=110) != close_position and
-        state_attr(blind, 'current_position') | int(default=101) > shading_position
-      }}
-    for: "00:00:05"
-    id: "t_si_2"
-
-  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
-    value_template: >-
-      {{
-        is_shading_enabled and
-        shading_brightness_sensor != [] and
-        states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start and
-        state_attr(blind, 'current_position') | int(default=110) != close_position and
-        state_attr(blind, 'current_position') | int(default=101) > shading_position
-      }}
-    for: "00:00:05"
-    id: "t_si_3"
-
-  - platform: template
-    value_template: >-
-      {{
-        is_shading_enabled and
-        default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min) and
-        state_attr(blind, 'current_position') | int(default=110) != close_position and
-        state_attr(blind, 'current_position') | int(default=101) > shading_position
-      }}
-    for: "00:00:05"
-    id: "t_si_4"
-
-  - platform: template
-    value_template: >-
-      {{
-        is_shading_enabled and
-        default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start) and
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end) and
-        state_attr(blind, 'current_position') | int(default=110) != close_position and
-        state_attr(blind, 'current_position') | int(default=101) > shading_position
-      }}
-    for: "00:00:05"
-    id: "t_si_5"
-
-  # TODO
-  # - platform: numeric_state
-  #   entity_id: !input shading_temperatur_sensor1
-  #   above: !input shading_forecast_temp
+  # - platform: template # Optional trigger
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       shading_brightness_sensor != [] and
+  #       states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start and
+  #       default_sun_sensor != [] and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
+  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
+  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
+  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
+  #     }}
   #   for: "00:00:05"
-  #   id: "t_si_6"
+  #   id: "t_si_2"
+
+  # - platform: template # Optional trigger
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       shading_temperatur_sensor1 != [] and
+  #       states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 and
+  #       default_sun_sensor != [] and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
+  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
+  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
+  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
+  #     }}
+  #   for: "00:00:05"
+  #   id: "t_si_3"
+
+  # - platform: template # Optional trigger
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       shading_temperatur_sensor2 != [] and
+  #       states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 and
+  #       default_sun_sensor != [] and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
+  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
+  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
+  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
+  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
+  #     }}
+  #   for: "00:00:05"
+  #   id: "t_si_4"
+
+  # - platform: template
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       default_sun_sensor != [] and
+  #       (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min) and
+  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
+  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
+  #     }}
+  #   for: "00:00:05"
+  #   id: "t_si_4"
+
+  # - platform: template
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       default_sun_sensor != [] and
+  #       (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start) and
+  #       (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end) and
+  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
+  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
+  #     }}
+  #   for: "00:00:05"
+  #   id: "t_si_5"
 
   ########################################
   # Triggers for shading out
@@ -1785,8 +1801,7 @@ trigger:
       {{
         is_shading_enabled and
         shading_temperatur_sensor1 != [] and
-        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) < shading_min_temperatur1 and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) < shading_min_temperatur1
       }}
     for: "00:00:05"
     id: "t_so_1"
@@ -1796,8 +1811,7 @@ trigger:
       {{
         is_shading_enabled and
         shading_temperatur_sensor2 != [] and
-        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) < shading_min_temperatur2 and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) < shading_min_temperatur2
       }}
     for: "00:00:05"
     id: "t_so_2"
@@ -1807,8 +1821,7 @@ trigger:
       {{
         is_shading_enabled and
         shading_brightness_sensor != [] and
-        states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end
       }}
     for: "00:00:05"
     id: "t_so_3"
@@ -1818,8 +1831,7 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max) and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max)
       }}
     for: "00:00:05"
     id: "t_so_4"
@@ -1829,8 +1841,7 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end) and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end)
       }}
     for: "00:00:05"
     id: "t_so_5"
@@ -1840,27 +1851,10 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min) and
-        state_attr(blind, 'current_position') | int(default=110) != open_position
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
       }}
     for: "00:00:05"
     id: "t_so_6"
-
-  # TODO
-  # - platform: template
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       shading_brightness_sensor != [] and
-  #       default_sun_sensor != [] and
-  #       states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end and
-  #       (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_so_test"
-
-  # - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
-  # - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
 
   ########################################
   # Trigger for manual cover movements
@@ -1891,11 +1885,9 @@ action:
       - condition: trigger
         id:
           - "t_si_1"
-          - "t_si_2"
-          - "t_si_3"
-          - "t_si_4"
-          - "t_si_5"
-          # - "t_si_6"
+          # - "t_si_2"
+          # - "t_si_3"
+          # - "t_si_4"
     then:
       - service: weather.get_forecasts
         target:
@@ -2311,13 +2303,14 @@ action:
           - condition: trigger
             id:
               - "t_si_1"
-              - "t_si_2"
-              - "t_si_3"
-              - "t_si_4"
-              - "t_si_5"
-              # - "t_si_6"
+              # - "t_si_2"
+              # - "t_si_3"
+              # - "t_si_4"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
+          - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+          - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
+          - "{{ current_position | int(default=101) > shading_position }}"
           - or: # Check the current positions
               # - "{{ is_ventilation_enabled and contact_sensor != [] and is_state(contact_sensor, ['true', 'on']) }}" # TODO: Why?
               - "{{ is_status_helper_enabled and ignore_shading_after_manual and is_cover_manual }}"
@@ -2325,7 +2318,7 @@ action:
               - "{{ is_status_helper_enabled and not (is_cover_ventilated or is_cover_locked) }}"
               - "{{ not (current_position | int(default=101) == ventilate_position) }}" # TODO: Why not checking with shading_pos, too?
           - or: # Only once a day
-              - "{{ not is_status_helper_enabled or is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
+              - "{{ (not is_status_helper_enabled) or is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
           - or:
               - and:
                   - "{{ is_time_field_enabled }}"
@@ -2335,17 +2328,25 @@ action:
                   - "{{ is_schedule_helper_enabled }}"
                   - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'on') }}"
-          - "{{ ( (shading_temperatur_sensor1 == [] ) or (states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1) ) }}"
-          - "{{ ( (shading_temperatur_sensor2 == [] ) or (states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2) ) }}"
-          - "{{ ( (shading_brightness_sensor == [] ) or (states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start) ) }}"
-          - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
-          - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
-          - "{{ current_position | int(default=101) > shading_position }}"
-          - "{{ resident_sensor == [] or is_state(resident_sensor, ['false', 'off']) }}"
           - or:
-              - "{{ ( shading_forecast_sensor == [] ) and (shading_temperatur_sensor1 == [] ) }}"
-              - "{{ ( shading_forecast_sensor != [] ) and (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp ) }}"
-          - "{{ ( shading_forecast_sensor == [] ) or ((not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions) }}"
+              - "{{ shading_temperatur_sensor1 == [] }}"
+              - "{{ states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 }}"
+          - or:
+              - "{{ shading_temperatur_sensor2 == [] }}"
+              - "{{ states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 }}"
+          - or:
+              - "{{ shading_brightness_sensor == [] }}"
+              - "{{ states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start }}"
+          - or:
+              - "{{ shading_forecast_sensor == [] }}"
+              - "{{ (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp ) }}"
+          - or:
+              - "{{ shading_forecast_sensor == [] }}"
+              - "{{ shading_weather_conditions == [] }}"
+              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions }}"
+          - or:
+              - "{{ resident_sensor == [] }}"
+              - "{{ is_state(resident_sensor, ['false', 'off']) }}"
 
         sequence:
           - if: # Check helper or if cover is higher than ventilate position. In this case we consider cover position like open and therefor we want to use the delay timer
@@ -2453,7 +2454,7 @@ action:
                       - "{{ not (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}"
 
         sequence:
-          - if: # If sun is outside of shading window (azimuth or elevation) we immediately stop shading
+          - if: # If sun is outside of shading window (azimuth or elevation) we immediately stop shading # TODO: Why here and not above? Not not necessary anymore.
               - and:
                   - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
                   - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.03.14-01
+    **Version**: 2024.03.19-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -78,43 +78,6 @@ blueprint:
     <details>
     <summary><strong>Latest changes</strong></summary>
 
-    2024.02.18-01:
-      - Fixed: Schedule open/close-bug
-      - Fixed: Next try - faster checking for manual position changes
-      - Separate ventilation from lockout protection
-      - Added own lockout protection feature
-      - Removed door/window chooser (contact_cover_place)
-
-    2024.02.18-02:
-      - Fixed: Problems with helper json
-
-    2024.02.19-01:
-      - Added: External trigger to force opening or closing. Useful for Antifreeze, RainProtection or WindProtection.
-      - Fixed: Still timing problems occur when recognising manual drives
-      - Added: Additional actions for open, close, ventilation, shading start and shading end
-
-    2024.02.28-01:
-      - Fixed a nasty bug in the helper detection.
-      - Fixed the warning: AttributeError: ‘list’ object has no attribute ‘lower’
-
-    2024.02.28-02:
-      - Fixed: Float values were incorrectly compared as integers. This fixed problems with sun-elevation and brightness.
-
-    2024.03.01-01:
-      - Roller blinds may only be closed once after Time_Down_Late. Previously, the entire day was checked.
-
-    2024.03.11-01:
-      - Added various options for fine adjustment
-      - Possibility to ignore actions after manual position changes
-      - Only compare such positions if the mode has been activated accordingly
-      - Avoid status change from 'unavailable'
-      - Allow delay in ventilation mode
-      - Fixed: Shading should not be activated when ventilation mode is active
-      - Fixed: Closing the door contact should always lower the roller
-      - Instead of cover helper and position detection working against each other, the two can now complement each other.
-      - Manual detection adjusted. Positions 0% and 100% always result in close/open regardless of the configuration.
-      - Forcing a status is now also automatically used as a negative condition in other queries.
-
     2024.03.11-02:
       - Completely new structure of the various choose-branches
       - Relocation of some conditions to the sequence section
@@ -133,8 +96,14 @@ blueprint:
       - Fixed: Ventilation mode could always be started by mistake.
       - Fixing helper length check. Thx to crandler.
 
-    2024.03.14-xx:
-      - Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
+    2024.03.19-01:
+      - New: Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
+      - New: Added possibility to disable the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions
+      - Fixed: Shading Forecast Weather Conditions
+      - Fixed: Ventilation mode should not only be ended in the evening, but whenever it is not yet daytime.
+      - Fixed: Added the ventilation mode activation on closing down again
+      - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
+      - Try to avoid overlaps in the execution of the automation if several triggers are triggered shortly after each other.
 
     </details>
 
@@ -242,6 +211,29 @@ blueprint:
             The cover is closed when the threshold is undershot and the helper is off.
 
         </details>
+        <br />
+        <details>
+        <summary><code><strong>CLICK HERE:</strong> Important information since version 2024.03.19-01</code></summary>
+
+
+        It is not possible to find out more about the status of the schedule helper in Home Assistant.
+        I never know whether we are at the beginning or end of the period.
+        However, this is important to avoid bouncing when controlling the brightness, for example.
+        In order to recognise whether we are still in the opening period or the closing period,
+        it is necessary to enter a very rough time period in the time variables in the blueprint.
+        <br />
+        <ins>Example:</ins>
+        If the schedule helper goes to the "ON" status at 08:00 and to the "OFF" status at 18:00, it is sufficient to configure the times as follows:
+        <br /><br />
+        Time For Drive Up - Early: 06:00<br />
+        Time For Drive Up - Late: 12:00<br /><br />
+        Time For Drive Down - Early: 16:00<br />
+        Time For Drive Down - Late: 22:00<br />
+
+        The times are not used for triggering, but only to divide the day into two halves!
+
+        </details>
+
       default: time_control_input
       selector:
         select:
@@ -878,7 +870,7 @@ blueprint:
       name: "🥵 Shading Brightness Start Value"
       description: >-
         The minimum brightness value from which shading should start.
-        (Must be above the value of brightness out!)
+        (Must be above the value of brightness end!)
         <br /><br />`Optional`
         <br /><br />`Shading`
       default: 35000
@@ -893,7 +885,7 @@ blueprint:
       name: "🥵 Shading Brightness End Value"
       description: >-
         The brightness value from which shading is no longer necessary.
-        (Must be BELOW the value of brightness in!).
+        (Must be below the value of brightness start!).
         <br /><br />`Optional`
         <br /><br />`Shading`
       default: 25000
@@ -1171,7 +1163,20 @@ blueprint:
 
     individual_config:
       name: "⚙️ Individual Configuration"
-      description: "Various different options for some fine adjustments"
+      description: >-
+        Various different options for some fine adjustments
+
+        <details>
+        <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
+
+          - <ins>Prevent 'set_cover_position' and 'set_cover_tilt_position'</ins>
+            There are devices that have problems when the two services 'set_cover_position' and 'set_cover_tilt_position' are executed directly one after the other.
+            For example, there are Shelly devices that use the script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066) here.
+            Or Homematic blind actuators, which can better use their own service for this: [homematicip_local.set_cover_combined_position](https://github.com/danielperna84/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position).
+            This option can be used to disable the standard services and allows the control to be implemented individually via the addtional actions.
+
+        </details>
+
       default: []
       selector:
         select:
@@ -1182,10 +1187,12 @@ blueprint:
               value: "prevent_higher_position_closing"
             - label: "🚫 Prevent the automation from moving to a higher closing position at the end of shading"
               value: "prevent_higher_position_shading_end"
-            - label: "🚫 Prevent the use of the get_forecasts service"
+            - label: "🚫 Prevent the use of the 'get_forecasts' service"
               value: "prevent_forecast_service"
             - label: "🚫 Prevent the end of shading when the cover is already closed"
               value: "prevent_shading_end_if_closed"
+            - label: "🚫 Prevent the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions"
+              value: "prevent_default_cover_actions"
           multiple: true
           sort: false
           custom_value: false
@@ -1218,13 +1225,14 @@ blueprint:
             - "info"
             - "warning"
 
-mode: restart
+mode: restart #queued
 max_exceeded: silent
 
 variables:
-  version: "2024.03.14-01"
-  blind: !input blind
+  version: "2024.03.19-01"
+
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
+  current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
   current_sun_azimuth: "{{ state_attr(default_sun_sensor, 'azimuth') }}"
   current_sun_elevation: "{{ state_attr(default_sun_sensor, 'elevation') }}"
 
@@ -1262,9 +1270,7 @@ variables:
     {% endif %}
 
   # Positions
-  open_position: !input open_position
   open_tilt_position: !input shading_tilt_position
-  close_position: !input close_position
   close_tilt_position: !input close_tilt_position
   ventilate_position: !input ventilate_position
   ventilate_tilt_position: !input ventilate_tilt_position
@@ -1276,7 +1282,6 @@ variables:
   auto_ventilate_force: !input auto_ventilate_force
 
   # Shading
-  shading_position: !input shading_position
   shading_tilt_position: !input shading_tilt_position
   shading_waitingtime_start: !input shading_waitingtime_start
   shading_waitingtime_end: !input shading_waitingtime_end
@@ -1286,9 +1291,6 @@ variables:
   # Config check
   check_config: !input check_config
   check_config_debuglevel: !input check_config_debuglevel
-
-  # Little helper for leaner code
-  current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
 
   # Cover Status Helper
   cover_status_options: !input cover_status_options
@@ -1401,6 +1403,7 @@ variables:
   prevent_higher_position_shading_end: "{{ 'prevent_higher_position_shading_end' in individual_config }}"
   prevent_forecast_service: "{{ 'prevent_forecast_service' in individual_config }}"
   prevent_shading_end_if_closed: "{{ 'prevent_shading_end_if_closed' in individual_config }}"
+  prevent_default_cover_actions: "{{ 'prevent_default_cover_actions' in individual_config }}"
 
   ignore_after_manual_config: !input ignore_after_manual_config
   ignore_opening_after_manual: "{{ 'ignore_opening_after_manual' in ignore_after_manual_config }}"
@@ -1413,6 +1416,13 @@ variables:
   ventilation_if_lower_enabled: "{{ 'ventilation_if_lower_enabled' in auto_ventilate_options }}"
 
 trigger_variables:
+  blind: !input blind
+
+  # Positions
+  open_position: !input open_position
+  close_position: !input close_position
+  shading_position: !input shading_position
+
   # Modes
   auto_options: !input auto_options
 
@@ -1502,48 +1512,62 @@ trigger:
       {{
         is_brightness_enabled and
         default_brightness_sensor != [] and
-        (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up) and
-        (
-          (
-            is_time_field_enabled and
-            now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
-            now() <= today_at([time_up_late, time_up_late_non_workday] | min) + timedelta(seconds = 5)
-          )
-          or
-          (
-            is_schedule_helper_enabled and
-            time_schedule_helper != [] and
-            is_state(time_schedule_helper, 'on')
-          )
-        )
+        (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up)
       }}
     for:
       seconds: !input brightness_time_duration
-    id: "t_bo_4"
+    id:
+      "t_bo_4"
+
+      # {{
+      #   is_brightness_enabled and
+      #   default_brightness_sensor != [] and
+      #   (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up) and
+      #   (
+      #     (
+      #       is_time_field_enabled and
+      #       now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
+      #       now() <= today_at([time_up_late, time_up_late_non_workday] | max) + timedelta(seconds = 5)
+      #     )
+      #     or
+      #     (
+      #       is_schedule_helper_enabled and
+      #       time_schedule_helper != [] and
+      #       is_state(time_schedule_helper, 'on')
+      #     )
+      #   )
+      # }}
 
   - platform: template
     value_template: >-
       {{
         is_sun_elevation_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up) and
-        (
-          (
-            is_time_field_enabled and
-            now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
-            now() <= today_at([time_up_late, time_up_late_non_workday] | min) + timedelta(seconds = 5)
-          )
-          or
-          (
-            is_schedule_helper_enabled and
-            time_schedule_helper != [] and
-            is_state(time_schedule_helper, 'on')
-          )
-        )
+        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up)
       }}
     for:
       seconds: !input sun_time_duration
-    id: "t_bo_5"
+    id:
+      "t_bo_5"
+
+      # {{
+      #   is_sun_elevation_enabled and
+      #   default_sun_sensor != [] and
+      #   (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up) and
+      #   (
+      #     (
+      #       is_time_field_enabled and
+      #       now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
+      #       now() <= today_at([time_up_late, time_up_late_non_workday] | max) + timedelta(seconds = 5)
+      #     )
+      #     or
+      #     (
+      #       is_schedule_helper_enabled and
+      #       time_schedule_helper != [] and
+      #       is_state(time_schedule_helper, 'on')
+      #     )
+      #   )
+      # }}
 
   - platform: state
     entity_id: !input resident_sensor
@@ -1588,49 +1612,62 @@ trigger:
       {{
         is_brightness_enabled and
         default_brightness_sensor != [] and
-        (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) and
-        (
-          (
-            is_time_field_enabled and
-            now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
-            now() <= today_at([time_down_late, time_down_late_non_workday] | min) + timedelta(seconds = 5)
-          )
-          or
-          (
-            is_schedule_helper_enabled and
-            time_schedule_helper != [] and
-            is_state(time_schedule_helper, 'on')
-          )
-        )
+        (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down)
       }}
     for:
       seconds: !input brightness_time_duration
-    id: "t_bc_4"
+    id:
+      "t_bc_4"
+
+      # {{
+      #   is_brightness_enabled and
+      #   default_brightness_sensor != [] and
+      #   (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) and
+      #   (
+      #     (
+      #       is_time_field_enabled and
+      #       now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
+      #       now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5)
+      #     )
+      #     or
+      #     (
+      #       is_schedule_helper_enabled and
+      #       time_schedule_helper != [] and
+      #       is_state(time_schedule_helper, 'on')
+      #     )
+      #   )
+      # }}
 
   - platform: template
     value_template: >-
       {{
         is_sun_elevation_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_down) < sun_elevation_down) and
-        (
-          (
-            is_time_field_enabled and
-            now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
-            now() <= today_at([time_down_late, time_down_late_non_workday] | min) + timedelta(seconds = 5)
-          )
-          or
-          (
-            is_schedule_helper_enabled and
-            time_schedule_helper != [] and
-            is_state(time_schedule_helper, 'on')
-          )
-        )
+        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_down) < sun_elevation_down)
       }}
-
     for:
       seconds: !input sun_time_duration
-    id: "t_bc_5"
+    id:
+      "t_bc_5"
+
+      # {{
+      #   is_sun_elevation_enabled and
+      #   default_sun_sensor != [] and
+      #   (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_down) < sun_elevation_down) and
+      #   (
+      #     (
+      #       is_time_field_enabled and
+      #       now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
+      #       now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5)
+      #     )
+      #     or
+      #     (
+      #       is_schedule_helper_enabled and
+      #       time_schedule_helper != [] and
+      #       is_state(time_schedule_helper, 'on')
+      #     )
+      #   )
+      # }}
 
   - platform: state
     entity_id: !input resident_sensor
@@ -1666,23 +1703,32 @@ trigger:
   # Triggers for shading in
   ########################################
 
-  - platform: template # Only allow triggers in certain time periods. Too volatile
+  #  TODO: Combine into one trigger
+  # - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+  # - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
+  # - "{{ current_position | int(default=101) > shading_position }}"
+
+  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
     value_template: >-
       {{
         is_shading_enabled and
         shading_temperatur_sensor1 != [] and
-        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1
-      }}"
+        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 and
+        state_attr(blind, 'current_position') | int(default=110) != close_position and
+        state_attr(blind, 'current_position') | int(default=101) > shading_position
+      }}
     for: "00:00:05"
     id: "t_si_1"
 
-  - platform: template # Only allow triggers in certain time periods. Too volatile
+  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
     value_template: >-
       {{
         is_shading_enabled and
         shading_temperatur_sensor2 != [] and
-        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2
-      }}"
+        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 and
+        state_attr(blind, 'current_position') | int(default=110) != close_position and
+        state_attr(blind, 'current_position') | int(default=101) > shading_position
+      }}
     for: "00:00:05"
     id: "t_si_2"
 
@@ -1691,8 +1737,10 @@ trigger:
       {{
         is_shading_enabled and
         shading_brightness_sensor != [] and
-        states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start
-      }}"
+        states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start and
+        state_attr(blind, 'current_position') | int(default=110) != close_position and
+        state_attr(blind, 'current_position') | int(default=101) > shading_position
+      }}
     for: "00:00:05"
     id: "t_si_3"
 
@@ -1701,8 +1749,10 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min)
-      }}"
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min) and
+        state_attr(blind, 'current_position') | int(default=110) != close_position and
+        state_attr(blind, 'current_position') | int(default=101) > shading_position
+      }}
     for: "00:00:05"
     id: "t_si_4"
 
@@ -1712,11 +1762,14 @@ trigger:
         is_shading_enabled and
         default_sun_sensor != [] and
         (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start) and
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end)
-      }}"
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end) and
+        state_attr(blind, 'current_position') | int(default=110) != close_position and
+        state_attr(blind, 'current_position') | int(default=101) > shading_position
+      }}
     for: "00:00:05"
     id: "t_si_5"
 
+  # TODO
   # - platform: numeric_state
   #   entity_id: !input shading_temperatur_sensor1
   #   above: !input shading_forecast_temp
@@ -1727,14 +1780,14 @@ trigger:
   # Triggers for shading out
   ########################################
 
-  # state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position')
   - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
     value_template: >-
       {{
         is_shading_enabled and
         shading_temperatur_sensor1 != [] and
-        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) < shading_min_temperatur1
-      }}"
+        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) < shading_min_temperatur1 and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_1"
 
@@ -1743,8 +1796,9 @@ trigger:
       {{
         is_shading_enabled and
         shading_temperatur_sensor2 != [] and
-        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) < shading_min_temperatur2
-      }}"
+        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) < shading_min_temperatur2 and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_2"
 
@@ -1753,8 +1807,9 @@ trigger:
       {{
         is_shading_enabled and
         shading_brightness_sensor != [] and
-        states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end
-      }}"
+        states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_3"
 
@@ -1763,8 +1818,9 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max)
-      }}"
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max) and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_4"
 
@@ -1773,8 +1829,9 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end)
-      }}"
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end) and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_5"
 
@@ -1783,10 +1840,27 @@ trigger:
       {{
         is_shading_enabled and
         default_sun_sensor != [] and
-        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
-      }}"
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min) and
+        state_attr(blind, 'current_position') | int(default=110) != open_position
+      }}
     for: "00:00:05"
     id: "t_so_6"
+
+  # TODO
+  # - platform: template
+  #   value_template: >-
+  #     {{
+  #       is_shading_enabled and
+  #       shading_brightness_sensor != [] and
+  #       default_sun_sensor != [] and
+  #       states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end and
+  #       (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
+  #     }}
+  #   for: "00:00:05"
+  #   id: "t_so_test"
+
+  # - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+  # - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
 
   ########################################
   # Trigger for manual cover movements
@@ -1802,12 +1876,11 @@ trigger:
 condition:
   - condition: !input auto_global_condition
   - condition: template
+    value_template: "{{ state_attr(this.entity_id,'current') | int(99) == 0 }}"
+  - condition: template
     value_template: "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
   - condition: template
     value_template: "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}"
-
-  # - condition: template # Problem mit 'closing'
-  #   value_template: "{{ trigger.to_state.state != trigger.from_state.state }}"
 
 action:
   # We have to call a service for forecast due to HA changes
@@ -1918,12 +1991,6 @@ action:
                   - "{{ is_state(time_schedule_helper, 'on') }}"
                   - condition: trigger
                     id: "t_bo_3"
-              # - and: # Opening - Via schedule helper w/o brightness and sun TODO: ?????
-              #     - "{{ is_schedule_helper_enabled }}"
-              #     - "{{ not is_brightness_enabled }}"
-              #     - "{{ not is_sun_elevation_enabled }}"
-              #     - "{{ time_schedule_helper != [] }}"
-              #     - "{{ is_state(time_schedule_helper, 'on') }}"
               - and: # Opening - Up early reached or schedule helper is on and brightness/sun above minimum
                   - or:
                       - and:
@@ -1934,6 +2001,8 @@ action:
                           - "{{ is_schedule_helper_enabled }}"
                           - "{{ time_schedule_helper != [] }}"
                           - "{{ is_state(time_schedule_helper, 'on') }}"
+                          - "{{ now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) }}"
+                          - "{{ now() <= today_at([time_up_late, time_up_late_non_workday] | max) + timedelta(seconds = 5) }}"
                   - or:
                       - or:
                           - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
@@ -1944,35 +2013,39 @@ action:
 
         sequence:
           - delay: "00:00:{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - if:
-                    - "{{ open_position == 100 }}"
-                  then:
-                    - alias: "Moving the cover to open position"
-                      service: cover.open_cover
-                      data: {}
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                  else:
-                    - alias: "Moving the cover to open position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input open_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
-                      data:
-                        tilt_position: !input open_tilt_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - if:
+                        - "{{ open_position == 100 }}"
+                      then:
+                        - alias: "Moving the cover to open position"
+                          service: cover.open_cover
+                          data: {}
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                      else:
+                        - alias: "Moving the cover to open position"
+                          service: cover.set_cover_position
+                          data:
+                            position: !input open_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input open_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2051,11 +2124,6 @@ action:
                   - "{{ is_state(time_schedule_helper, 'off') }}"
                   - condition: trigger
                     id: "t_bc_3"
-              # - and: # Closing - Via schedule helper w/o brightness and sun TODO: ?????
-              #     - "{{ not is_brightness_enabled }}"
-              #     - "{{ not is_sun_elevation_enabled }}"
-              #     - "{{ is_schedule_helper_enabled }}"
-              #     - "{{ is_state(time_schedule_helper, 'off') }}"
               - and: # Closing - Down early reached and brightness/sun below minimum
                   - or:
                       - and:
@@ -2066,6 +2134,8 @@ action:
                           - "{{ is_schedule_helper_enabled }}"
                           - "{{ time_schedule_helper != [] }}"
                           - "{{ is_state(time_schedule_helper, 'on') }}"
+                          - "{{ now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) }}"
+                          - "{{ now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5) }}"
                   - or:
                       - or:
                           - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
@@ -2111,61 +2181,123 @@ action:
 
           - delay: "00:00:{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - if:
-                    - "{{ close_position == 0 }}"
-                  then:
-                    - alias: "Moving the cover to close position"
-                      service: cover.close_cover
-                      data: {}
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                  else:
-                    - alias: "Moving the cover to close position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input close_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
-                      data:
-                        tilt_position: !input close_tilt_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
-
+          # Ventilation
           - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+              - "{{ is_ventilation_enabled }}"
+              - "{{ contact_sensor != [] }}"
+              - "{{ is_state(contact_sensor, ['true', 'on']) }}"
             then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - alias: "Moving the cover to ventilate position"
+                          service: cover.set_cover_position
+                          data:
+                            position: !input ventilate_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input ventilate_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                          delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
-          - choose: []
-            default: !input auto_down_action
+              - if:
+                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - choose: []
+                default: !input auto_ventilate_action
+
+              - stop: "Stop automation: Moved to ventilation position during the closing process"
+
+            else:
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - if:
+                            - "{{ close_position == 0 }}"
+                          then:
+                            - alias: "Moving the cover to close position"
+                              service: cover.close_cover
+                              data: {}
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                          else:
+                            - alias: "Moving the cover to close position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input close_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input close_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                          delay: "00:00:{{ (range(1, 3)|random|int) }}"
+
+              - if:
+                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - choose: []
+                default: !input auto_down_action
+
+              - stop: "Stop automation: Moved to closing position"
 
           - stop: "Stop automation: Closing"
 
@@ -2213,7 +2345,7 @@ action:
           - or:
               - "{{ ( shading_forecast_sensor == [] ) and (shading_temperatur_sensor1 == [] ) }}"
               - "{{ ( shading_forecast_sensor != [] ) and (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp ) }}"
-          - "{{ ( shading_forecast_sensor == [] ) or (states(shading_forecast_sensor) in shading_weather_conditions) }}"
+          - "{{ ( shading_forecast_sensor == [] ) or ((not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions) }}"
 
         sequence:
           - if: # Check helper or if cover is higher than ventilate position. In this case we consider cover position like open and therefor we want to use the delay timer
@@ -2228,26 +2360,29 @@ action:
 
           - delay: "00:00:{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - alias: "Moving the cover to shading position"
-                  service: cover.set_cover_position
-                  data:
-                    position: !input shading_position
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - alias: "Moving the cover to shading position"
+                      service: cover.set_cover_position
                       data:
-                        tilt_position: !input shading_tilt_position
+                        position: !input shading_position
                       target:
                         entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input shading_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2331,26 +2466,29 @@ action:
               - "{{ is_ventilation_enabled }}"
               - "{{ contact_sensor != [] and is_state(contact_sensor, ['true', 'on']) }}"
             then:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - alias: "Moving the cover to ventilate position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input ventilate_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - alias: "Moving the cover to ventilate position"
+                          service: cover.set_cover_position
                           data:
-                            tilt_position: !input ventilate_tilt_position
+                            position: !input ventilate_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input ventilate_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                          delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
               - if:
                   - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2378,35 +2516,38 @@ action:
                 default: !input auto_ventilate_action
 
             else:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - if:
-                        - "{{ open_position == 100 }}"
-                      then:
-                        - alias: "Moving the cover to open position"
-                          service: cover.open_cover
-                          data: {}
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                      else:
-                        - alias: "Moving the cover to open position"
-                          service: cover.set_cover_position
-                          data:
-                            position: !input open_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
-                          data:
-                            tilt_position: !input open_tilt_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - if:
+                            - "{{ open_position == 100 }}"
+                          then:
+                            - alias: "Moving the cover to open position"
+                              service: cover.open_cover
+                              data: {}
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                          else:
+                            - alias: "Moving the cover to open position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input open_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input open_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                          delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
               - if:
                   - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2450,30 +2591,32 @@ action:
           - or:
               - "{{ is_status_helper_enabled and is_cover_closed }}"
               - "{{ (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}" # always
-              # - "{{ not ventilation_if_lower_enabled }}" # TODO: WRONG. Ventilation starts always
               - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
 
         sequence: # Ventilation because contact open
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - alias: "Moving the cover to ventilate position"
-                  service: cover.set_cover_position
-                  data:
-                    position: !input ventilate_position
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - alias: "Moving the cover to ventilate position"
+                      service: cover.set_cover_position
                       data:
-                        tilt_position: !input ventilate_tilt_position
+                        position: !input ventilate_position
                       target:
                         entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input ventilate_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2521,14 +2664,34 @@ action:
               - "{{ is_status_helper_enabled and (is_cover_ventilated or is_cover_locked) }}"
               - "{{ current_position | int(default=101) == ventilate_position }}"
           - or:
-              - and: # Closed - Down late reached
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() >= today_at(time_down_late_today) }}"
-              - and: # Closed - Scheduler is off
+              - and: # OPEN/CLOSE - Whenever the scheduler is off
                   - "{{ is_schedule_helper_enabled }}"
                   - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'off') }}"
-              - and: # Closed - Down early reached and brightness/sun below minimum
+              - and: # <OPEN - Always before the earliest possible time
+                  - "{{ is_time_field_enabled }}"
+                  - "{{ now() <= today_at(time_up_early_today) }}"
+              - and: # >CLOSE - Always after the latest time
+                  - "{{ is_time_field_enabled }}"
+                  - "{{ now() >= today_at(time_down_late_today) }}"
+              - and: # <OPEN - Between the time intervals only if the brightness/sun-elevation is still too low.
+                  - or:
+                      - and:
+                          - "{{ is_time_field_enabled }}"
+                          - "{{ now() >= today_at(time_up_early_today) }}"
+                          - "{{ now() <= today_at(time_up_late_today) }}"
+                      - and:
+                          - "{{ is_schedule_helper_enabled }}"
+                          - "{{ time_schedule_helper != [] }}"
+                          - "{{ is_state(time_schedule_helper, 'on') }}"
+                  - or:
+                      - or:
+                          - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
+                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_up) < brightness_up) }}"
+                      - or:
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_up) < sun_elevation_up) }}"
+              - and: # >CLOSE - Between the time intervals only if the brightness/sun-elevation has already fallen.
                   - or:
                       - and:
                           - "{{ is_time_field_enabled }}"
@@ -2552,36 +2715,38 @@ action:
             then:
               - delay: "00:00:{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - if:
-                    - "{{ close_position == 0 }}"
-                  then:
-                    - alias: "Moving the cover to close position"
-                      service: cover.close_cover
-                      data: {}
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                  else:
-                    - alias: "Moving the cover to close position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input close_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
-                      data:
-                        tilt_position: !input close_tilt_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - if:
+                        - "{{ close_position == 0 }}"
+                      then:
+                        - alias: "Moving the cover to close position"
+                          service: cover.close_cover
+                          data: {}
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                      else:
+                        - alias: "Moving the cover to close position"
+                          service: cover.set_cover_position
+                          data:
+                            position: !input close_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input close_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2620,35 +2785,38 @@ action:
             id: "t_bo_force"
           - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
         sequence:
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - if:
-                    - "{{ open_position == 100 }}"
-                  then:
-                    - alias: "Moving the cover to open position"
-                      service: cover.open_cover
-                      data: {}
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                  else:
-                    - alias: "Moving the cover to open position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input open_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
-                      data:
-                        tilt_position: !input open_tilt_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - if:
+                        - "{{ open_position == 100 }}"
+                      then:
+                        - alias: "Moving the cover to open position"
+                          service: cover.open_cover
+                          data: {}
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                      else:
+                        - alias: "Moving the cover to open position"
+                          service: cover.set_cover_position
+                          data:
+                            position: !input open_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input open_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2687,35 +2855,38 @@ action:
             id: "t_bc_force"
           - "{{ auto_down_force != [] and is_state(auto_down_force, ['true', 'on']) }}"
         sequence:
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - if:
-                    - "{{ close_position == 0 }}"
-                  then:
-                    - alias: "Moving the cover to close position"
-                      service: cover.close_cover
-                      data: {}
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                  else:
-                    - alias: "Moving the cover to close position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input close_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
-                      data:
-                        tilt_position: !input close_tilt_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - if:
+                        - "{{ close_position == 0 }}"
+                      then:
+                        - alias: "Moving the cover to close position"
+                          service: cover.close_cover
+                          data: {}
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                      else:
+                        - alias: "Moving the cover to close position"
+                          service: cover.set_cover_position
+                          data:
+                            position: !input close_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input close_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
@@ -2754,26 +2925,29 @@ action:
             id: "t_co_force"
           - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
         sequence:
-          - repeat:
-              for_each: "{{ blind_entities|list }}"
-              sequence:
-                - alias: "Moving the cover to ventilate position"
-                  service: cover.set_cover_position
-                  data:
-                    position: !input ventilate_position
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                - if:
-                    - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                  then:
-                    - alias: "Moving the cover to tilt position"
-                      service: cover.set_cover_tilt_position
+          - if:
+              - "{{ not prevent_default_cover_actions}}"
+            then:
+              - repeat:
+                  for_each: "{{ blind_entities|list }}"
+                  sequence:
+                    - alias: "Moving the cover to ventilate position"
+                      service: cover.set_cover_position
                       data:
-                        tilt_position: !input ventilate_tilt_position
+                        position: !input ventilate_position
                       target:
                         entity_id: "{{ repeat.item }}"
-                - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                  delay: "00:00:{{ (range(1, 3)|random|int) }}"
+                    - if:
+                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                      then:
+                        - alias: "Moving the cover to tilt position"
+                          service: cover.set_cover_tilt_position
+                          data:
+                            tilt_position: !input ventilate_tilt_position
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                      delay: "00:00:{{ (range(1, 3)|random|int) }}"
 
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.03.20-01
+    **Version**: 2024.03.21-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -96,13 +96,13 @@ blueprint:
       - Fixed: Ventilation mode could always be started by mistake.
       - Fixing helper length check. Thx to crandler.
 
-    2024.03.20-01:
+    2024.03.21-01:
+      - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
       - New: Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
       - New: Added possibility to disable the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions
       - Fixed: Shading Forecast Weather Conditions
       - Fixed: Ventilation mode should not only be ended in the evening, but whenever it is not yet daytime.
       - Fixed: Added the ventilation mode activation on closing down again
-      - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
       - Try to avoid overlaps in the execution of the automation if several triggers are triggered shortly after each other.
       - Fixed: Optional weather conditions for "shading in" #41
 
@@ -214,7 +214,7 @@ blueprint:
         </details>
         <br />
         <details>
-        <summary><code><strong>CLICK HERE:</strong> Important information since version 2024.03.20-01</code></summary>
+        <summary><code><strong>CLICK HERE:</strong> Important information since version 2024.03.21-01</code></summary>
 
 
         It is not possible to find out more about the status of the schedule helper in Home Assistant.
@@ -653,7 +653,7 @@ blueprint:
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
-        Bear in mind that the other positions are not too close to each other if you include the tolerance.
+        Attention: Bear in mind that the other positions are not too close to each other if you include the tolerance.
         The following could cause problems and would then be <ins>incorrect</ins>:
         <br />
         - Open Position = 100<br />
@@ -1226,11 +1226,74 @@ blueprint:
             - "info"
             - "warning"
 
-mode: restart #queued
-max_exceeded: silent
+trigger_variables:
+  blind: !input blind
+
+  # Positions
+  open_position: !input open_position
+  close_position: !input close_position
+  shading_position: !input shading_position
+  position_tolerance: !input position_tolerance
+
+  # Modes
+  auto_options: !input auto_options
+
+  # Times
+  time_up_early: !input time_up_early
+  time_up_early_non_workday: !input time_up_early_non_workday
+  time_up_late: !input time_up_late
+  time_up_late_non_workday: !input time_up_late_non_workday
+  time_down_early: !input time_down_early
+  time_down_early_non_workday: !input time_down_early_non_workday
+  time_down_late: !input time_down_late
+  time_down_late_non_workday: !input time_down_late_non_workday
+  workday_sensor: !input workday_sensor
+
+  # Brightness
+  default_brightness_sensor: !input default_brightness_sensor
+  brightness_up: !input brightness_up
+  brightness_down: !input brightness_down
+
+  # Sun
+  default_sun_sensor: !input default_sun_sensor
+  sun_elevation_up: !input sun_elevation_up
+  sun_elevation_down: !input sun_elevation_down
+
+  # Sensors
+  contact_sensor: !input contact_sensor
+  resident_sensor: !input resident_sensor
+
+  # Time controls
+  time_control: !input time_control
+  time_schedule_helper: !input time_schedule_helper
+
+  # Shading
+  shading_brightness_sensor: !input shading_brightness_sensor
+  shading_temperatur_sensor1: !input shading_temperatur_sensor1
+  shading_temperatur_sensor2: !input shading_temperatur_sensor2
+  shading_min_temperatur1: !input shading_min_temperatur1
+  shading_min_temperatur2: !input shading_min_temperatur2
+  shading_azimuth_start: !input shading_azimuth_start
+  shading_azimuth_end: !input shading_azimuth_end
+  shading_elevation_min: !input shading_elevation_min
+  shading_elevation_max: !input shading_elevation_max
+  shading_sun_brightness_start: !input shading_sun_brightness_start
+  shading_sun_brightness_end: !input shading_sun_brightness_end
+  shading_forecast_temp: !input shading_forecast_temp
+
+  # Internal code helper
+  is_shading_enabled: "{{ 'auto_shading_enabled' in auto_options }}"
+  is_up_enabled: "{{ 'auto_up_enabled' in auto_options }}"
+  is_down_enabled: "{{ 'auto_down_enabled' in auto_options }}"
+  is_brightness_enabled: "{{ 'auto_brightness_enabled' in auto_options }}"
+  is_sun_elevation_enabled: "{{ 'auto_sun_enabled' in auto_options }}"
+  is_ventilation_enabled: "{{ 'auto_ventilate_enabled' in auto_options }}"
+  is_lockout_protection_enabled: "{{ 'auto_lockout_protection_enabled' in auto_options }}"
+  is_time_field_enabled: "{{ 'time_control_input' in time_control or time_control == [] or time_schedule_helper == [] }}"
+  is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
 
 variables:
-  version: "2024.03.20-01"
+  version: "2024.03.21-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1275,7 +1338,6 @@ variables:
   close_tilt_position: !input close_tilt_position
   ventilate_position: !input ventilate_position
   ventilate_tilt_position: !input ventilate_tilt_position
-  position_tolerance: !input position_tolerance
 
   # Force
   auto_up_force: !input auto_up_force
@@ -1398,6 +1460,11 @@ variables:
       (states(cover_status_helper)|from_json).t
     }}
 
+  in_open_position: "{{ (current_position | int(default=101) <= open_position + position_tolerance) and (current_position | int(default=101) >= open_position - position_tolerance) }}"
+  in_close_position: "{{ (current_position | int(default=101) <= close_position + position_tolerance) and (current_position | int(default=101) >= close_position - position_tolerance) }}"
+  in_shading_position: "{{ (current_position | int(default=101) <= shading_position + position_tolerance) and (current_position | int(default=101) >= shading_position - position_tolerance) }}"
+  in_ventilate_position: "{{ (current_position | int(default=101) <= ventilate_position + position_tolerance) and (current_position | int(default=101) >= ventilate_position - position_tolerance) }}"
+
   individual_config: !input individual_config
   prevent_close_after_lockout: "{{ '_prevent_close_after_lockout' in individual_config }}"
   prevent_higher_position_closing: "{{ 'prevent_higher_position_closing' in individual_config }}"
@@ -1416,70 +1483,8 @@ variables:
   ventilation_delay_enabled: "{{ 'ventilation_delay_enabled' in auto_ventilate_options }}"
   ventilation_if_lower_enabled: "{{ 'ventilation_if_lower_enabled' in auto_ventilate_options }}"
 
-trigger_variables:
-  blind: !input blind
-
-  # Positions
-  open_position: !input open_position
-  close_position: !input close_position
-  shading_position: !input shading_position
-
-  # Modes
-  auto_options: !input auto_options
-
-  # Times
-  time_up_early: !input time_up_early
-  time_up_early_non_workday: !input time_up_early_non_workday
-  time_up_late: !input time_up_late
-  time_up_late_non_workday: !input time_up_late_non_workday
-  time_down_early: !input time_down_early
-  time_down_early_non_workday: !input time_down_early_non_workday
-  time_down_late: !input time_down_late
-  time_down_late_non_workday: !input time_down_late_non_workday
-  workday_sensor: !input workday_sensor
-
-  # Brightness
-  default_brightness_sensor: !input default_brightness_sensor
-  brightness_up: !input brightness_up
-  brightness_down: !input brightness_down
-
-  # Sun
-  default_sun_sensor: !input default_sun_sensor
-  sun_elevation_up: !input sun_elevation_up
-  sun_elevation_down: !input sun_elevation_down
-
-  # Sensors
-  contact_sensor: !input contact_sensor
-  resident_sensor: !input resident_sensor
-
-  # Time controls
-  time_control: !input time_control
-  time_schedule_helper: !input time_schedule_helper
-
-  # Shading
-  shading_brightness_sensor: !input shading_brightness_sensor
-  shading_temperatur_sensor1: !input shading_temperatur_sensor1
-  shading_temperatur_sensor2: !input shading_temperatur_sensor2
-  shading_min_temperatur1: !input shading_min_temperatur1
-  shading_min_temperatur2: !input shading_min_temperatur2
-  shading_azimuth_start: !input shading_azimuth_start
-  shading_azimuth_end: !input shading_azimuth_end
-  shading_elevation_min: !input shading_elevation_min
-  shading_elevation_max: !input shading_elevation_max
-  shading_sun_brightness_start: !input shading_sun_brightness_start
-  shading_sun_brightness_end: !input shading_sun_brightness_end
-  shading_forecast_temp: !input shading_forecast_temp
-
-  # Internal code helper
-  is_shading_enabled: "{{ 'auto_shading_enabled' in auto_options }}"
-  is_up_enabled: "{{ 'auto_up_enabled' in auto_options }}"
-  is_down_enabled: "{{ 'auto_down_enabled' in auto_options }}"
-  is_brightness_enabled: "{{ 'auto_brightness_enabled' in auto_options }}"
-  is_sun_elevation_enabled: "{{ 'auto_sun_enabled' in auto_options }}"
-  is_ventilation_enabled: "{{ 'auto_ventilate_enabled' in auto_options }}"
-  is_lockout_protection_enabled: "{{ 'auto_lockout_protection_enabled' in auto_options }}"
-  is_time_field_enabled: "{{ 'time_control_input' in time_control or time_control == [] or time_schedule_helper == [] }}"
-  is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
+mode: restart #queued
+max_exceeded: silent
 
 trigger:
   ########################################
@@ -1517,27 +1522,7 @@ trigger:
       }}
     for:
       seconds: !input brightness_time_duration
-    id:
-      "t_bo_4"
-
-      # {{
-      #   is_brightness_enabled and
-      #   default_brightness_sensor != [] and
-      #   (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up) and
-      #   (
-      #     (
-      #       is_time_field_enabled and
-      #       now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
-      #       now() <= today_at([time_up_late, time_up_late_non_workday] | max) + timedelta(seconds = 5)
-      #     )
-      #     or
-      #     (
-      #       is_schedule_helper_enabled and
-      #       time_schedule_helper != [] and
-      #       is_state(time_schedule_helper, 'on')
-      #     )
-      #   )
-      # }}
+    id: "t_bo_4"
 
   - platform: template
     value_template: >-
@@ -1548,27 +1533,7 @@ trigger:
       }}
     for:
       seconds: !input sun_time_duration
-    id:
-      "t_bo_5"
-
-      # {{
-      #   is_sun_elevation_enabled and
-      #   default_sun_sensor != [] and
-      #   (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up) and
-      #   (
-      #     (
-      #       is_time_field_enabled and
-      #       now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
-      #       now() <= today_at([time_up_late, time_up_late_non_workday] | max) + timedelta(seconds = 5)
-      #     )
-      #     or
-      #     (
-      #       is_schedule_helper_enabled and
-      #       time_schedule_helper != [] and
-      #       is_state(time_schedule_helper, 'on')
-      #     )
-      #   )
-      # }}
+    id: "t_bo_5"
 
   - platform: state
     entity_id: !input resident_sensor
@@ -1617,27 +1582,7 @@ trigger:
       }}
     for:
       seconds: !input brightness_time_duration
-    id:
-      "t_bc_4"
-
-      # {{
-      #   is_brightness_enabled and
-      #   default_brightness_sensor != [] and
-      #   (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) and
-      #   (
-      #     (
-      #       is_time_field_enabled and
-      #       now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
-      #       now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5)
-      #     )
-      #     or
-      #     (
-      #       is_schedule_helper_enabled and
-      #       time_schedule_helper != [] and
-      #       is_state(time_schedule_helper, 'on')
-      #     )
-      #   )
-      # }}
+    id: "t_bc_4"
 
   - platform: template
     value_template: >-
@@ -1648,27 +1593,7 @@ trigger:
       }}
     for:
       seconds: !input sun_time_duration
-    id:
-      "t_bc_5"
-
-      # {{
-      #   is_sun_elevation_enabled and
-      #   default_sun_sensor != [] and
-      #   (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_down) < sun_elevation_down) and
-      #   (
-      #     (
-      #       is_time_field_enabled and
-      #       now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
-      #       now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5)
-      #     )
-      #     or
-      #     (
-      #       is_schedule_helper_enabled and
-      #       time_schedule_helper != [] and
-      #       is_state(time_schedule_helper, 'on')
-      #     )
-      #   )
-      # }}
+    id: "t_bc_5"
 
   - platform: state
     entity_id: !input resident_sensor
@@ -1701,7 +1626,7 @@ trigger:
     id: "t_co_force"
 
   ########################################
-  # Triggers for shading in
+  # Triggers for shading start
   ########################################
 
   - platform: template # Mandatory and optional triggers
@@ -1719,84 +1644,18 @@ trigger:
     for: "00:00:05"
     id: "t_si_1"
 
-  # - platform: template # Optional trigger
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       shading_brightness_sensor != [] and
-  #       states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start and
-  #       default_sun_sensor != [] and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
-  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
-  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
-  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_si_2"
-
-  # - platform: template # Optional trigger
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       shading_temperatur_sensor1 != [] and
-  #       states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 and
-  #       default_sun_sensor != [] and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
-  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
-  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
-  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_si_3"
-
-  # - platform: template # Optional trigger
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       shading_temperatur_sensor2 != [] and
-  #       states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 and
-  #       default_sun_sensor != [] and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start and
-  #       state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end and
-  #       state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min and
-  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
-  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_si_4"
-
-  # - platform: template
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       default_sun_sensor != [] and
-  #       (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min) and
-  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
-  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_si_4"
-
-  # - platform: template
-  #   value_template: >-
-  #     {{
-  #       is_shading_enabled and
-  #       default_sun_sensor != [] and
-  #       (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start) and
-  #       (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end) and
-  #       state_attr(blind, 'current_position') | int(default=110) != close_position and
-  #       state_attr(blind, 'current_position') | int(default=101) > shading_position
-  #     }}
-  #   for: "00:00:05"
-  #   id: "t_si_5"
-
   ########################################
-  # Triggers for shading out
+  # Triggers for shading end
   ########################################
+  # Problem:
+  # I would like to reduce the triggering here, but I cannot use further constraints here (such as comparison with ShadingPos),
+  # because then the current position also triggers. And that leads to many unpredictable consequences.
+  # Triggers should be executed at the time of the correct event. And not all together, e.g. when the blinds are closed.
+  #
+  # There are hardly any AND conditions at the end of shading, only many different OR scenarios.
+  # So I can't pack everything into one big trigger.
 
-  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+  - platform: template
     value_template: >-
       {{
         is_shading_enabled and
@@ -1806,7 +1665,7 @@ trigger:
     for: "00:00:05"
     id: "t_so_1"
 
-  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+  - platform: template
     value_template: >-
       {{
         is_shading_enabled and
@@ -1816,7 +1675,7 @@ trigger:
     for: "00:00:05"
     id: "t_so_2"
 
-  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+  - platform: template
     value_template: >-
       {{
         is_shading_enabled and
@@ -1864,8 +1723,11 @@ trigger:
     entity_id: !input blind
     attribute: current_position
     id: "t_ma_1"
-    for:
-      seconds: !input drive_time
+    for: "00:01:00"
+
+  ########################################
+  # Global conditions
+  ########################################
 
 condition:
   - condition: !input auto_global_condition
@@ -1876,6 +1738,10 @@ condition:
   - condition: template
     value_template: "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}"
 
+  ########################################
+  # Action
+  ########################################
+
 action:
   # We have to call a service for forecast due to HA changes
   - if:
@@ -1883,11 +1749,7 @@ action:
       - "{{ not prevent_forecast_service }}"
       - "{{ (shading_forecast_sensor != [] ) }}"
       - condition: trigger
-        id:
-          - "t_si_1"
-          # - "t_si_2"
-          # - "t_si_3"
-          # - "t_si_4"
+        id: "t_si_1"
     then:
       - service: weather.get_forecasts
         target:
@@ -1947,7 +1809,7 @@ action:
 
   - choose:
       ############################################################
-      # ANCHOR
+      # ANCHOR: OPEN
       ############################################################
       - alias: "Check for opening"
         conditions:
@@ -1965,8 +1827,8 @@ action:
           - or: # Check the current positions
               - "{{ is_status_helper_enabled and ignore_opening_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and not is_cover_open }}"
-              - "{{ is_ventilation_enabled and (current_position | int(default=101) == ventilate_position) }}"
-              - "{{ (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance)}}"
+              - "{{ is_ventilation_enabled and in_ventilate_position }}"
+              - "{{ in_close_position }}"
           - or: # Only once a day
               - "{{ not is_status_helper_enabled or is_status_helper_enabled and (now().day != is_cover_open_ts|timestamp_custom('%-d')|int) }}"
           - or:
@@ -2067,7 +1929,7 @@ action:
           - stop: "Stop automation: Opening"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: CLOSE
       ############################################################
       - alias: "Check for closing cover"
         conditions:
@@ -2086,24 +1948,23 @@ action:
           - or: # Optional: Continue if cover is shaded and close position is lower than shading position
               - "{{ not prevent_higher_position_shading_end }}"
               - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
-              - "{{ current_position | int(default=101) != shading_position }}" # Continue if cover is not shaded
+              - "{{ not in_shading_position }}" # Continue if cover is not shaded
               - and:
                   - "{{ is_status_helper_enabled }}"
                   - "{{ prevent_higher_position_shading_end }}"
                   - "{{ is_cover_shaded }}"
                   - "{{ close_position < shading_position }}"
-              - and:
-                  # - "{{ not is_status_helper_enabled }}" # Todo
+              - and: # Always, no further checks for 'is_status_helper_enabled'
                   - "{{ prevent_higher_position_shading_end }}"
-                  - "{{ current_position | int(default=101) == shading_position }}"
+                  - "{{ in_shading_position }}"
                   - "{{ close_position < shading_position }}"
           - or: # Optional: Continue if close-position is higher than the current position
               - "{{ not prevent_higher_position_closing }}"
-              - "{{ prevent_higher_position_closing and (current_position | int(default=110) >= close_position) }}"
+              - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
           - or: # Check the current positions
               - "{{ is_status_helper_enabled and ignore_closing_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and not is_cover_closed }}"
-              - "{{ (current_position | int(default=110) <= open_position + position_tolerance) and (current_position | int(default=110) >= open_position - position_tolerance)}}"
+              - "{{ in_open_position }}"
           - or: # Only once a day
               - "{{ not is_status_helper_enabled or is_status_helper_enabled and (is_cover_closed_ts < today_at(time_down_early) | as_timestamp) }}"
           - or:
@@ -2294,31 +2155,27 @@ action:
           - stop: "Stop automation: Closing"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: SHADING START
       ############################################################
-      - alias: "Check for shading in"
+      - alias: "Check for shading start"
         conditions:
           - "{{ is_shading_enabled }}"
           - condition: !input auto_shading_start_condition
           - condition: trigger
-            id:
-              - "t_si_1"
-              # - "t_si_2"
-              # - "t_si_3"
-              # - "t_si_4"
+            id: "t_si_1"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
           - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
           - "{{ current_position | int(default=101) > shading_position }}"
           - or: # Check the current positions
-              # - "{{ is_ventilation_enabled and contact_sensor != [] and is_state(contact_sensor, ['true', 'on']) }}" # TODO: Why?
               - "{{ is_status_helper_enabled and ignore_shading_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and not is_cover_shaded }}"
               - "{{ is_status_helper_enabled and not (is_cover_ventilated or is_cover_locked) }}"
-              - "{{ not (current_position | int(default=101) == ventilate_position) }}" # TODO: Why not checking with shading_pos, too?
+              - "{{ not in_ventilate_position }}"
           - or: # Only once a day
-              - "{{ (not is_status_helper_enabled) or is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
+              - "{{ (not is_status_helper_enabled) }}"
+              - "{{ is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
           - or:
               - and:
                   - "{{ is_time_field_enabled }}"
@@ -2338,9 +2195,12 @@ action:
               - "{{ shading_brightness_sensor == [] }}"
               - "{{ states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start }}"
           - or:
+              - "{{ prevent_forecast_service }}"
               - "{{ shading_forecast_sensor == [] }}"
-              - "{{ (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp ) }}"
+              - "{{ shading_forecast_temp == [] }}"
+              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp }}"
           - or:
+              - "{{ prevent_forecast_service }}"
               - "{{ shading_forecast_sensor == [] }}"
               - "{{ shading_weather_conditions == [] }}"
               - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions }}"
@@ -2350,7 +2210,7 @@ action:
 
         sequence:
           - if: # Check helper or if cover is higher than ventilate position. In this case we consider cover position like open and therefor we want to use the delay timer
-              - or:
+              - or: # TODO: Why this?
                   - "{{ is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) and not is_cover_shaded }}"
                   - "{{ is_ventilation_enabled and (current_position | int(default=101) > ventilate_position) }}"
                   - "{{ not is_ventilation_enabled and (current_position | int(default=101) > shading_position) }}" # Fallback
@@ -2413,9 +2273,9 @@ action:
           - stop: "Stop automation: Shading-start"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: SHADING END
       ############################################################
-      - alias: "Check for shading out"
+      - alias: "Check for shading end"
         conditions:
           - "{{ is_shading_enabled }}"
           - condition: !input auto_shading_end_condition
@@ -2440,7 +2300,7 @@ action:
           - or:
               - "{{ is_status_helper_enabled and ignore_shading_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and is_cover_shaded }}"
-              - "{{ current_position | int(default=101) == shading_position }}"
+              - "{{ in_shading_position }}" # Be careful if the tolerance value is too high!
           - or: # Optional: Continue if cover is not already closed
               - "{{ not prevent_shading_end_if_closed }}"
               - or:
@@ -2448,14 +2308,13 @@ action:
                       - "{{ is_status_helper_enabled }}"
                       - "{{ prevent_shading_end_if_closed }}"
                       - "{{ not is_cover_closed }}"
-                  - and:
-                      # - "{{ not is_status_helper_enabled }}" # Todo
+                  - and: # Always, no further checks for 'is_status_helper_enabled'
                       - "{{ prevent_shading_end_if_closed }}"
-                      - "{{ not (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}"
+                      - "{{ not in_close_position }}"
 
         sequence:
-          - if: # If sun is outside of shading window (azimuth or elevation) we immediately stop shading # TODO: Why here and not above? Not not necessary anymore.
-              - and:
+          - if: # If sun is outside of shading window (azimuth or elevation) we immediately stop shading
+              - and: # TODO: Why here and not above? Not not necessary anymore.
                   - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
                   - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
             then:
@@ -2463,7 +2322,7 @@ action:
                 delay:
                   seconds: !input shading_waitingtime_end
 
-          - if: # Ventilation after shading out
+          - if: # Ventilation after shading end
               - "{{ is_ventilation_enabled }}"
               - "{{ contact_sensor != [] and is_state(contact_sensor, ['true', 'on']) }}"
             then:
@@ -2578,7 +2437,7 @@ action:
           - stop: "Stop automation: Shading-end"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: CONTACT OPEN
       ############################################################
       - alias: "Contact sensor opened"
         conditions:
@@ -2591,7 +2450,7 @@ action:
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
           - or:
               - "{{ is_status_helper_enabled and is_cover_closed }}"
-              - "{{ (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}" # always
+              - "{{ in_close_position }}" # always
               - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
 
         sequence: # Ventilation because contact open
@@ -2647,7 +2506,7 @@ action:
           - stop: "Stop automation: Contact sensor has been opened"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: CONTACT CLOSED
       ############################################################
       - alias: "Contact sensor closed / Closing after ventilation and after lockout-protection"
         conditions:
@@ -2663,7 +2522,7 @@ action:
           - or:
               - "{{ is_status_helper_enabled and ignore_ventilation_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and (is_cover_ventilated or is_cover_locked) }}"
-              - "{{ current_position | int(default=101) == ventilate_position }}"
+              - "{{ in_ventilate_position }}"
           - or:
               - and: # OPEN/CLOSE - Whenever the scheduler is off
                   - "{{ is_schedule_helper_enabled }}"
@@ -2777,7 +2636,7 @@ action:
           - stop: "Stop automation: Closing after ventilation and after lockout-protection"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: FORCE OPEN
       ############################################################
       - alias: "Forced opening of the cover"
         conditions:
@@ -2847,7 +2706,7 @@ action:
           - stop: "Stop automation: Forced Opening"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: FORCE CLOSE
       ############################################################
       - alias: "Forced closing of the cover"
         conditions:
@@ -2917,7 +2776,7 @@ action:
           - stop: "Stop automation: Forced Closing"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: FORCE VENTILATION
       ############################################################
       - alias: "Forced ventilation of the cover"
         conditions:
@@ -2978,13 +2837,13 @@ action:
           - stop: "Stop automation: Forced Ventilation"
 
       ############################################################
-      # ANCHOR
+      # ANCHOR: MANUAL
       ############################################################
       - alias: "Cover movement - Checking for manual position changes"
         conditions:
           - "{{ 'cover_helper_enabled' in cover_status_options }}" # Do not use 'is_status_helper_enabled' (with the embedded regex here), because it could be set after variable declaration
           - "{{ cover_status_helper != [] }}"
-          - "{{ as_timestamp(now()) - cover_status_time > (drive_time + 30)}}" # Drive time + trigger waiting time
+          - "{{ as_timestamp(now()) > cover_status_time + drive_time + 60 }}" # Drive time + trigger waiting time
           - condition: trigger
             id: "t_ma_1"
           - "{{ is_number(trigger.to_state.attributes.current_position) and is_number(trigger.from_state.attributes.current_position) }}" # Avoid status change from -unavailable- (common with Homematic)
@@ -2994,10 +2853,10 @@ action:
           - choose:
               - conditions: # Defined positions can be assigned
                   - not:
-                      - "{{ is_up_enabled and (current_position | int(default=110) <= open_position + position_tolerance) and (current_position | int(default=110) >= open_position - position_tolerance) }}"
-                      - "{{ is_down_enabled and (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}"
-                      - "{{ is_ventilation_enabled and (current_position | int(default=110) <= ventilate_position + position_tolerance) and (current_position | int(default=110) >= ventilate_position - position_tolerance) }}"
-                      - "{{ is_shading_enabled and (current_position | int(default=110) <= shading_position + position_tolerance) and (current_position | int(default=110) >= shading_position - position_tolerance) }}"
+                      - "{{ is_up_enabled and in_open_position }}"
+                      - "{{ is_down_enabled and in_close_position }}"
+                      - "{{ is_ventilation_enabled and in_ventilate_position }}"
+                      - "{{ is_shading_enabled and in_shading_position }}"
                 sequence:
                   - service: input_text.set_value
                     data:
@@ -3021,10 +2880,10 @@ action:
               - conditions: # Manually opened
                   - "{{ is_up_enabled }}"
                   - or:
-                      - "{{ (current_position | int(default=110) <= open_position + position_tolerance) and (current_position | int(default=110) >= open_position - position_tolerance) }}"
-                      - "{{ (current_position | int(default=110) > ventilate_position) }}"
-                      - "{{ (current_position | int(default=110) >= open_position) }}"
-                      - "{{ (current_position | int(default=110) == 100) }}"
+                      - "{{ in_open_position }}"
+                      - "{{ (current_position | int(default=101) > ventilate_position) }}"
+                      - "{{ (current_position | int(default=101) >= open_position) }}"
+                      - "{{ (current_position | int(default=101) == 100) }}"
                 sequence:
                   - service: input_text.set_value
                     data:
@@ -3048,10 +2907,10 @@ action:
               - conditions: # Manually closed
                   - "{{ is_down_enabled }}"
                   - or:
-                      - "{{ (current_position | int(default=110) <= close_position + position_tolerance) and (current_position | int(default=110) >= close_position - position_tolerance) }}"
-                      - "{{ (current_position | int(default=110) < shading_position) and (current_position | int(default=110) < ventilate_position) }}"
-                      - "{{ (current_position | int(default=110) <= close_position) }}"
-                      - "{{ (current_position | int(default=110) == 0) }}"
+                      - "{{ in_close_position }}"
+                      - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}"
+                      - "{{ (current_position | int(default=101) <= close_position) }}"
+                      - "{{ (current_position | int(default=101) == 0) }}"
                 sequence:
                   - service: input_text.set_value
                     data:
@@ -3074,8 +2933,8 @@ action:
 
               - conditions: # Manually ventilated
                   - "{{ is_ventilation_enabled }}"
-                  - "{{ (current_position | int(default=110) <= ventilate_position + position_tolerance) and (current_position | int(default=110) >= ventilate_position - position_tolerance) }}"
-                  - "{{ (current_position | int(default=110) != open_position) }}" # If ventilate_position and open_position are too close together, the Ventilation-status should not be assigned.
+                  - "{{ in_ventilate_position }}"
+                  - "{{ not in_open_position }}" # If ventilate_position and open_position are too close together, the ventilation-status should not be assigned.
                 sequence:
                   - service: input_text.set_value
                     data:
@@ -3098,7 +2957,7 @@ action:
 
               - conditions: # Manually shaded
                   - "{{ is_shading_enabled }}"
-                  - "{{ (current_position | int(default=110) <= shading_position + position_tolerance) and (current_position | int(default=110) >= shading_position - position_tolerance) }}"
+                  - "{{ in_shading_position }}"
                 sequence:
                   - service: input_text.set_value
                     data:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -133,6 +133,9 @@ blueprint:
       - Fixed: Ventilation mode could always be started by mistake.
       - Fixing helper length check. Thx to crandler.
 
+    2024.03.14-xx:
+      - Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
+
     </details>
 
   source_url: https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml
@@ -1222,35 +1225,13 @@ variables:
   version: "2024.03.14-01"
   blind: !input blind
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
+  current_sun_azimuth: "{{ state_attr(default_sun_sensor, 'azimuth') }}"
+  current_sun_elevation: "{{ state_attr(default_sun_sensor, 'elevation') }}"
 
-  # Modes
-  auto_options: !input auto_options
-
-  # Brightness
-  default_brightness_sensor: !input default_brightness_sensor
-  brightness_up: !input brightness_up
-  brightness_down: !input brightness_down
-
-  # Sun
-  default_sun_sensor: !input default_sun_sensor
-  sun_elevation_up: !input sun_elevation_up
-  sun_elevation_down: !input sun_elevation_down
-
-  # Times / Delays
-  time_up_early: !input time_up_early
-  time_up_early_non_workday: !input time_up_early_non_workday
-  time_up_late: !input time_up_late
-  time_up_late_non_workday: !input time_up_late_non_workday
-  time_down_early: !input time_down_early
-  time_down_early_non_workday: !input time_down_early_non_workday
-  time_down_late: !input time_down_late
-  time_down_late_non_workday: !input time_down_late_non_workday
-  workday_sensor: !input workday_sensor
+  # Delays
   drive_delay_fix: !input drive_delay_fix
   drive_delay_random: !input drive_delay_random
   drive_time: !input drive_time
-  time_control: !input time_control
-  time_schedule_helper: !input time_schedule_helper
 
   time_up_early_today: >-
     {% if time_up_early_non_workday == [] or workday_sensor == [] or (is_state(workday_sensor, 'on')) %}
@@ -1289,31 +1270,17 @@ variables:
   ventilate_tilt_position: !input ventilate_tilt_position
   position_tolerance: !input position_tolerance
 
-  # Sensors
-  contact_sensor: !input contact_sensor
-  resident_sensor: !input resident_sensor
+  # Force
   auto_up_force: !input auto_up_force
   auto_down_force: !input auto_down_force
   auto_ventilate_force: !input auto_ventilate_force
 
   # Shading
-  shading_brightness_sensor: !input shading_brightness_sensor
-  shading_temperatur_sensor1: !input shading_temperatur_sensor1
-  shading_temperatur_sensor2: !input shading_temperatur_sensor2
-  shading_min_temperatur1: !input shading_min_temperatur1
-  shading_min_temperatur2: !input shading_min_temperatur2
-  shading_azimuth_start: !input shading_azimuth_start
-  shading_azimuth_end: !input shading_azimuth_end
-  shading_elevation_min: !input shading_elevation_min
-  shading_elevation_max: !input shading_elevation_max
   shading_position: !input shading_position
   shading_tilt_position: !input shading_tilt_position
-  shading_sun_brightness_start: !input shading_sun_brightness_start
-  shading_sun_brightness_end: !input shading_sun_brightness_end
   shading_waitingtime_start: !input shading_waitingtime_start
   shading_waitingtime_end: !input shading_waitingtime_end
   shading_forecast_sensor: !input shading_forecast_sensor
-  shading_forecast_temp: !input shading_forecast_temp
   shading_weather_conditions: !input shading_weather_conditions
 
   # Config check
@@ -1322,8 +1289,6 @@ variables:
 
   # Little helper for leaner code
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
-  current_sun_azimuth: "{{ state_attr(default_sun_sensor, 'azimuth') }}"
-  current_sun_elevation: "{{ state_attr(default_sun_sensor, 'elevation') }}"
 
   # Cover Status Helper
   cover_status_options: !input cover_status_options
@@ -1430,16 +1395,6 @@ variables:
       (states(cover_status_helper)|from_json).t
     }}
 
-  is_shading_enabled: "{{ 'auto_shading_enabled' in auto_options }}"
-  is_up_enabled: "{{ 'auto_up_enabled' in auto_options }}"
-  is_down_enabled: "{{ 'auto_down_enabled' in auto_options }}"
-  is_brightness_enabled: "{{ 'auto_brightness_enabled' in auto_options }}"
-  is_sun_elevation_enabled: "{{ 'auto_sun_enabled' in auto_options }}"
-  is_ventilation_enabled: "{{ 'auto_ventilate_enabled' in auto_options }}"
-  is_lockout_protection_enabled: "{{ 'auto_lockout_protection_enabled' in auto_options }}"
-  is_time_field_enabled: "{{ 'time_control_input' in time_control or time_control == [] or time_schedule_helper == [] }}"
-  is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
-
   individual_config: !input individual_config
   prevent_close_after_lockout: "{{ '_prevent_close_after_lockout' in individual_config }}"
   prevent_higher_position_closing: "{{ 'prevent_higher_position_closing' in individual_config }}"
@@ -1457,176 +1412,402 @@ variables:
   ventilation_delay_enabled: "{{ 'ventilation_delay_enabled' in auto_ventilate_options }}"
   ventilation_if_lower_enabled: "{{ 'ventilation_if_lower_enabled' in auto_ventilate_options }}"
 
+trigger_variables:
+  # Modes
+  auto_options: !input auto_options
+
+  # Times
+  time_up_early: !input time_up_early
+  time_up_early_non_workday: !input time_up_early_non_workday
+  time_up_late: !input time_up_late
+  time_up_late_non_workday: !input time_up_late_non_workday
+  time_down_early: !input time_down_early
+  time_down_early_non_workday: !input time_down_early_non_workday
+  time_down_late: !input time_down_late
+  time_down_late_non_workday: !input time_down_late_non_workday
+  workday_sensor: !input workday_sensor
+
+  # Brightness
+  default_brightness_sensor: !input default_brightness_sensor
+  brightness_up: !input brightness_up
+  brightness_down: !input brightness_down
+
+  # Sun
+  default_sun_sensor: !input default_sun_sensor
+  sun_elevation_up: !input sun_elevation_up
+  sun_elevation_down: !input sun_elevation_down
+
+  # Sensors
+  contact_sensor: !input contact_sensor
+  resident_sensor: !input resident_sensor
+
+  # Time controls
+  time_control: !input time_control
+  time_schedule_helper: !input time_schedule_helper
+
+  # Shading
+  shading_brightness_sensor: !input shading_brightness_sensor
+  shading_temperatur_sensor1: !input shading_temperatur_sensor1
+  shading_temperatur_sensor2: !input shading_temperatur_sensor2
+  shading_min_temperatur1: !input shading_min_temperatur1
+  shading_min_temperatur2: !input shading_min_temperatur2
+  shading_azimuth_start: !input shading_azimuth_start
+  shading_azimuth_end: !input shading_azimuth_end
+  shading_elevation_min: !input shading_elevation_min
+  shading_elevation_max: !input shading_elevation_max
+  shading_sun_brightness_start: !input shading_sun_brightness_start
+  shading_sun_brightness_end: !input shading_sun_brightness_end
+  shading_forecast_temp: !input shading_forecast_temp
+
+  # Internal code helper
+  is_shading_enabled: "{{ 'auto_shading_enabled' in auto_options }}"
+  is_up_enabled: "{{ 'auto_up_enabled' in auto_options }}"
+  is_down_enabled: "{{ 'auto_down_enabled' in auto_options }}"
+  is_brightness_enabled: "{{ 'auto_brightness_enabled' in auto_options }}"
+  is_sun_elevation_enabled: "{{ 'auto_sun_enabled' in auto_options }}"
+  is_ventilation_enabled: "{{ 'auto_ventilate_enabled' in auto_options }}"
+  is_lockout_protection_enabled: "{{ 'auto_lockout_protection_enabled' in auto_options }}"
+  is_time_field_enabled: "{{ 'time_control_input' in time_control or time_control == [] or time_schedule_helper == [] }}"
+  is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
+
 trigger:
-  # triggers for shading in
-  - platform: numeric_state
-    entity_id: !input shading_temperatur_sensor1
-    above: !input shading_min_temperatur1
-    id: "t_si_1"
-  - platform: numeric_state
-    entity_id: !input shading_temperatur_sensor2
-    above: !input shading_min_temperatur2
-    id: "t_si_2"
-  - platform: numeric_state
-    entity_id: !input shading_brightness_sensor
-    above: !input shading_sun_brightness_start
-    id: "t_si_3"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: elevation
-    above: !input shading_elevation_min
-    id: "t_si_4"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: azimuth
-    above: !input shading_azimuth_start
-    below: !input shading_azimuth_end
-    id: "t_si_5"
-  - platform: numeric_state
-    entity_id: !input shading_temperatur_sensor1
-    above: !input shading_forecast_temp
-    id: "t_si_6"
+  ########################################
+  # Trigger for opening cover
+  ########################################
 
-  # triggers for shading out
-  - platform: numeric_state
-    entity_id: !input shading_temperatur_sensor1
-    below: !input shading_min_temperatur1
-    id: "t_so_1"
-  - platform: numeric_state
-    entity_id: !input shading_temperatur_sensor2
-    below: !input shading_min_temperatur2
-    id: "t_so_2"
-  - platform: numeric_state
-    entity_id: !input shading_brightness_sensor
-    below: !input shading_sun_brightness_end
-    id: "t_so_3"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: elevation
-    above: !input shading_elevation_max
-    id: "t_so_4"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: azimuth
-    above: !input shading_azimuth_end
-    id: "t_so_5"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: elevation
-    below: !input shading_elevation_min
-    id: "t_so_6"
+  - platform: template
+    value_template: >-
+      {% if time_up_early_non_workday == [] or workday_sensor == [] or (is_state(workday_sensor, 'on')) %}
+        {{ is_time_field_enabled and now() >= today_at(time_up_early) }}
+      {% else %}
+        {{ is_time_field_enabled and now() >= today_at(time_up_early_non_workday) }}
+      {% endif %}
+    id: "t_bo_1"
 
-  # trigger for opening cover
-  - platform: numeric_state
-    entity_id: !input default_brightness_sensor
-    above: !input brightness_up
+  - platform: template
+    value_template: >-
+      {% if time_up_late_non_workday == [] or workday_sensor == [] or (is_state(workday_sensor, 'on')) %}
+        {{ is_time_field_enabled and now() >= today_at(time_up_late) }}
+      {% else %}
+        {{ is_time_field_enabled and now() >= today_at(time_up_late_non_workday) }}
+      {% endif %}
+    id: "t_bo_2"
+
+  - platform: template
+    value_template: "{{ is_schedule_helper_enabled and time_schedule_helper != [] and is_state(time_schedule_helper, ['true', 'on']) }}"
+    id: "t_bo_3"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_brightness_enabled and
+        default_brightness_sensor != [] and
+        (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up) and
+        (
+          (
+            is_time_field_enabled and
+            now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
+            now() <= today_at([time_up_late, time_up_late_non_workday] | min) + timedelta(seconds = 5)
+          )
+          or
+          (
+            is_schedule_helper_enabled and
+            time_schedule_helper != [] and
+            is_state(time_schedule_helper, 'on')
+          )
+        )
+      }}
     for:
       seconds: !input brightness_time_duration
-    id: "t_bo_1"
-  - platform: time
-    at: !input time_up_late
-    id: "t_bo_2"
-  - platform: time
-    at: !input time_up_late_non_workday
-    id: "t_bo_3"
-  - platform: time
-    at: !input time_up_early
     id: "t_bo_4"
-  - platform: time
-    at: !input time_up_early_non_workday
+
+  - platform: template
+    value_template: >-
+      {{
+        is_sun_elevation_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up) and
+        (
+          (
+            is_time_field_enabled and
+            now() >= today_at([time_up_early, time_up_early_non_workday] | min) - timedelta(seconds = 5) and
+            now() <= today_at([time_up_late, time_up_late_non_workday] | min) + timedelta(seconds = 5)
+          )
+          or
+          (
+            is_schedule_helper_enabled and
+            time_schedule_helper != [] and
+            is_state(time_schedule_helper, 'on')
+          )
+        )
+      }}
+    for:
+      seconds: !input sun_time_duration
     id: "t_bo_5"
+
   - platform: state
     entity_id: !input resident_sensor
     from: "on"
     to: "off"
     id: "t_bo_6"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    above: !input sun_elevation_up
-    attribute: elevation
-    for:
-      seconds: !input sun_time_duration
-    id: "t_bo_7"
-  - platform: state
-    entity_id: !input time_schedule_helper
-    from: "off"
-    to: "on"
-    id: "t_bo_8"
+
   - platform: state
     entity_id: !input auto_up_force
     from: "off"
     to: "on"
-    id: "t_bo_9"
+    id: "t_bo_force"
 
-  # trigger for closing cover
-  - platform: numeric_state
-    entity_id: !input default_brightness_sensor
-    below: !input brightness_down
-    for: !input brightness_time_duration
+  ########################################
+  # Trigger for closing cover
+  ########################################
+
+  - platform: template
+    value_template: >-
+      {% if time_down_early_non_workday == [] or workday_sensor == [] or (is_state(workday_sensor, 'on')) %}
+        {{ is_time_field_enabled and now() >= today_at(time_down_early) }}
+      {% else %}
+        {{ is_time_field_enabled and now() >= today_at(time_down_early_non_workday) }}
+      {% endif %}
     id: "t_bc_1"
-  - platform: time
-    at: !input time_down_early
+
+  - platform: template
+    value_template: >-
+      {% if time_down_late_non_workday == [] or workday_sensor == [] or (is_state(workday_sensor, 'on')) %}
+        {{ is_time_field_enabled and now() >= today_at(time_down_late) }}
+      {% else %}
+        {{ is_time_field_enabled and now() >= today_at(time_down_late_non_workday) }}
+      {% endif %}
     id: "t_bc_2"
-  - platform: time
-    at: !input time_down_early_non_workday
+
+  - platform: template
+    value_template: "{{ is_schedule_helper_enabled and time_schedule_helper != [] and is_state(time_schedule_helper, ['false', 'off']) }}"
     id: "t_bc_3"
-  - platform: time
-    at: !input time_down_late
+
+  - platform: template
+    value_template: >-
+      {{
+        is_brightness_enabled and
+        default_brightness_sensor != [] and
+        (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) and
+        (
+          (
+            is_time_field_enabled and
+            now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
+            now() <= today_at([time_down_late, time_down_late_non_workday] | min) + timedelta(seconds = 5)
+          )
+          or
+          (
+            is_schedule_helper_enabled and
+            time_schedule_helper != [] and
+            is_state(time_schedule_helper, 'on')
+          )
+        )
+      }}
+    for:
+      seconds: !input brightness_time_duration
     id: "t_bc_4"
-  - platform: time
-    at: !input time_down_late_non_workday
+
+  - platform: template
+    value_template: >-
+      {{
+        is_sun_elevation_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_down) < sun_elevation_down) and
+        (
+          (
+            is_time_field_enabled and
+            now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) and
+            now() <= today_at([time_down_late, time_down_late_non_workday] | min) + timedelta(seconds = 5)
+          )
+          or
+          (
+            is_schedule_helper_enabled and
+            time_schedule_helper != [] and
+            is_state(time_schedule_helper, 'on')
+          )
+        )
+      }}
+
+    for:
+      seconds: !input sun_time_duration
     id: "t_bc_5"
+
   - platform: state
     entity_id: !input resident_sensor
     from: "off"
     to: "on"
-    id: "t_bc_7"
-  - platform: numeric_state
-    entity_id: !input default_sun_sensor
-    attribute: elevation
-    below: !input sun_elevation_down
-    for:
-      seconds: !input sun_time_duration
-    id: "t_bc_8"
-  - platform: state
-    entity_id: !input time_schedule_helper
-    from: "on"
-    to: "off"
-    id: "t_bc_9"
+    id: "t_bc_6"
+
   - platform: state
     entity_id: !input auto_down_force
     from: "off"
     to: "on"
-    id: "t_bc_10"
+    id: "t_bc_force"
 
-  # trigger for ventilate
-  - platform: state
-    entity_id: !input contact_sensor
-    from: "off"
-    to: "on"
-    id: "t_bv_1"
-  - platform: state
-    entity_id: !input contact_sensor
-    from: "on"
-    to: "off"
-    id: "t_bv_2"
+  ########################################
+  # Trigger for ventilate
+  ########################################
+
+  - platform: template
+    value_template: "{{ is_ventilation_enabled and contact_sensor != [] and is_state(contact_sensor, ['true', 'on']) }}"
+    id: "t_co_open"
+
+  - platform: template
+    value_template: "{{ is_ventilation_enabled and contact_sensor != [] and is_state(contact_sensor, ['false', 'off']) }}"
+    id: "t_co_close"
+
   - platform: state
     entity_id: !input auto_ventilate_force
     from: "off"
     to: "on"
-    id: "t_bv_3"
+    id: "t_co_force"
 
-  # trigger for manual cover movements
+  ########################################
+  # Triggers for shading in
+  ########################################
+
+  - platform: template # Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_temperatur_sensor1 != [] and
+        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1
+      }}"
+    for: "00:00:05"
+    id: "t_si_1"
+
+  - platform: template # Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_temperatur_sensor2 != [] and
+        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2
+      }}"
+    for: "00:00:05"
+    id: "t_si_2"
+
+  - platform: template # TODO: Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_brightness_sensor != [] and
+        states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start
+      }}"
+    for: "00:00:05"
+    id: "t_si_3"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_shading_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) > shading_elevation_min)
+      }}"
+    for: "00:00:05"
+    id: "t_si_4"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_shading_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) > shading_azimuth_start) and
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) < shading_azimuth_end)
+      }}"
+    for: "00:00:05"
+    id: "t_si_5"
+
+  # - platform: numeric_state
+  #   entity_id: !input shading_temperatur_sensor1
+  #   above: !input shading_forecast_temp
+  #   for: "00:00:05"
+  #   id: "t_si_6"
+
+  ########################################
+  # Triggers for shading out
+  ########################################
+
+  # state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position')
+  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_temperatur_sensor1 != [] and
+        states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) < shading_min_temperatur1
+      }}"
+    for: "00:00:05"
+    id: "t_so_1"
+
+  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_temperatur_sensor2 != [] and
+        states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) < shading_min_temperatur2
+      }}"
+    for: "00:00:05"
+    id: "t_so_2"
+
+  - platform: template # TODO: Not used anyhwere / Only allow triggers in certain time periods. Too volatile
+    value_template: >-
+      {{
+        is_shading_enabled and
+        shading_brightness_sensor != [] and
+        states(shading_brightness_sensor) | float(default=shading_sun_brightness_end) < shading_sun_brightness_end
+      }}"
+    for: "00:00:05"
+    id: "t_so_3"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_shading_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max)
+      }}"
+    for: "00:00:05"
+    id: "t_so_4"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_shading_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end)
+      }}"
+    for: "00:00:05"
+    id: "t_so_5"
+
+  - platform: template
+    value_template: >-
+      {{
+        is_shading_enabled and
+        default_sun_sensor != [] and
+        (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
+      }}"
+    for: "00:00:05"
+    id: "t_so_6"
+
+  ########################################
+  # Trigger for manual cover movements
+  ########################################
+
   - platform: state
     entity_id: !input blind
     attribute: current_position
     id: "t_ma_1"
-    #for: "00:00:30"
     for:
       seconds: !input drive_time
 
 condition:
   - condition: !input auto_global_condition
+  - condition: template
+    value_template: "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
+  - condition: template
+    value_template: "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}"
+
+  # - condition: template # Problem mit 'closing'
+  #   value_template: "{{ trigger.to_state.state != trigger.from_state.state }}"
 
 action:
   # We have to call a service for forecast due to HA changes
@@ -1641,7 +1822,7 @@ action:
           - "t_si_3"
           - "t_si_4"
           - "t_si_5"
-          - "t_si_6"
+          # - "t_si_6"
     then:
       - service: weather.get_forecasts
         target:
@@ -1715,8 +1896,6 @@ action:
               - "t_bo_4"
               - "t_bo_5"
               - "t_bo_6"
-              - "t_bo_7"
-              - "t_bo_8"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
           - or: # Check the current positions
               - "{{ is_status_helper_enabled and ignore_opening_after_manual and is_cover_manual }}"
@@ -1738,7 +1917,7 @@ action:
                   - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'on') }}"
                   - condition: trigger
-                    id: "t_bo_8"
+                    id: "t_bo_3"
               # - and: # Opening - Via schedule helper w/o brightness and sun TODO: ?????
               #     - "{{ is_schedule_helper_enabled }}"
               #     - "{{ not is_brightness_enabled }}"
@@ -1758,10 +1937,10 @@ action:
                   - or:
                       - or:
                           - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_up) >= brightness_up) }}"
+                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_up) > brightness_up) }}"
                       - or:
                           - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_up) >= sun_elevation_up) }}"
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_up) > sun_elevation_up) }}"
 
         sequence:
           - delay: "00:00:{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -1836,9 +2015,7 @@ action:
               - "t_bc_3"
               - "t_bc_4"
               - "t_bc_5"
-              - "t_bc_7"
-              - "t_bc_8"
-              - "t_bc_9"
+              - "t_bc_6"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - or: # Optional: Continue if cover is shaded and close position is lower than shading position
@@ -1866,23 +2043,20 @@ action:
               - "{{ not is_status_helper_enabled or is_status_helper_enabled and (is_cover_closed_ts < today_at(time_down_early) | as_timestamp) }}"
           - or:
               - and: # Closing - Down late reached
-                  - "{{ is_down_enabled }}"
                   - "{{ is_time_field_enabled }}"
                   - "{{ now() >= today_at(time_down_late_today) }}"
               - and: # Closing - Scheduler changes to off
-                  - "{{ is_down_enabled }}"
                   - "{{ is_schedule_helper_enabled }}"
+                  - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'off') }}"
                   - condition: trigger
-                    id: "t_bc_9"
+                    id: "t_bc_3"
               # - and: # Closing - Via schedule helper w/o brightness and sun TODO: ?????
-              #     - "{{ is_down_enabled }}"
               #     - "{{ not is_brightness_enabled }}"
               #     - "{{ not is_sun_elevation_enabled }}"
               #     - "{{ is_schedule_helper_enabled }}"
               #     - "{{ is_state(time_schedule_helper, 'off') }}"
               - and: # Closing - Down early reached and brightness/sun below minimum
-                  - "{{ is_down_enabled }}"
                   - or:
                       - and:
                           - "{{ is_time_field_enabled }}"
@@ -1895,14 +2069,13 @@ action:
                   - or:
                       - or:
                           - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) <= brightness_down) }}"
+                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) }}"
                       - or:
                           - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) <= sun_elevation_down) }}"
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) < sun_elevation_down) }}"
               - and: # Closing - due to resident goes sleeping
                   - condition: trigger
-                    id: t_bc_7
-                  - "{{ is_down_enabled }}"
+                    id: t_bc_6
                   - "{{ resident_sensor != [] }}"
                   - "{{ is_state(resident_sensor, ['true', 'on']) }}"
 
@@ -2010,7 +2183,7 @@ action:
               - "t_si_3"
               - "t_si_4"
               - "t_si_5"
-              - "t_si_6"
+              # - "t_si_6"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - or: # Check the current positions
@@ -2018,7 +2191,7 @@ action:
               - "{{ is_status_helper_enabled and ignore_shading_after_manual and is_cover_manual }}"
               - "{{ is_status_helper_enabled and not is_cover_shaded }}"
               - "{{ is_status_helper_enabled and not (is_cover_ventilated or is_cover_locked) }}"
-              - "{{ not (current_position | int(default=101) == ventilate_position) }}"
+              - "{{ not (current_position | int(default=101) == ventilate_position) }}" # TODO: Why not checking with shading_pos, too?
           - or: # Only once a day
               - "{{ not is_status_helper_enabled or is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
           - or:
@@ -2030,16 +2203,16 @@ action:
                   - "{{ is_schedule_helper_enabled }}"
                   - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'on') }}"
-          - "{{ ( (shading_temperatur_sensor1 == [] ) or (states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) >= shading_min_temperatur1) ) }}"
-          - "{{ ( (shading_temperatur_sensor2 == [] ) or (states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) >= shading_min_temperatur2) ) }}"
-          - "{{ ( (shading_brightness_sensor == [] ) or (states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) >= shading_sun_brightness_start) ) }}"
-          - "{{ current_sun_azimuth >= shading_azimuth_start and current_sun_azimuth <= shading_azimuth_end }}"
-          - "{{ current_sun_elevation >= shading_elevation_min and current_sun_elevation <= shading_elevation_max }}"
+          - "{{ ( (shading_temperatur_sensor1 == [] ) or (states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1) ) }}"
+          - "{{ ( (shading_temperatur_sensor2 == [] ) or (states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2) ) }}"
+          - "{{ ( (shading_brightness_sensor == [] ) or (states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start) ) }}"
+          - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+          - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
           - "{{ current_position | int(default=101) > shading_position }}"
           - "{{ resident_sensor == [] or is_state(resident_sensor, ['false', 'off']) }}"
           - or:
               - "{{ ( shading_forecast_sensor == [] ) and (shading_temperatur_sensor1 == [] ) }}"
-              - "{{ ( shading_forecast_sensor != [] ) and (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) >= shading_forecast_temp ) }}"
+              - "{{ ( shading_forecast_sensor != [] ) and (not prevent_forecast_service) and ( weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp ) }}"
           - "{{ ( shading_forecast_sensor == [] ) or (states(shading_forecast_sensor) in shading_weather_conditions) }}"
 
         sequence:
@@ -2147,8 +2320,8 @@ action:
         sequence:
           - if: # If sun is outside of shading window (azimuth or elevation) we immediately stop shading
               - and:
-                  - "{{ current_sun_azimuth >= shading_azimuth_start and current_sun_azimuth <= shading_azimuth_end }}"
-                  - "{{ current_sun_elevation >= shading_elevation_min and current_sun_elevation <= shading_elevation_max }}"
+                  - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+                  - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
             then:
               - alias: "Wait the number of seconds set in shading_waitingtime_end"
                 delay:
@@ -2270,7 +2443,7 @@ action:
           - "{{ is_ventilation_enabled }}"
           - condition: !input auto_ventilate_condition
           - condition: trigger
-            id: "t_bv_1"
+            id: "t_co_open"
           - "{{ contact_sensor != [] }}"
           - "{{ is_state(contact_sensor, ['true', 'on']) }}"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
@@ -2338,7 +2511,7 @@ action:
               - "{{ is_ventilation_enabled }}"
               - "{{ is_lockout_protection_enabled and not prevent_close_after_lockout }}"
           - condition: trigger
-            id: "t_bv_2"
+            id: "t_co_close"
           - "{{ contact_sensor != [] }}"
           - "{{ is_state(contact_sensor, ['false', 'off']) }}"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
@@ -2353,6 +2526,7 @@ action:
                   - "{{ now() >= today_at(time_down_late_today) }}"
               - and: # Closed - Scheduler is off
                   - "{{ is_schedule_helper_enabled }}"
+                  - "{{ time_schedule_helper != [] }}"
                   - "{{ is_state(time_schedule_helper, 'off') }}"
               - and: # Closed - Down early reached and brightness/sun below minimum
                   - or:
@@ -2367,10 +2541,10 @@ action:
                   - or:
                       - or:
                           - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) <= brightness_down) }}"
+                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) }}"
                       - or:
                           - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) <= sun_elevation_down) }}"
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) < sun_elevation_down) }}"
 
         sequence:
           - if:
@@ -2443,7 +2617,7 @@ action:
         conditions:
           - "{{ is_up_enabled }}"
           - condition: trigger
-            id: "t_bo_9"
+            id: "t_bo_force"
           - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
         sequence:
           - repeat:
@@ -2510,7 +2684,7 @@ action:
         conditions:
           - "{{ is_down_enabled }}"
           - condition: trigger
-            id: "t_bc_10"
+            id: "t_bc_force"
           - "{{ auto_down_force != [] and is_state(auto_down_force, ['true', 'on']) }}"
         sequence:
           - repeat:
@@ -2577,7 +2751,7 @@ action:
         conditions:
           - "{{ is_ventilation_enabled }}"
           - condition: trigger
-            id: "t_bv_3"
+            id: "t_co_force"
           - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
         sequence:
           - repeat:


### PR DESCRIPTION
      - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
      - New: Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
      - New: Added possibility to disable the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions
      - Fixed: Shading Forecast Weather Conditions
      - Fixed: Ventilation mode should not only be ended in the evening, but whenever it is not yet daytime.
      - Fixed: Added the ventilation mode activation on closing down again
      - Try to avoid overlaps in the execution of the automation if several triggers are triggered shortly after each other.
      - Fixed: Optional weather conditions for "shading in" #41