### PR TITLE
Major Update: Complete restructuring and logic change for shading, lockout protection and ventilation

### DIFF
--- a/blueprints/automation/CHANGELOG.md
+++ b/blueprints/automation/CHANGELOG.md
@@ -162,3 +162,23 @@
 2024.05.15-02:
   - Quick workaround, as opening and closing does not currently work.
   - Minor changes
+
+2024.05.28-01:
+  - Complete restructuring and logic change for shading, lockout protection and ventilation:
+      - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
+      - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
+      - If the cover is closed and the corresponding contact is opened, the ventilation position is activated.
+      - When the sun shading is activated, the lockout protection is taken into account if the contact is open. If the contact is closed, the cover moves back to the shading position.
+      - When the sun shading is stopped, the lockout protection is checked. It is also possible to move to the ventilation position when the contact is open. If the contact is closed here, the cover is opened.
+
+      <ins>Summary:</ins> CCA saves the temporary status (ventilation, lockout protection and shading) and the actual target status in the Cover Status Helper.
+      - This means that the cover is simply opened or closed as before.
+      - And it does <ins>not</ins> always return to the previous state (which may have changed in the meantime).
+      - Instead, it switches to the state that should actually be current.
+  - Fixed: Incorrect position detection during manual drives if shading_position is smaller than close_position
+  - Added: Shading activation before opening. The cover can now move into the shading during the opening process. #4
+  - Added: Prevent automatic closing due to the resident sensor #63
+  - Added: Option to deactivate time control. This means that the system can now also be controlled exclusively via the brightness and the height of the sun. I
+  - <strong>BREAKING CHANGES:</strong>
+      - Cover Status Helper is now mandatory for ventilation, lockout protection and shading!
+      - Invert the status of some options #61 ("Prevent the cover from being ... several times a day" instead of "Allow the cover to be ... several times a day")

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.05.27-01
+    **Version**: 2024.05.28-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -66,7 +66,7 @@ blueprint:
     <details>
     <summary><strong>Changes in the last days</strong></summary>
 
-    2024.05.27-01:
+    2024.05.28-01:
       - Complete restructuring and logic change for shading, lockout protection and ventilation:
           - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
           - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
@@ -81,6 +81,7 @@ blueprint:
       - Fixed: Incorrect position detection during manual drives if shading_position is smaller than close_position
       - Added: Shading activation before opening. The cover can now move into the shading during the opening process. #4
       - Added: Prevent automatic closing due to the resident sensor #63
+      - Added: Option to deactivate time control. This means that the system can now also be controlled exclusively via the brightness and the height of the sun. I
       - <strong>BREAKING CHANGES:</strong>
           - Cover Status Helper is now mandatory for ventilation, lockout protection and shading!
           - Invert the status of some options #61 ("Prevent the cover from being ... several times a day" instead of "Allow the cover to be ... several times a day")
@@ -161,9 +162,9 @@ blueprint:
               value: "auto_up_enabled"
             - label: "🔻 - Enable automatic daily cover closing"
               value: "auto_down_enabled"
-            - label: "🔅 - Enable control (for opening/closing) via brightness values"
+            - label: "🔅 - Enable control (to open/close) via brightness values"
               value: "auto_brightness_enabled"
-            - label: "☀️ - Enable control (for opening/closing) via sun elevation"
+            - label: "☀️ - Enable control (to open/close) via sun elevation"
               value: "auto_sun_enabled"
             - label: "💨 - Enable ventilation mode"
               value: "auto_ventilate_enabled"
@@ -262,7 +263,7 @@ blueprint:
         However, this is important to avoid bouncing when controlling the brightness, for example.
         In order to recognise whether we are still in the opening period or the closing period,
         it is necessary to enter a very rough time period in the time variables in the blueprint.
-        <br />
+        <br /><br />
         <ins>Example:</ins>
         If the schedule helper goes to the "ON" status at 08:00 and to the "OFF" status at 18:00, it is sufficient to configure the times as follows:
         <br /><br />
@@ -272,6 +273,12 @@ blueprint:
         Time For Drive Down - Late: 22:00<br />
 
         The times are not used for triggering, but only to divide the day into two halves!
+
+
+        <ins>Disable time control and all time triggers</ins><br />
+        Finally, you can also deactivate the time control completely.
+        This means that the roller shutters are not opened or closed via time triggers.
+        The sun-elevation and brightness control then also runs completely independently.
 
         </details>
 
@@ -283,6 +290,8 @@ blueprint:
               value: "time_control_input"
             - label: "⏲️ Use an external schedule helper"
               value: "time_control_schedule"
+            - label: "🚫 Disable time control and all time triggers"
+              value: "time_control_disabled"
           sort: false
           multiple: false
           custom_value: false
@@ -318,7 +327,9 @@ blueprint:
       name: "❓ Additional condition for the entire automation"
       description: >-
         This condition allows you to control the execution of the <ins>entire</ins> automation dynamically and outside of the blueprint configuration.
-        With this option you could enable a party mode.
+        With this option you could enable a party mode.<br /><br />
+        This is the only condition that is also taken into account in the force features.
+        Forcing Open/Close/Shading/Ventilation is therefore only possible if this condition remains empty or becomes valid.
         <br /><br />`Optional`
       default: []
       selector:
@@ -1443,9 +1454,10 @@ trigger_variables:
   is_lockout_protection_enabled: "{{ 'auto_lockout_protection_enabled' in auto_options }}"
   is_time_field_enabled: "{{ 'time_control_input' in time_control or time_control == [] or time_schedule_helper == [] }}"
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
+  is_time_control_disabled: "{{ 'time_control_disabled' in time_control }}"
 
 variables:
-  version: "2024.05.27-01"
+  version: "2024.05.28-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1455,7 +1467,6 @@ variables:
   # Delays
   drive_delay_fix: !input drive_delay_fix
   drive_delay_random: !input drive_delay_random
-  # tilt_delay: !input tilt_delay
   drive_time: !input drive_time
 
   time_up_early_today: >-
@@ -1965,6 +1976,8 @@ action:
               - "{{ resident_sensor == [] }}"
               - "{{ is_state(resident_sensor, ['false', 'off']) }}"
           - or: # Now we have to check different opening scenarios
+              - and: # Control via times disabled
+                  - "{{ is_time_control_disabled }}"
               - and: # Opening - Up late reached
                   - "{{ is_time_field_enabled }}"
                   - "{{ now() >= today_at(time_up_late_today) }}"
@@ -1977,6 +1990,8 @@ action:
                     id: "t_bo_3"
               - and: # Opening - Up early reached or schedule helper is on and brightness/sun above minimum
                   - or:
+                      - and:
+                          - "{{ is_time_control_disabled }}"
                       - and:
                           - "{{ is_time_field_enabled }}"
                           - "{{ now() >= today_at(time_up_early_today) }}"
@@ -2158,6 +2173,8 @@ action:
               - "{{ not prevent_closing_multiple_times }}"
               - "{{ is_status_helper_enabled and prevent_closing_multiple_times and (is_cover_closed_ts < today_at(time_down_early_today) | as_timestamp) }}"
           - or:
+              - and: # Control via times disabled
+                  - "{{ is_time_control_disabled }}"
               - and: # Closing - Down late reached
                   - "{{ is_time_field_enabled }}"
                   - "{{ now() >= today_at(time_down_late_today) }}"
@@ -2169,6 +2186,8 @@ action:
                     id: "t_bc_3"
               - and: # Closing - Down early reached and brightness/sun below minimum
                   - or:
+                      - and: # Control via times disabled
+                          - "{{ is_time_control_disabled }}"
                       - and:
                           - "{{ is_time_field_enabled }}"
                           - "{{ now() >= today_at(time_down_early_today) }}"
@@ -2433,6 +2452,8 @@ action:
               - "{{ prevent_shading_multiple_times and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
           - or:
               - and:
+                  - "{{ is_time_control_disabled }}"
+              - and:
                   - "{{ is_time_field_enabled }}"
                   - "{{ now() >= today_at(time_up_early_today) }}"
                   - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
@@ -2591,6 +2612,8 @@ action:
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
           - or:
               - and:
+                  - "{{ is_time_control_disabled }}"
+              - and:
                   - "{{ is_time_field_enabled }}"
                   - "{{ now() >= today_at(time_up_early_today) }}"
                   - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
@@ -2630,7 +2653,7 @@ action:
                   ################################################
                   # Consider lockout protection when shading ends
                   ################################################
-                  - alias: "Consider lockout protection when shading ends" # Only required in this branch. So no separate choose-Condition.
+                  - alias: "Consider lockout protection when shading ends" # Only required in this branch. So no separate choose-condition.
                     if:
                       - "{{ is_lockout_protection_enabled }}"
                       - "{{ contact_sensor_lockout != [] }}"
@@ -3556,7 +3579,7 @@ action:
         then:
           # Checking time slots
           - if:
-              - "{{ today_at(time_up_early) >= today_at(time_up_late) }}"
+              - "{{ not is_time_control_disabled and (today_at(time_up_early) >= today_at(time_up_late)) }}"
             then:
               - service: system_log.write
                 data:
@@ -3564,7 +3587,7 @@ action:
                   message: "Cover Control Automation (CCA): Config issue: time_up_early should be earlier than time_up_late - {{this.entity_id}}"
                   logger: "blueprints.hvorragend.cover_control_automation"
           - if:
-              - "{{ today_at(time_up_early_non_workday) >= today_at(time_up_late_non_workday) }}"
+              - "{{ not is_time_control_disabled and (today_at(time_up_early_non_workday) >= today_at(time_up_late_non_workday)) }}"
             then:
               - service: system_log.write
                 data:
@@ -3572,7 +3595,7 @@ action:
                   message: "Cover Control Automation (CCA): Config issue: time_up_early_non_workday should be earlier than time_up_late_non_workday - {{this.entity_id}}"
                   logger: "blueprints.hvorragend.cover_control_automation"
           - if:
-              - "{{ today_at(time_down_early) >= today_at(time_down_late) }}"
+              - "{{ not is_time_control_disabled and (today_at(time_down_early) >= today_at(time_down_late)) }}"
             then:
               - service: system_log.write
                 data:
@@ -3580,7 +3603,7 @@ action:
                   message: "Cover Control Automation (CCA): Config issue: time_down_early should be earlier than time_down_late - {{this.entity_id}}"
                   logger: "blueprints.hvorragend.cover_control_automation"
           - if:
-              - "{{ today_at(time_down_early_non_workday) >= today_at(time_down_late_non_workday) }}"
+              - "{{ not is_time_control_disabled and (today_at(time_down_early_non_workday) >= today_at(time_down_late_non_workday)) }}"
             then:
               - service: system_log.write
                 data:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2195,10 +2195,10 @@ action:
 
         sequence:
           - choose:
-              ###################################
-              # Consider lockout protection
-              ###################################
-              - alias: "Consider lockout protection"
+              ###########################################
+              # Consider lockout protection when closing
+              ###########################################
+              - alias: "Consider lockout protection when closing"
                 conditions:
                   - "{{ is_lockout_protection_enabled }}"
                   - "{{ contact_sensor_lockout != [] }}"
@@ -2289,9 +2289,9 @@ action:
                   - choose: []
                     default: !input auto_ventilate_action
 
-              ###########################################
-              # Cover is already near the close position
-              ###########################################
+              ###################################
+              # Cover is already (almost) closed
+              ###################################
 
               - alias: "Only status change if cover is already near the close position"
                 conditions:
@@ -2465,10 +2465,10 @@ action:
 
         sequence:
           - choose:
-              ###################################
-              # Consider lockout protection
-              ###################################
-              - alias: "Consider lockout protection"
+              ##################################################
+              # Consider lockout protection when shading starts
+              ##################################################
+              - alias: "Consider lockout protection when shading starts"
                 conditions:
                   - "{{ is_lockout_protection_enabled }}"
                   - "{{ contact_sensor_lockout != [] }}"
@@ -2552,9 +2552,9 @@ action:
                   - choose: []
                     default: !input auto_shading_start_action
 
-              ###################################
+              ####################################
               # Save shading state for the future
-              ###################################
+              ####################################
               - alias: "Save shading state for the future"
                 conditions:
                   - "{{ is_cover_closed }}"
@@ -2612,37 +2612,9 @@ action:
         sequence:
           - choose:
               ###################################
-              # Consider lockout protection
+              # Ventilation after shading ends
               ###################################
-              - alias: "Consider lockout protection"
-                conditions:
-                  - "{{ is_lockout_protection_enabled }}"
-                  - "{{ contact_sensor_lockout != [] }}"
-                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
-                sequence:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
-              ###################################
-              # Ventilation after shading end
-              ###################################
-              - alias: "Ventilation after shading end"
+              - alias: "Ventilation after shading ends"
                 conditions:
                   - "{{ is_ventilation_enabled }}"
                   - "{{ contact_sensor != [] }}"
@@ -2655,6 +2627,36 @@ action:
                       - "{{ contact_sensor_lockout == [] }}"
                       - "{{ is_state(contact_sensor_lockout, ['false', 'off']) }}"
                 sequence:
+                  ################################################
+                  # Consider lockout protection when shading ends
+                  ################################################
+                  - alias: "Consider lockout protection when shading ends" # Only required in this branch. So no separate choose-Condition.
+                    if:
+                      - "{{ is_lockout_protection_enabled }}"
+                      - "{{ contact_sensor_lockout != [] }}"
+                      - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'close':{'a':false,'t':dict_var.close.t},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+
+                      - stop: "Stop automation: Lockout protection when shading ends"
+
                   - service: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -2799,10 +2801,10 @@ action:
                   - "{{ in_shading_position }}" # Always and independently of the helper
         sequence:
           - choose:
-              ###################################
-              # Consider lockout protection
-              ###################################
-              - alias: "Consider lockout protection" # TODO: Do I really need this here?
+              #################################################
+              # Consider lockout protection when contact opens
+              #################################################
+              - alias: "Consider lockout protection when contact opens" # TODO: Do I really need this here?
                 conditions:
                   - "{{ is_lockout_protection_enabled }}"
                   - "{{ contact_sensor_lockout != [] }}"
@@ -2917,14 +2919,17 @@ action:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
           - choose:
-              ###################################
-              # Consider lockout protection
-              ###################################
-              - alias: "Consider lockout protection"
+              ###################################################
+              # Consider lockout protection when contact closes
+              ###################################################
+              - alias: "Consider lockout protection when contact closes"
                 conditions:
                   - "{{ is_lockout_protection_enabled }}"
                   - "{{ contact_sensor_lockout != [] }}"
                   - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                  - "{{ not is_cover_open }}" # Not required if the cover is opened anyway
+                  - "{{ is_cover_closed }}"
+                  - "{{ is_cover_shaded }}"
                 sequence:
                   - service: input_text.set_value
                     data:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.05.24-01
+    **Version**: 2024.05.27-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -66,7 +66,7 @@ blueprint:
     <details>
     <summary><strong>Changes in the last days</strong></summary>
 
-    2024.05.24-01:
+    2024.05.27-01:
       - Complete restructuring and logic change for shading, lockout protection and ventilation:
           - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
           - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
@@ -413,10 +413,10 @@ blueprint:
         This can be used for the following purposes under certain circumstances: Antifreeze, RainProtection or WindProtection.
 
         Note:
-          - However, after forcing a state, you must ensure that you move to the correct target position yourself.
+          - However, after forcing a state, you must ensure that you move to the correct target position yourself. You are responsible for getting CCA back on track.
+          - This cannot be performed in CCA and must therefore be done via a separate automation. Presumably in the same automation that sets the "Force"-boolean. It is sufficient, by the way, if a configured position is targeted. CCA then recognises the status.
           - Force is a final state that cannot be cancelled or resetted by CCA.
           - The default automations (open, close, and further) will never be able to override a force. The force feature must therefore be cancelled manually beforehand.
-          - If you use any force feature, you are responsible for getting CCA back on track.
 
         </details>
         <br /><code>Optional</code>
@@ -522,10 +522,10 @@ blueprint:
         This can be used for the following purposes under certain circumstances: Antifreeze, RainProtection or WindProtection.
 
         Note:
-          - However, after forcing a state, you must ensure that you move to the correct target position yourself.
+          - However, after forcing a state, you must ensure that you move to the correct target position yourself. You are responsible for getting CCA back on track.
+          - This cannot be performed in CCA and must therefore be done via a separate automation. Presumably in the same automation that sets the "Force"-boolean. It is sufficient, by the way, if a configured position is targeted. CCA then recognises the status.
           - Force is a final state that cannot be cancelled or resetted by CCA.
           - The default automations (open, close, and further) will never be able to override a force. The force feature must therefore be cancelled manually beforehand.
-          - If you use any force feature, you are responsible for getting CCA back on track.
 
         </details>
         <br /><code>Optional</code>
@@ -757,6 +757,9 @@ blueprint:
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
+        If a three-way sensor is available, it must be converted to a binary two-way sensor using a [template sensor](https://www.home-assistant.io/integrations/template/).
+        See also the [following posts](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539/593) in the forum.
+
         If the door contact changes to on/true, the cover is moved to the ventilation position.
         The prerequisite is that the cover is already closed.
         After the status changes to off/false, the close position is activated.
@@ -780,6 +783,9 @@ blueprint:
         <details>
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
+
+        If a three-way sensor is available, it must be converted to a binary two-way sensor using a [template sensor](https://www.home-assistant.io/integrations/template/).
+        See also the [following posts](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539/593) in the forum.
 
         The cover is not closed and the sun shading is not activated when the door contact is open.
         Note that the cover can close in the evening when the door contact is closed.
@@ -855,10 +861,10 @@ blueprint:
         This can be used for the following purposes under certain circumstances: Antifreeze, RainProtection or WindProtection.
 
         Note:
-          - However, after forcing a state, you must ensure that you move to the correct target position yourself.
+          - However, after forcing a state, you must ensure that you move to the correct target position yourself. You are responsible for getting CCA back on track.
+          - This cannot be performed in CCA and must therefore be done via a separate automation. Presumably in the same automation that sets the "Force"-boolean. It is sufficient, by the way, if a configured position is targeted. CCA then recognises the status.
           - Force is a final state that cannot be cancelled or resetted by CCA.
           - The default automations (open, close, and further) will never be able to override a force. The force feature must therefore be cancelled manually beforehand.
-          - If you use any force feature, you are responsible for getting CCA back on track.
 
         </details>
         <br /><code>Optional</code>
@@ -885,24 +891,24 @@ blueprint:
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
-          - <ins>Enable delay after contacts are closed:</ins>
+          - <ins>Use a delay in ventilation mode after closing the contact:</ins>
             <br />
             Normally, when the window contact is closed, there is no delay in the upcoming drives. If you do want this, you can activate it here.
             <br /><br />
             The "Fixed Drive Delay" and "Random Drive Delay" settings which are already used everywhere are then used.
             <br /><br />
-          - <ins>Allow ventilation not only when closed:</ins>
+          - <ins>Allow ventilation even if cover is already in a higher position:</ins>
             <br />
-            Allow ventilation not only in closed state, but also when the position is below the ventilation position.
+            Activate ventilation mode even if the current position of the cover is already higher than the ventilation position.
 
         </details>
       default: []
       selector:
         select:
           options:
-            - label: "💨 Enable delay in ventilation mode"
+            - label: "💨 Use a delay in ventilation mode after closing the contact"
               value: "ventilation_delay_enabled"
-            - label: "💨 Allow ventilation not only when closed"
+            - label: "💨 Allow ventilation even if cover is already in a higher position"
               value: "ventilation_if_lower_enabled"
           multiple: true
           sort: false
@@ -1223,10 +1229,10 @@ blueprint:
         This can be used for the following purposes under certain circumstances: Antifreeze, RainProtection or WindProtection.
 
         Note:
-          - However, after forcing a state, you must ensure that you move to the correct target position yourself.
+          - However, after forcing a state, you must ensure that you move to the correct target position yourself. You are responsible for getting CCA back on track.
+          - This cannot be performed in CCA and must therefore be done via a separate automation. Presumably in the same automation that sets the "Force"-boolean. It is sufficient, by the way, if a configured position is targeted. CCA then recognises the status.
           - Force is a final state that cannot be cancelled or resetted by CCA.
           - The default automations (open, close, and further) will never be able to override a force. The force feature must therefore be cancelled manually beforehand.
-          - If you use any force feature, you are responsible for getting CCA back on track.
 
         </details>
         <br /><code>Optional</code>
@@ -1439,7 +1445,7 @@ trigger_variables:
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
 
 variables:
-  version: "2024.05.24-01"
+  version: "2024.05.27-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1790,7 +1796,7 @@ trigger:
         (shading_brightness_sensor == [] or states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start) and
         (shading_temperatur_sensor1 == [] or states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1) and
         (shading_temperatur_sensor2 == [] or states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2) and
-        (shading_forecast_sensor == [] or states(shading_forecast_sensor) in shading_weather_conditions)
+        (shading_forecast_sensor == [] or shading_weather_conditions == [] or states(shading_forecast_sensor) in shading_weather_conditions)
       }}
     for:
       seconds: !input shading_waitingtime_start
@@ -2218,15 +2224,18 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              ###################################
-              # Move to ventilation position
-              ###################################
+              ###################################################
+              # Move to ventilation position instead of closing
+              ###################################################
               - alias: "Move to ventilation position"
                 conditions:
                   - "{{ is_ventilation_enabled }}"
                   - "{{ contact_sensor != [] }}"
                   - "{{ is_state(contact_sensor, ['true', 'on']) }}"
                   - "{{ is_status_helper_enabled }}"
+                  - or:
+                      - "{{ (current_position | int(default=101) < ventilate_position) }}"
+                      - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) >= ventilate_position) }}"
                 sequence:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -2638,6 +2647,9 @@ action:
                   - "{{ is_ventilation_enabled }}"
                   - "{{ contact_sensor != [] }}"
                   - "{{ is_state(contact_sensor, ['true', 'on']) }}"
+                  - or:
+                      - "{{ (current_position | int(default=101) < ventilate_position) }}"
+                      - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) >= ventilate_position) }}"
                   - or: # The cover is not allowed to be lowered when the lockout protection is enabled
                       - "{{ not is_lockout_protection_enabled }}"
                       - "{{ contact_sensor_lockout == [] }}"
@@ -2776,57 +2788,88 @@ action:
           - "{{ is_state(contact_sensor, ['true', 'on']) }}"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
           - or:
+              - "{{ (current_position | int(default=101) < ventilate_position) }}"
+              - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) >= ventilate_position) }}"
+          - or:
               - or: # Source: Close
                   - "{{ is_cover_closed }}"
                   - "{{ in_close_position }}" # Always and independently of the helper
-                  - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
               - or: # Source: Shading
                   - "{{ is_cover_shaded }}"
                   - "{{ in_shading_position }}" # Always and independently of the helper
         sequence:
-          - service: input_text.set_value
-            data:
-              entity_id: !input cover_status_helper
-              value: |
-                {% set dict_var = states(cover_status_helper) | from_json %}
-                {% set dict_new = dict(dict_var, **{
-                  'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                  'p':current_position,
-                  'v':4,
-                  't':as_timestamp(now()) | round(0)
-                  })
-                %}
-                {{ dict_new | to_json }}
+          - choose:
+              ###################################
+              # Consider lockout protection
+              ###################################
+              - alias: "Consider lockout protection" # TODO: Do I really need this here?
+                conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
 
-          - if:
-              - "{{ not prevent_default_cover_actions}}"
-            then:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - alias: "Moving the cover to ventilate position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input ventilate_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Tilt Delay"
-                          delay:
-                            seconds: !input tilt_delay
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+            ########################################################
+            # Move to ventilate position because contact was opened
+            ########################################################
+            default:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - alias: "Moving the cover to ventilate position"
+                          service: cover.set_cover_position
                           data:
-                            tilt_position: !input ventilate_tilt_position
+                            position: !input ventilate_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - delay:
-                        seconds: "{{ (range(1, 3)|random|int) }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Tilt Delay"
+                              delay:
+                                seconds: !input tilt_delay
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input ventilate_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - delay:
+                            seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - choose: []
-            default: !input auto_ventilate_action
+              - choose: []
+                default: !input auto_ventilate_action
 
           - stop: "Stop automation: CONTACT OPEN"
 
@@ -2874,6 +2917,30 @@ action:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
           - choose:
+              ###################################
+              # Consider lockout protection
+              ###################################
+              - alias: "Consider lockout protection"
+                conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'ventilate':{'a':false,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
               ########################################
               # Contact sensor closed. Open the cover
               ########################################
@@ -3011,25 +3078,6 @@ action:
                 conditions:
                   - "{{ is_cover_shaded }}"
                 sequence:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
                   - service: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -124,11 +124,12 @@ blueprint:
       - Added: Separation of the contact sensors for ventilation and lockout protection
         BREAKING CHANGE: Reconfiguration of lockout protection necessary!
       - Updated: Combining the shading triggers. No more problems with waiting times and retriggers.
-      - Fixed: Do not close after closing the contact if 'Automatic Closing' is disabled
+      - Fixed: Do not drive down the cover after closing the contact if 'Automatic Closing Mode' is disabled
       - Fixed: Missing shading force trigger
+      - Fixed: Prevent trigger with invalid status
 
     2024.05.xx-01:
-      - Fixed: Incorrect position detection during manual movement if ShadingPosition is smaller than ClosedPosition
+      - Fixed: Incorrect position detection during manual movement if shading_position is smaller than close_position
 
     </details>
 
@@ -2025,68 +2026,132 @@ action:
         sequence:
           - delay:
               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+          - choose:
+              # Cover should be shaded
+              - conditions:
+                  - "{{ is_cover_shaded }}"
+                sequence:
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'close':{'a':false,'t':dict_var.close.t},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to shading position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input shading_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input shading_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+                  - choose: []
+                    default: !input auto_shading_start_action
 
-          - if:
-              - "{{ not prevent_default_cover_actions}}"
-            then:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - if:
-                        - "{{ open_position == 100 }}"
-                      then:
-                        - alias: "Moving the cover to open position"
-                          service: cover.open_cover
-                          data: {}
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                      else:
-                        - alias: "Moving the cover to open position"
-                          service: cover.set_cover_position
-                          data:
-                            position: !input open_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Tilt Delay"
-                          delay:
-                            seconds: !input tilt_delay
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
-                          data:
-                            tilt_position: !input open_tilt_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
-                        seconds: "{{ (range(1, 3)|random|int) }}"
+                  - stop: "Stop automation: Shading activated instead opening"
 
-          - choose: []
-            default: !input auto_up_action
+          - choose:
+              # Cover should be opened
+              - conditions:
+                  - "{{ not is_cover_open }}" # TODO: Twice as much
+                sequence:
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'close':{'a':false,'t':dict_var.close.t},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - if:
+                                - "{{ open_position == 100 }}"
+                              then:
+                                - alias: "Moving the cover to open position"
+                                  service: cover.open_cover
+                                  data: {}
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                              else:
+                                - alias: "Moving the cover to open position"
+                                  service: cover.set_cover_position
+                                  data:
+                                    position: !input open_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input open_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_up_action
+
+                  - stop: "Stop automation: Activate opening"
 
           - stop: "Stop automation: Opening"
 
@@ -2173,169 +2238,174 @@ action:
                   - "{{ is_state(resident_sensor, ['true', 'on']) }}"
 
         sequence:
-          # Consider lockout protection
-          - if:
-              - "{{ is_lockout_protection_enabled }}"
-              - "{{ contact_sensor_lockout != [] }}"
-              - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
-            then:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-              - stop: "Stop automation: Lockout-protection"
+          - choose:
+              # Consider lockout protection
+              - conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':false,'t':dict_var.open.t},
+                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+                  - stop: "Stop automation: Lockout-protection"
 
-          - delay:
-              seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+              # Ventilation
+              - conditions:
+                  - "{{ is_ventilation_enabled }}"
+                  - "{{ contact_sensor != [] }}"
+                  - "{{ is_state(contact_sensor, ['true', 'on']) }}"
+                sequence:
+                  - delay:
+                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':false,'t':dict_var.open.t},
+                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
 
-          # Ventilation
-          - if:
-              - "{{ is_ventilation_enabled }}"
-              - "{{ contact_sensor != [] }}"
-              - "{{ is_state(contact_sensor, ['true', 'on']) }}"
-            then:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
-              - if:
-                  - "{{ not prevent_default_cover_actions}}"
-                then:
-                  - repeat:
-                      for_each: "{{ blind_entities|list }}"
-                      sequence:
-                        - alias: "Moving the cover to ventilate position"
-                          service: cover.set_cover_position
-                          data:
-                            position: !input ventilate_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                        - if:
-                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                          then:
-                            - alias: "Tilt Delay"
-                              delay:
-                                seconds: !input tilt_delay
-                            - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
-                              data:
-                                tilt_position: !input ventilate_tilt_position
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                          delay:
-                            seconds: "{{ (range(1, 3)|random|int) }}"
-
-              - choose: []
-                default: !input auto_ventilate_action
-
-              - stop: "Stop automation: Moved to ventilation position during the closing process"
-
-            else:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
-              - if:
-                  - "{{ not prevent_default_cover_actions}}"
-                then:
-                  - repeat:
-                      for_each: "{{ blind_entities|list }}"
-                      sequence:
-                        - if:
-                            - "{{ close_position == 0 }}"
-                          then:
-                            - alias: "Moving the cover to close position"
-                              service: cover.close_cover
-                              data: {}
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                          else:
-                            - alias: "Moving the cover to close position"
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to ventilate position"
                               service: cover.set_cover_position
                               data:
-                                position: !input close_position
+                                position: !input ventilate_position
                               target:
                                 entity_id: "{{ repeat.item }}"
-                        - if:
-                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                          then:
-                            - alias: "Tilt Delay"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input ventilate_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
                               delay:
-                                seconds: !input tilt_delay
-                            - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
-                              data:
-                                tilt_position: !input close_tilt_position
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                          delay:
-                            seconds: "{{ (range(1, 3)|random|int) }}"
+                                seconds: "{{ (range(1, 3)|random|int) }}"
 
-              - choose: []
-                default: !input auto_down_action
+                  - choose: []
+                    default: !input auto_ventilate_action
 
-              - stop: "Stop automation: Moved to closing position"
+                  - stop: "Stop automation: Moved to ventilation position during the closing process"
+
+              # Activate closing
+              - conditions:
+                  - "{{ is_down_enabled }}" # TODO FIXME - better placeholder
+                sequence:
+                  - delay:
+                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':false,'t':dict_var.open.t},
+                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - if:
+                                - "{{ close_position == 0 }}"
+                              then:
+                                - alias: "Moving the cover to close position"
+                                  service: cover.close_cover
+                                  data: {}
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                              else:
+                                - alias: "Moving the cover to close position"
+                                  service: cover.set_cover_position
+                                  data:
+                                    position: !input close_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input close_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_down_action
+
+                  - stop: "Stop automation: Moved to closing position"
 
           - stop: "Stop automation: Closing"
 
       ############################################################
       # ANCHOR: SHADING START
-      # Source: Open (all over shadingPos)
+      # Source: Open (all gt shading_position)
       # Target: Shading, Lockout
       ############################################################
       - alias: "Check for shading start"
@@ -2351,7 +2421,6 @@ action:
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
           - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
-          - "{{ current_position | int(default=101) > shading_position }}"
           - or: # Check the current positions
               - "{{ not is_status_helper_enabled }}"
               - "{{ is_status_helper_enabled and not is_cover_shaded }}"
@@ -2398,90 +2467,118 @@ action:
               - "{{ is_state(resident_sensor, ['false', 'off']) }}"
 
         sequence:
-          # Consider lockout protection
-          - if:
-              - "{{ is_lockout_protection_enabled }}"
-              - "{{ contact_sensor_lockout != [] }}"
-              - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
-            then:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-              - stop: "Stop automation: Lockout-protection while shading start"
+          - choose:
+              # Consider lockout protection
+              - conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':false,'t':dict_var.open.t},
+                              'close':{'a':false,'t':dict_var.close.t},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+                  - stop: "Stop automation: Lockout-protection while shading start"
 
-          - delay:
-              seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+              # Start Shading
+              - conditions:
+                  - "{{ current_position | int(default=101) > shading_position }}"
+                sequence:
+                  - delay:
+                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'close':{'a':false,'t':dict_var.close.t},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'manual':{'a':false,'t':dict_var.manual.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to shading position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input shading_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input shading_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+                  - choose: []
+                    default: !input auto_shading_start_action
 
-          - if:
-              - "{{ not prevent_default_cover_actions}}"
-            then:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - alias: "Moving the cover to shading position"
-                      service: cover.set_cover_position
-                      data:
-                        position: !input shading_position
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Tilt Delay"
-                          delay:
-                            seconds: !input tilt_delay
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
-                          data:
-                            tilt_position: !input shading_tilt_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
-                        seconds: "{{ (range(1, 3)|random|int) }}"
+                  - stop: "Stop automation: Shading activated"
 
-          - choose: []
-            default: !input auto_shading_start_action
+              # Save Shading state
+              - conditions:
+                  - "{{ is_cover_closed }}"
+                sequence:
+                  - if:
+                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
+
+                  - stop: "Stop automation: Shading state saved for the future"
 
           - stop: "Stop automation: Shading-start"
 
@@ -2694,6 +2791,8 @@ action:
           - condition: !input auto_ventilate_condition
           - condition: trigger
             id: "t_ct_vent_open"
+          - "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
+          - "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}"
           - "{{ contact_sensor != [] }}"
           - "{{ is_state(contact_sensor, ['true', 'on']) }}"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
@@ -2767,6 +2866,8 @@ action:
           - "{{ is_status_helper_enabled }}" # Sorry, it is mandatory now!
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
+          - "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
+          - "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}"
           - or:
               - and:
                   - "{{ is_ventilation_enabled }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2139,22 +2139,6 @@ action:
               - "t_bc_6"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
-          # - or: # Optional: Continue if cover is shaded and close position is lower than shading position
-          #     - "{{ not prevent_higher_position_shading_end }}"
-          #     - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
-          #     - "{{ not in_shading_position }}" # Continue if cover is not shaded
-          #     - and:
-          #         - "{{ is_status_helper_enabled }}"
-          #         - "{{ prevent_higher_position_shading_end }}"
-          #         - "{{ is_cover_shaded }}"
-          #         - "{{ close_position < shading_position }}"
-          #     - and: # Always, no further checks for 'is_status_helper_enabled'
-          #         - "{{ prevent_higher_position_shading_end }}"
-          #         - "{{ in_shading_position }}"
-          #         - "{{ close_position < shading_position }}"
-          # - or: # Optional: Continue if close-position is higher than the current position
-          #     - "{{ not prevent_higher_position_closing }}"
-          #     - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
           - or: # Check the current positions
               - "{{ is_status_helper_enabled and not is_cover_closed }}"
               - "{{ in_open_position }}"
@@ -3459,12 +3443,12 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              - conditions: # Manually closed (TODO: Moved to the end of this choose)
+              - conditions: # Manually closed
                   - "{{ is_down_enabled }}"
                   - "{{ not in_shading_position }}"
                   - or:
                       - "{{ in_close_position }}"
-                      - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}" # TODO: This causes problems if shadingPos < closedPos in cover status helper
+                      - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}" # This can cause problems if shadingPos < closedPos in cover status helper
                       - "{{ (current_position | int(default=101) <= close_position) }}"
                       - "{{ (current_position | int(default=101) == 0) }}"
                 sequence:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.05.23-01
+    **Version**: 2024.05.24-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -66,7 +66,7 @@ blueprint:
     <details>
     <summary><strong>Changes in the last days</strong></summary>
 
-    2024.05.23-01:
+    2024.05.24-01:
       - Complete restructuring and logic change for shading, lockout protection and ventilation:
           - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
           - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
@@ -1321,7 +1321,7 @@ blueprint:
               value: "prevent_close_after_lockout"
             - label: "🚫 Prevent the cover from moving to a higher position when it is closed"
               value: "prevent_higher_position_closing"
-            - label: "🚫 Prevent the automation from moving to a higher closing position at the end of sun shading"
+            - label: "🚫 Prevent the cover from moving to a higher closing position at the end of sun shading"
               value: "prevent_higher_position_shading_end"
             - label: "🚫 Prevent the use of the 'get_forecasts' service"
               value: "prevent_forecast_service"
@@ -1439,7 +1439,7 @@ trigger_variables:
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
 
 variables:
-  version: "2024.05.23-01"
+  version: "2024.05.24-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -2139,22 +2139,22 @@ action:
               - "t_bc_6"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
-          - or: # Optional: Continue if cover is shaded and close position is lower than shading position
-              - "{{ not prevent_higher_position_shading_end }}"
-              - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
-              - "{{ not in_shading_position }}" # Continue if cover is not shaded
-              - and:
-                  - "{{ is_status_helper_enabled }}"
-                  - "{{ prevent_higher_position_shading_end }}"
-                  - "{{ is_cover_shaded }}"
-                  - "{{ close_position < shading_position }}"
-              - and: # Always, no further checks for 'is_status_helper_enabled'
-                  - "{{ prevent_higher_position_shading_end }}"
-                  - "{{ in_shading_position }}"
-                  - "{{ close_position < shading_position }}"
-          - or: # Optional: Continue if close-position is higher than the current position
-              - "{{ not prevent_higher_position_closing }}"
-              - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
+          # - or: # Optional: Continue if cover is shaded and close position is lower than shading position
+          #     - "{{ not prevent_higher_position_shading_end }}"
+          #     - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
+          #     - "{{ not in_shading_position }}" # Continue if cover is not shaded
+          #     - and:
+          #         - "{{ is_status_helper_enabled }}"
+          #         - "{{ prevent_higher_position_shading_end }}"
+          #         - "{{ is_cover_shaded }}"
+          #         - "{{ close_position < shading_position }}"
+          #     - and: # Always, no further checks for 'is_status_helper_enabled'
+          #         - "{{ prevent_higher_position_shading_end }}"
+          #         - "{{ in_shading_position }}"
+          #         - "{{ close_position < shading_position }}"
+          # - or: # Optional: Continue if close-position is higher than the current position
+          #     - "{{ not prevent_higher_position_closing }}"
+          #     - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
           - or: # Check the current positions
               - "{{ is_status_helper_enabled and not is_cover_closed }}"
               - "{{ in_open_position }}"
@@ -2295,6 +2295,47 @@ action:
 
                   - choose: []
                     default: !input auto_ventilate_action
+
+              ###########################################
+              # Cover is already near the close position
+              ###########################################
+
+              - alias: "Only status change if cover is already near the close position"
+                conditions:
+                  - or:
+                      - and: # Stop if cover is shaded and close position is lower than shading position
+                          - "{{ is_status_helper_enabled }}"
+                          - "{{ prevent_higher_position_shading_end }}"
+                          - "{{ is_cover_shaded }}"
+                          - "{{ close_position > shading_position }}"
+                      - and: # Stop if cover is shaded and close position is lower than shading position
+                          - "{{ prevent_higher_position_shading_end }}"
+                          - "{{ in_shading_position }}" # Always, no further checks for 'is_status_helper_enabled'
+                          - "{{ close_position > shading_position }}"
+                      - and: # Stop if close-position is higher than the current position
+                          - "{{ prevent_higher_position_closing }}"
+                          - "{{ (current_position | int(default=101) <= close_position) }}"
+                sequence:
+                  - if:
+                      - "{{ is_status_helper_enabled }}"
+                    then:
+                      - service: input_text.set_value
+                        data:
+                          entity_id: !input cover_status_helper # Manual not set here! Keep old value
+                          value: |
+                            {% set dict_var = states(cover_status_helper) | from_json %}
+                            {% set dict_new = dict(dict_var, **{
+                              'open':{'a':false,'t':dict_var.open.t},
+                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                              'shading':{'a':false,'t':dict_var.shading.t},
+                              'locked':{'a':false,'t':dict_var.locked.t},
+                              'p':current_position,
+                              'v':4,
+                              't':as_timestamp(now()) | round(0)
+                              })
+                            %}
+                            {{ dict_new | to_json }}
 
             ###################################
             # Normal closing of the cover
@@ -3344,32 +3385,6 @@ action:
 
         sequence:
           - choose:
-              - conditions: # Defined positions can be assigned
-                  - not:
-                      - "{{ is_up_enabled and in_open_position }}"
-                      - "{{ is_down_enabled and in_close_position }}"
-                      - "{{ is_ventilation_enabled and in_ventilate_position }}"
-                      - "{{ is_shading_enabled and in_shading_position }}"
-                sequence:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
               - conditions: # Manually opened
                   - "{{ is_up_enabled }}"
                   - or:
@@ -3446,6 +3461,7 @@ action:
 
               - conditions: # Manually closed (TODO: Moved to the end of this choose)
                   - "{{ is_down_enabled }}"
+                  - "{{ not in_shading_position }}"
                   - or:
                       - "{{ in_close_position }}"
                       - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}" # TODO: This causes problems if shadingPos < closedPos in cover status helper
@@ -3460,6 +3476,32 @@ action:
                         {% set dict_new = dict(dict_var, **{
                           'open':{'a':false,'t':dict_var.open.t},
                           'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - conditions: # Defined positions can be assigned
+                  - not:
+                      - "{{ is_up_enabled and in_open_position }}"
+                      - "{{ is_down_enabled and in_close_position }}"
+                      - "{{ is_ventilation_enabled and in_ventilate_position }}"
+                      - "{{ is_shading_enabled and in_shading_position }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':false,'t':dict_var.close.t},
                           'ventilate':{'a':false,'t':dict_var.ventilate.t},
                           'shading':{'a':false,'t':dict_var.shading.t},
                           'locked':{'a':false,'t':dict_var.locked.t},

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -123,7 +123,7 @@ blueprint:
     2024.05.17-01:
       - Updated: Combining the shading triggers. No more problems with waiting times and retriggers.
       - Fixed: Do not close after closing the contact if 'Automatic Closing' is disabled
-      - Added: Separate contact Sensors
+      - Added: Separate contact sensors
 
     </details>
 
@@ -1941,6 +1941,8 @@ action:
   - choose:
       ############################################################
       # ANCHOR: OPEN
+      # Source: All
+      # Target: Open
       ############################################################
       - alias: "Check for opening"
         conditions:
@@ -2072,6 +2074,8 @@ action:
 
       ############################################################
       # ANCHOR: CLOSE
+      # Source: Open, Close, Ventilation, Shading
+      # Target: Close
       ############################################################
       - alias: "Check for closing cover"
         conditions:
@@ -2227,7 +2231,7 @@ action:
                         {% set dict_var = states(cover_status_helper) | from_json %}
                         {% set dict_new = dict(dict_var, **{
                           'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':false,'t':dict_var.close.t},
+                          'close':{'a':true,'t':dict_var.close.t},
                           'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'shading':{'a':false,'t':dict_var.shading.t},
                           'locked':{'a':false,'t':dict_var.locked.t},
@@ -2313,6 +2317,8 @@ action:
 
       ############################################################
       # ANCHOR: SHADING START
+      # Source: Open (all over shadingPos)
+      # Target: Shading Start
       ############################################################
       - alias: "Check for shading start"
         conditions:
@@ -2332,7 +2338,6 @@ action:
               - "{{ not is_status_helper_enabled }}"
               - "{{ is_status_helper_enabled and not is_cover_shaded }}"
               - "{{ is_status_helper_enabled and not (is_cover_ventilated or is_cover_locked) }}"
-              # - "{{ not in_ventilate_position }}" # TODO: With the OR condition, this means ALWAYS. Bad idea. Disabled.
           - or: # Ignore check
               - "{{ not is_status_helper_enabled }}"
               - "{{ is_status_helper_enabled and not is_cover_manual }}"
@@ -2464,6 +2469,8 @@ action:
 
       ############################################################
       # ANCHOR: SHADING END
+      # Source: Shading Start
+      # Target: Open, Ventilation, Lockout
       ############################################################
       - alias: "Check for shading end" # TODO: No forecast sensor trigger atm
         conditions:
@@ -2631,6 +2638,8 @@ action:
 
       ############################################################
       # ANCHOR: CONTACT OPEN
+      # Source: Shading, Close
+      # Target: Ventilation
       ############################################################
       - alias: "Contact sensor opened"
         conditions:
@@ -2641,11 +2650,13 @@ action:
           - "{{ contact_sensor != [] }}"
           - "{{ is_state(contact_sensor, ['true', 'on']) }}"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
-          - or:
+          - or: # Source: Close
               - "{{ is_status_helper_enabled and is_cover_closed }}"
-              - "{{ in_close_position }}" # always
+              - "{{ in_close_position }}" # Always and independently of the helper
               - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
-
+          - or: # Source: Shading
+              - "{{ is_status_helper_enabled and is_cover_shaded }}"
+              - "{{ in_shading_position }}" # Always and independently of the helper
         sequence:
           - if:
               - "{{ not prevent_default_cover_actions}}"
@@ -2684,12 +2695,7 @@ action:
                   value: |
                     {% set dict_var = states(cover_status_helper) | from_json %}
                     {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
                       'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
                       'p':current_position,
                       'v':4,
                       't':as_timestamp(now()) | round(0)
@@ -2704,6 +2710,8 @@ action:
 
       ############################################################
       # ANCHOR: CONTACT CLOSED
+      # Source: Ventilation
+      # Target: Open, Close, Shading
       ############################################################
       - alias: "Contact sensor closed / Closing after ventilation and after lockout-protection"
         conditions:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.05.17-01
+    **Version**: 2024.05.xx-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
@@ -120,10 +120,15 @@ blueprint:
       - Quick workaround, as opening and closing does not currently work.
       - Minor changes
 
-    2024.05.17-01:
+    2024.05.22-01:
+      - Added: Separation of the contact sensors for ventilation and lockout protection
+        BREAKING CHANGE: Reconfiguration of lockout protection necessary!
       - Updated: Combining the shading triggers. No more problems with waiting times and retriggers.
       - Fixed: Do not close after closing the contact if 'Automatic Closing' is disabled
-      - Added: Separate contact sensors
+      - Fixed: Missing shading force trigger
+
+    2024.05.xx-01:
+      - Fixed: Incorrect position detection during manual movement if ShadingPosition is smaller than ClosedPosition
 
     </details>
 
@@ -174,7 +179,7 @@ blueprint:
         For example, the brightness control only works if a brightness sensor is also specified.
 
 
-        **Note:** If you want to use the <ins>lockout protection</ins>, I recommend configuring a cover status helper.
+        **Note:** If you want to use <ins>ventilation</ins> or the <ins>lockout protection</ins>, you have to configure a <ins>Cover Status Helper</ins>!
         Otherwise, the cover cannot be moved to the next state after the door contact is closed.
         See further information in the description of "Contact Sensor Entity"
 
@@ -292,6 +297,13 @@ blueprint:
         Regardless of which option is selected here, the position detection is based on this attribute.
         The <em>current_tilt_position</em> attribute is <ins>not</ins> taken into account.
 
+        <p>
+          <strong>
+          I strongly recommend using the Cover Status Helper!<br />
+          The full range of functions is only available if this is configured.
+          </strong>
+        </p>
+
         <details>
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
@@ -304,7 +316,7 @@ blueprint:
         Only basic features are available with this setting.
 
 
-        - <ins>Use an external cover status helper</ins><br />
+        - <ins>Use an external Cover Status Helper</ins><br />
         If you want to be able to do manual overrides and have the automation do the next movement as usual,
         then a helper is necessary. Without a helper, the manual override would always be overwritten by the automation.
         This has the advantage that the cover does not necessarily have to be in a defined position.
@@ -318,7 +330,7 @@ blueprint:
           options:
             - label: "#️⃣ Check the current position"
               value: "cover_helper_disabled"
-            - label: "🦮 Use an external cover status helper"
+            - label: "🦮 Use an external Cover Status Helper"
               value: "cover_helper_enabled"
 
     cover_status_helper:
@@ -915,9 +927,9 @@ blueprint:
         <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
-          - <ins>Enable delay in ventilation mode:</ins>
+          - <ins>Enable delay after contacts are closed:</ins>
             <br />
-            Normally, when the window contact is opened, there is no delay in the upcoming movements. If you do want this, you can activate it here.
+            Normally, when the window contact is closed, there is no delay in the upcoming movements. If you do want this, you can activate it here.
             <br /><br />
             The "Fixed Drive Delay" and "Random Drive Delay" settings which are already used everywhere are then used.
             <br /><br />
@@ -1298,7 +1310,7 @@ blueprint:
         conscious decision is weighted higher than the upcoming action of the automation.
 
 
-        As soon as a cover has been moved manually, the status is recorded in the cover status helper.
+        As soon as a cover has been moved manually, the status is recorded in the Cover Status Helper.
         This usually means that a person has deliberately decided against a status.
 
           - If option is not activated: The covers are moved even if a manual correction has been made.
@@ -1466,7 +1478,7 @@ trigger_variables:
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
 
 variables:
-  version: "2024.05.17-01"
+  version: "2024.05.xx-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1824,6 +1836,12 @@ trigger:
       seconds: !input shading_waitingtime_start
     id: "t_si_1"
 
+  - platform: state
+    entity_id: !input auto_shading_start_force
+    from: "off"
+    to: "on"
+    id: "t_si_force"
+
   ########################################
   # Triggers for shading end
   ########################################
@@ -1941,8 +1959,8 @@ action:
   - choose:
       ############################################################
       # ANCHOR: OPEN
-      # Source: All
-      # Target: Open
+      # Source: All (Open, Close, Ventilation, Shading)
+      # Target: Open, Shading
       ############################################################
       - alias: "Check for opening"
         conditions:
@@ -2009,6 +2027,28 @@ action:
               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
           - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'close':{'a':false,'t':dict_var.close.t},
+                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                      'shading':{'a':false,'t':dict_var.shading.t},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
+          - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
               - repeat:
@@ -2045,28 +2085,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_up_action
 
@@ -2074,8 +2092,8 @@ action:
 
       ############################################################
       # ANCHOR: CLOSE
-      # Source: Open, Close, Ventilation, Shading
-      # Target: Close
+      # Source: All (Open, Close, Ventilation, Shading)
+      # Target: Close, Lockout, Ventilation
       ############################################################
       - alias: "Check for closing cover"
         conditions:
@@ -2194,6 +2212,28 @@ action:
               - "{{ is_state(contact_sensor, ['true', 'on']) }}"
             then:
               - if:
+                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - if:
                   - "{{ not prevent_default_cover_actions}}"
                 then:
                   - repeat:
@@ -2221,6 +2261,12 @@ action:
                           delay:
                             seconds: "{{ (range(1, 3)|random|int) }}"
 
+              - choose: []
+                default: !input auto_ventilate_action
+
+              - stop: "Stop automation: Moved to ventilation position during the closing process"
+
+            else:
               - if:
                   - "{{ 'cover_helper_enabled' in cover_status_options }}"
                 then:
@@ -2231,8 +2277,8 @@ action:
                         {% set dict_var = states(cover_status_helper) | from_json %}
                         {% set dict_new = dict(dict_var, **{
                           'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':true,'t':dict_var.close.t},
-                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
                           'shading':{'a':false,'t':dict_var.shading.t},
                           'locked':{'a':false,'t':dict_var.locked.t},
                           'manual':{'a':false,'t':dict_var.manual.t},
@@ -2243,12 +2289,6 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              - choose: []
-                default: !input auto_ventilate_action
-
-              - stop: "Stop automation: Moved to ventilation position during the closing process"
-
-            else:
               - if:
                   - "{{ not prevent_default_cover_actions}}"
                 then:
@@ -2286,28 +2326,6 @@ action:
                           delay:
                             seconds: "{{ (range(1, 3)|random|int) }}"
 
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
               - choose: []
                 default: !input auto_down_action
 
@@ -2318,7 +2336,7 @@ action:
       ############################################################
       # ANCHOR: SHADING START
       # Source: Open (all over shadingPos)
-      # Target: Shading Start
+      # Target: Shading, Lockout
       ############################################################
       - alias: "Check for shading start"
         conditions:
@@ -2398,7 +2416,7 @@ action:
                           'open':{'a':false,'t':dict_var.open.t},
                           'close':{'a':false,'t':dict_var.close.t},
                           'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'manual':{'a':false,'t':dict_var.manual.t},
                           'p':current_position,
@@ -2411,6 +2429,28 @@ action:
 
           - delay:
               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
+          - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':false,'t':dict_var.open.t},
+                      'close':{'a':false,'t':dict_var.close.t},
+                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
 
           - if:
               - "{{ not prevent_default_cover_actions}}"
@@ -2440,28 +2480,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_shading_start_action
 
@@ -2469,7 +2487,7 @@ action:
 
       ############################################################
       # ANCHOR: SHADING END
-      # Source: Shading Start
+      # Source: Shading
       # Target: Open, Ventilation, Lockout
       ############################################################
       - alias: "Check for shading end" # TODO: No forecast sensor trigger atm
@@ -2508,6 +2526,35 @@ action:
                       - "{{ not in_close_position }}"
 
         sequence:
+          # Consider lockout protection
+          - if:
+              - "{{ is_lockout_protection_enabled }}"
+              - "{{ contact_sensor_lockout != [] }}"
+              - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+            then:
+              - if:
+                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+              - stop: "Stop automation: Lockout-protection while shading end"
+
           # Ventilation after shading end
           - if:
               - "{{ is_ventilation_enabled }}"
@@ -2518,6 +2565,28 @@ action:
                   - "{{ contact_sensor_lockout == [] }}"
                   - "{{ is_state(contact_sensor_lockout, ['false', 'off']) }}"
             then:
+              - if:
+                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
               - if:
                   - "{{ not prevent_default_cover_actions}}"
                 then:
@@ -2546,6 +2615,10 @@ action:
                           delay:
                             seconds: "{{ (range(1, 3)|random|int) }}"
 
+              - choose: []
+                default: !input auto_ventilate_action
+
+            else:
               - if:
                   - "{{ 'cover_helper_enabled' in cover_status_options }}"
                 then:
@@ -2555,9 +2628,9 @@ action:
                       value: |
                         {% set dict_var = states(cover_status_helper) | from_json %}
                         {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
                           'shading':{'a':false,'t':dict_var.shading.t},
                           'locked':{'a':false,'t':dict_var.locked.t},
                           'manual':{'a':false,'t':dict_var.manual.t},
@@ -2568,10 +2641,6 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              - choose: []
-                default: !input auto_ventilate_action
-
-            else:
               - if:
                   - "{{ not prevent_default_cover_actions}}"
                 then:
@@ -2609,28 +2678,6 @@ action:
                           delay:
                             seconds: "{{ (range(1, 3)|random|int) }}"
 
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
               - choose: []
                 default: !input auto_shading_end_action
 
@@ -2650,14 +2697,32 @@ action:
           - "{{ contact_sensor != [] }}"
           - "{{ is_state(contact_sensor, ['true', 'on']) }}"
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
-          - or: # Source: Close
-              - "{{ is_status_helper_enabled and is_cover_closed }}"
-              - "{{ in_close_position }}" # Always and independently of the helper
-              - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
-          - or: # Source: Shading
-              - "{{ is_status_helper_enabled and is_cover_shaded }}"
-              - "{{ in_shading_position }}" # Always and independently of the helper
+          - or:
+              - or: # Source: Close
+                  - "{{ is_status_helper_enabled and is_cover_closed }}"
+                  - "{{ in_close_position }}" # Always and independently of the helper
+                  - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
+              - or: # Source: Shading
+                  - "{{ is_status_helper_enabled and is_cover_shaded }}"
+                  - "{{ in_shading_position }}" # Always and independently of the helper
         sequence:
+          - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
           - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
@@ -2686,23 +2751,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_ventilate_action
 
@@ -2710,12 +2758,13 @@ action:
 
       ############################################################
       # ANCHOR: CONTACT CLOSED
-      # Source: Ventilation
+      # Source: Ventilation, Lockout
       # Target: Open, Close, Shading
       ############################################################
-      - alias: "Contact sensor closed / Closing after ventilation and after lockout-protection"
+      - alias: "Contact sensor closed"
         conditions:
           - "{{ is_down_enabled }}" # Only close if it is allowed
+          - "{{ is_status_helper_enabled }}" # Sorry, it is mandatory now!
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - or:
@@ -2726,112 +2775,242 @@ action:
                   - "{{ contact_sensor != [] }}"
                   - "{{ is_state(contact_sensor, ['false', 'off']) }}"
                   - or:
-                      - "{{ is_status_helper_enabled and is_cover_ventilated }}" # Status check
+                      - "{{ is_cover_ventilated }}" # Status check
                       - "{{ in_ventilate_position }}" # Position check
                   - or: # Ignore check
-                      - "{{ not is_status_helper_enabled }}"
-                      - "{{ is_status_helper_enabled and not is_cover_manual }}"
-                      - "{{ is_status_helper_enabled and ignore_ventilation_after_manual }}"
-                      - "{{ is_status_helper_enabled and is_cover_manual and not ignore_ventilation_after_manual }}"
+                      - "{{ not is_cover_manual }}"
+                      - "{{ ignore_ventilation_after_manual }}"
+                      - "{{ is_cover_manual and not ignore_ventilation_after_manual }}"
               - and:
                   - "{{ is_lockout_protection_enabled and not prevent_close_after_lockout }}"
                   - condition: trigger
                     id: "t_ct_lock_close"
                   - "{{ contact_sensor_lockout != [] }}"
                   - "{{ is_state(contact_sensor_lockout, ['false', 'off']) }}"
-                  - "{{ is_status_helper_enabled and is_cover_locked }}" # Status check
-          - or:
-              - and: # OPEN/CLOSE - Whenever the scheduler is off
-                  - "{{ is_schedule_helper_enabled }}"
-                  - "{{ time_schedule_helper != [] }}"
-                  - "{{ is_state(time_schedule_helper, 'off') }}"
-              - and: # <OPEN - Always before the earliest possible time
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() <= today_at(time_up_early_today) }}"
-              - and: # >CLOSE - Always after the latest time
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() >= today_at(time_down_late_today) }}"
-              - and: # <OPEN - Between the time intervals only if the brightness/sun-elevation is still too low.
-                  - or:
-                      - and:
-                          - "{{ is_time_field_enabled }}"
-                          - "{{ now() >= today_at(time_up_early_today) }}"
-                          - "{{ now() <= today_at(time_up_late_today) }}"
-                      - and:
-                          - "{{ is_schedule_helper_enabled }}"
-                          - "{{ time_schedule_helper != [] }}"
-                          - "{{ is_state(time_schedule_helper, 'on') }}"
-                  - or:
-                      - or:
-                          - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_up) < brightness_up) }}"
-                      - or:
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_up) < sun_elevation_up) }}"
-              - and: # >CLOSE - Between the time intervals only if the brightness/sun-elevation has already fallen.
-                  - or:
-                      - and:
-                          - "{{ is_time_field_enabled }}"
-                          - "{{ now() >= today_at(time_down_early_today) }}"
-                          - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
-                      - and:
-                          - "{{ is_schedule_helper_enabled }}"
-                          - "{{ time_schedule_helper != [] }}"
-                          - "{{ is_state(time_schedule_helper, 'on') }}"
-                  - or:
-                      - or:
-                          - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) }}"
-                      - or:
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) < sun_elevation_down) }}"
+                  - "{{ is_cover_locked }}" # Status check
 
         sequence:
           - if:
-              - condition: trigger
-                id: "t_ct_vent_close"
               - "{{ ventilation_delay_enabled }}"
             then:
               - delay:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-          - if:
-              - "{{ not prevent_default_cover_actions}}"
-            then:
-              - repeat:
-                  for_each: "{{ blind_entities|list }}"
-                  sequence:
-                    - if:
-                        - "{{ close_position == 0 }}"
-                      then:
-                        - alias: "Moving the cover to close position"
-                          service: cover.close_cover
-                          data: {}
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                      else:
-                        - alias: "Moving the cover to close position"
-                          service: cover.set_cover_position
-                          data:
-                            position: !input close_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - if:
-                        - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                      then:
-                        - alias: "Tilt Delay"
-                          delay:
-                            seconds: !input tilt_delay
-                        - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
-                          data:
-                            tilt_position: !input close_tilt_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
-                        seconds: "{{ (range(1, 3)|random|int) }}"
+          - choose:
+              # Contact closed > Opening
+              - conditions:
+                  - "{{ is_cover_open }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - if:
+                                - "{{ open_position == 100 }}"
+                              then:
+                                - alias: "Moving the cover to open position"
+                                  service: cover.open_cover
+                                  data: {}
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                              else:
+                                - alias: "Moving the cover to open position"
+                                  service: cover.set_cover_position
+                                  data:
+                                    position: !input open_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input open_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
 
+                  - choose: []
+                    default: !input auto_up_action
+
+                  - stop: "Stop automation: Opening after ventilation or after lockout-protection"
+
+              # Contact closed > Closing
+              - conditions:
+                  - "{{ is_cover_closed }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - if:
+                                - "{{ close_position == 0 }}"
+                              then:
+                                - alias: "Moving the cover to close position"
+                                  service: cover.close_cover
+                                  data: {}
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                              else:
+                                - alias: "Moving the cover to close position"
+                                  service: cover.set_cover_position
+                                  data:
+                                    position: !input close_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input close_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_down_action
+
+                  - stop: "Stop automation: Closing after ventilation or after lockout-protection"
+
+              # Contact closed > Shading
+              - conditions:
+                  - "{{ is_cover_shaded }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to shading position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input shading_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input shading_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
+                              delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_shading_start_action
+
+                  - stop: "Stop automation: Shading-start after ventilation or after lockout-protection"
+
+          - stop: "Stop automation: Contact closed"
+
+      ############################################################
+      # ANCHOR: FORCE OPEN
+      ############################################################
+      - alias: "Forced opening of the cover"
+        conditions:
+          - condition: trigger
+            id: "t_bo_force"
+          - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
+        sequence:
           - if:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
             then:
@@ -2841,8 +3020,8 @@ action:
                   value: |
                     {% set dict_var = states(cover_status_helper) | from_json %}
                     {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'close':{'a':false,'t':dict_var.close.t},
                       'ventilate':{'a':false,'t':dict_var.ventilate.t},
                       'shading':{'a':false,'t':dict_var.shading.t},
                       'locked':{'a':false,'t':dict_var.locked.t},
@@ -2854,20 +3033,6 @@ action:
                     %}
                     {{ dict_new | to_json }}
 
-          - choose: []
-            default: !input auto_down_action
-
-          - stop: "Stop automation: Closing after ventilation and after lockout-protection"
-
-      ############################################################
-      # ANCHOR: FORCE OPEN
-      ############################################################
-      - alias: "Forced opening of the cover"
-        conditions:
-          - condition: trigger
-            id: "t_bo_force"
-          - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
-        sequence:
           - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
@@ -2905,28 +3070,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_up_action
 
@@ -2941,6 +3084,28 @@ action:
             id: "t_bc_force"
           - "{{ auto_down_force != [] and is_state(auto_down_force, ['true', 'on']) }}"
         sequence:
+          - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':false,'t':dict_var.open.t},
+                      'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                      'shading':{'a':false,'t':dict_var.shading.t},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
           - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
@@ -2978,28 +3143,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_down_action
 
@@ -3014,6 +3157,28 @@ action:
             id: "t_ve_force"
           - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
         sequence:
+          - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':false,'t':dict_var.open.t},
+                      'close':{'a':false,'t':dict_var.close.t},
+                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'shading':{'a':false,'t':dict_var.shading.t},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
           - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
@@ -3042,28 +3207,6 @@ action:
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
-
           - choose: []
             default: !input auto_ventilate_action
 
@@ -3078,6 +3221,28 @@ action:
             id: "t_si_force"
           - "{{ auto_shading_start_force != [] and is_state(auto_shading_start_force, ['true', 'on']) }}"
         sequence:
+          - if:
+              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            then:
+              - service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':false,'t':dict_var.open.t},
+                      'close':{'a':false,'t':dict_var.close.t},
+                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
           - if:
               - "{{ not prevent_default_cover_actions}}"
             then:
@@ -3105,28 +3270,6 @@ action:
                     - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
                       delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
-
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
 
           - choose: []
             default: !input auto_shading_start_action
@@ -3203,33 +3346,6 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              - conditions: # Manually closed
-                  - "{{ is_down_enabled }}"
-                  - or:
-                      - "{{ in_close_position }}"
-                      - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}"
-                      - "{{ (current_position | int(default=101) <= close_position) }}"
-                      - "{{ (current_position | int(default=101) == 0) }}"
-                sequence:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':false,'t':dict_var.open.t},
-                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':false,'t':dict_var.locked.t},
-                          'manual':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-
               - conditions: # Manually ventilated
                   - "{{ is_ventilation_enabled }}"
                   - "{{ in_ventilate_position }}"
@@ -3268,6 +3384,33 @@ action:
                           'close':{'a':false,'t':dict_var.close.t},
                           'ventilate':{'a':false,'t':dict_var.ventilate.t},
                           'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - conditions: # Manually closed (TODO: Moved to the end of this choose)
+                  - "{{ is_down_enabled }}"
+                  - or:
+                      - "{{ in_close_position }}"
+                      - "{{ (current_position | int(default=101) < shading_position) and (current_position | int(default=101) < ventilate_position) }}" # TODO: This causes problems if shadingPos < closedPos in cover status helper
+                      - "{{ (current_position | int(default=101) <= close_position) }}"
+                      - "{{ (current_position | int(default=101) == 0) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
                           'locked':{'a':false,'t':dict_var.locked.t},
                           'manual':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'p':current_position,

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,11 +4,13 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.05.xx-01
+    **Version**: 2024.05.23-01
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539)
     **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml)
     **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
     **Full Changelog**: [CHANGELOG.md](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/CHANGELOG.md)
+
+    **If you would like to support me or say thank you, please click here:** 🙏 [Click Here](https://www.paypal.com/donate/?hosted_button_id=NQE5MFJXAA8BQ) 🙏
 
     <details>
     <summary><strong>Features</strong></summary>
@@ -37,17 +39,6 @@ blueprint:
     </details>
 
     <details>
-    <summary><strong>Condition examples</strong></summary>
-
-    - If, for example, your blinds on the upper floor only close automatically and are not opened via the automation, you can also enable the blinds to be opened during this time by activating a vacation mode boolean.
-    - If you have visitors or a party, you may not want the blinds to close. This can be easily configured using a party mode boolean.
-    - If, for any reason, you want to pause the activation of sun shading or the ending of shading, this can be controlled via a shading boolean.
-    - If you want to suspend the entire roller blind control for a short time, perhaps because maintenance work or window cleaning is being carried out, this is possible with just one boolean.
-    - Are the roller blinds on side doors normally only opened by the automation system and never closed because you don't want to lock yourself out? But on vacation, the blinds should still be closed. This is how the conditions work.
-
-    </details>
-
-    <details>
     <summary><strong>Important notes</strong></summary>
 
     - It is <ins>not</ins> possible to execute this automation manually!
@@ -70,55 +61,29 @@ blueprint:
       In rare cases, this may mean that the first trigger does not move the blinds. This may take care of itself with the next trigger later.
       Alternatively, the roller blinds must be moved shortly once so that the automation system knows what the current status is.
 
-    *This was originally a fork of Eimeel's blueprint [automatic_blinds_shading.yaml](https://gist.github.com/jmerifjKriwe/bffbc7424dd04f4a31d6a71f7012cd1f) and is largely based on his programming.*
-    Note: My blueprint is not compatible with Eimeel's variant. I have used his basis, but the variables are completely different from his design.<br />
-
     </details>
 
     <details>
-    <summary><strong>Latest changes</strong></summary>
+    <summary><strong>Changes in the last days</strong></summary>
 
-    2024.03.21-01:
-      - **Breaking change** in the schedule helper usage! You can find the details in the section "Selection of time control options".
-      - New: Reduction of triggers and thus avoidance of overlaps due to running delays (fixes #40)
-      - New: Added possibility to disable the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions
-      - Fixed: Shading Forecast Weather Conditions
-      - Fixed: Ventilation mode should not only be ended in the evening, but whenever it is not yet daytime.
-      - Fixed: Added the ventilation mode activation on closing down again
-      - Try to avoid overlaps in the execution of the automation if several triggers are triggered shortly after each other.
-      - Fixed: Optional weather conditions for "shading in" #41
+    2024.05.23-01:
+      - Complete restructuring and logic change for shading, lockout protection and ventilation:
+          - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
+          - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
+          - If the cover is closed and the corresponding contact is opened, the ventilation position is activated.
+          - When the sun shading is activated, the lockout protection is taken into account if the contact is open. If the contact is closed, the cover moves back to the shading position.
+          - When the sun shading is stopped, the lockout protection is checked. It is also possible to move to the ventilation position when the contact is open. If the contact is closed here, the cover is opened.
 
-    2024.04.05-01:
-      - Update: Forecast Temperature below 0 possible
-      - Delay lines minimally changed
-      - Added: Allow shading to activate multiple times a day #44
-      - Fixed: Ventilation is usually activated too often.
-
-    2024.04.08-01:
-      - Fixed: Make the shading work even without a helper
-
-    2024.05.01-01:
-      - Updated: Trigger shading at time_up_early and schedule helper state change, too
-      - Fixed: Possibility to ignore actions after manual position changes
-      - Added Feature: Force activation of sun shading #49
-      - Fixed: Manual shutter movements after a core restart were not always recognised.
-
-    2024.05.03-01:
-      - Minor editorial changes
-
-    2024.05.15-01:
-      - Fixed: Do not recognise manual movement if status is unknown
-      - Updated: Change the step size for the brightness values to 1
-      - Fixed: Made the force function easier with fewer conditions
-      - Added: Make it possible to open and close the roller blinds multiple times
-      - Added: The forecast sensor can now trigger the sun shading #48
-      - Added: Delay between set_cover_position and set_cover_tilt_position.
-      - Added: Lockout protection implemented at the start and end of shading. #43/#55 (Attention: Cover may close in the evening after contact is closed again!)
-      - Fixed: Retriggering of the shading is possible again. Open/close branches are only started if automation is not already running.
-
-    2024.05.15-02:
-      - Quick workaround, as opening and closing does not currently work.
-      - Minor changes
+          <ins>Summary:</ins> CCA saves the temporary status (ventilation, lockout protection and shading) and the actual target status in the Cover Status Helper.
+          - This means that the cover is simply opened or closed as before.
+          - And it does <ins>not</ins> always return to the previous state (which may have changed in the meantime).
+          - Instead, it switches to the state that should actually be current.
+      - Fixed: Incorrect position detection during manual drives if shading_position is smaller than close_position
+      - Added: Shading activation before opening. The cover can now move into the shading during the opening process. #4
+      - Added: Prevent automatic closing due to the resident sensor #63
+      - <strong>BREAKING CHANGES:</strong>
+          - Cover Status Helper is now mandatory for ventilation, lockout protection and shading!
+          - Invert the status of some options #61 ("Prevent the cover from being ... several times a day" instead of "Allow the cover to be ... several times a day")
 
     2024.05.22-01:
       - Added: Separation of the contact sensors for ventilation and lockout protection
@@ -127,9 +92,6 @@ blueprint:
       - Fixed: Do not drive down the cover after closing the contact if 'Automatic Closing Mode' is disabled
       - Fixed: Missing shading force trigger
       - Fixed: Prevent trigger with invalid status
-
-    2024.05.xx-01:
-      - Fixed: Incorrect position detection during manual movement if shading_position is smaller than close_position
 
     </details>
 
@@ -168,6 +130,11 @@ blueprint:
       description: >-
         This <ins>basically</ins> determines whether the cover is allowed to open or close.
 
+
+        <strong>Important note:</strong>
+        The configuration of the Cover Status Helper is <ins>mandatory</ins> if you want to use the lockout protection, ventilation mode or shading.
+
+
         <details>
         <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
 
@@ -178,11 +145,6 @@ blueprint:
 
         **Please ensure that the corresponding sensors are also specified.**
         For example, the brightness control only works if a brightness sensor is also specified.
-
-
-        **Note:** If you want to use <ins>ventilation</ins> or the <ins>lockout protection</ins>, you have to configure a <ins>Cover Status Helper</ins>!
-        Otherwise, the cover cannot be moved to the next state after the door contact is closed.
-        See further information in the description of "Contact Sensor Entity"
 
         </details>
       default:
@@ -214,6 +176,58 @@ blueprint:
           custom_value: false
           mode: list
 
+    cover_status_options:
+      name: "🦮 Status detection of the cover"
+      description: >
+        It is essential that the roller blind has the <em>current_position</em> attribute.
+        Regardless of which option is selected here, the position detection is based on this attribute.
+        The <em>current_tilt_position</em> attribute is <ins>not</ins> taken into account.
+
+
+        <strong>Important note:</strong>
+        I strongly recommend using the Cover Status Helper! The full range of functions is only available if this is configured.
+
+
+        <details>
+        <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
+
+
+        - <ins>Check the current position</ins><br />
+        The automation only moves the cover if it is positioned at one of the defined positions (ventilate position, shading position, open position or closed position). Otherwise, the cover has been moved manually.
+        After a manual drive, it is unclear what is intended to be achieved, so the automation no longer takes action.
+        To automate the drive of the cover again, it must be moved to one of the defined positions beforehand.
+        The advantage of this is that you don't have to create a helper in Home Assistant.
+        Only basic features are available with this setting.
+
+
+        - <ins>Use an external Cover Status Helper</ins><br />
+        If you want to be able to do manual overrides and have the automation do the next drive as usual,
+        then a helper is necessary. Without a helper, the manual override would always be overwritten by the automation.
+        This has the advantage that the cover does not necessarily have to be in a defined position.
+        With this choice, advanced functions are possible and you can always rely on the automation.
+
+
+        </details>
+      default: cover_helper_disabled
+      selector:
+        select:
+          options:
+            - label: "#️⃣ Check the current position"
+              value: "cover_helper_disabled"
+            - label: "🦮 Use an external Cover Status Helper"
+              value: "cover_helper_enabled"
+
+    cover_status_helper:
+      name: "🦮 Cover Status Helper"
+      description: >-
+        Helper used to store the last cover event.
+        *Attention:* You will need to manually create a [input_text](https://my.home-assistant.io/redirect/helpers/) entity with a <ins>length of 254 chars</ins> for this.
+        <br /><br />`Optional`
+      default: []
+      selector:
+        entity:
+          domain: input_text
+
     time_control:
       name: "⏲️ Selection of time control options"
       description: >-
@@ -240,10 +254,7 @@ blueprint:
             The cover is opened when the threshold is exceeded and the helper is on.
             The cover is closed when the threshold is undershot and the helper is off.
 
-        </details>
-        <br />
-        <details>
-        <summary><code><strong>CLICK HERE:</strong> Important information on using the schedule helper</code></summary>
+        <strong>Important information on using the schedule helper</strong>
 
 
         It is not possible to find out more about the status of the schedule helper in Home Assistant.
@@ -291,62 +302,8 @@ blueprint:
                 - schedule
           multiple: false
 
-    cover_status_options:
-      name: "🦮 Status detection of the cover"
-      description: >
-        It is essential that the roller blind has the <em>current_position</em> attribute.
-        Regardless of which option is selected here, the position detection is based on this attribute.
-        The <em>current_tilt_position</em> attribute is <ins>not</ins> taken into account.
-
-        <p>
-          <strong>
-          I strongly recommend using the Cover Status Helper!<br />
-          The full range of functions is only available if this is configured.
-          </strong>
-        </p>
-
-        <details>
-        <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
-
-
-        - <ins>Check the current position</ins><br />
-        The automation only moves the cover if it is positioned at one of the defined positions (ventilate position, shading position, open position or closed position). Otherwise, the cover has been moved manually.
-        After a manual movement, it is unclear what is intended to be achieved, so the automation no longer takes action.
-        To automate the movement of the cover again, it must be moved to one of the defined positions beforehand.
-        The advantage of this is that you don't have to create a helper in Home Assistant.
-        Only basic features are available with this setting.
-
-
-        - <ins>Use an external Cover Status Helper</ins><br />
-        If you want to be able to do manual overrides and have the automation do the next movement as usual,
-        then a helper is necessary. Without a helper, the manual override would always be overwritten by the automation.
-        This has the advantage that the cover does not necessarily have to be in a defined position.
-        With this choice, advanced functions are possible and you can always rely on the automation.
-
-
-        </details>
-      default: cover_helper_disabled
-      selector:
-        select:
-          options:
-            - label: "#️⃣ Check the current position"
-              value: "cover_helper_disabled"
-            - label: "🦮 Use an external Cover Status Helper"
-              value: "cover_helper_enabled"
-
-    cover_status_helper:
-      name: "🦮 Cover Status Helper"
-      description: >-
-        Helper used to store the last cover event.
-        *Attention:* You will need to manually create a [input_text](https://my.home-assistant.io/redirect/helpers/) entity with a <ins>length of 254 chars</ins> for this.
-        <br /><br />`Optional`
-      default: []
-      selector:
-        entity:
-          domain: input_text
-
     drive_time:
-      name: "🦮 Cover Drive Time"
+      name: "⏲️ Cover Drive Time"
       description: "Can be used to recognise manual control. Please round up a little and do not adjust too precisely. Is used to delay the trigger if too much or incorrect position data is sent back."
       default: 90
       selector:
@@ -828,7 +785,7 @@ blueprint:
         Note that the cover can close in the evening when the door contact is closed.
         It is not moved to the previously desired shading position!
         <br /><br />
-        If the sun shading is cancelled, the door contact is open and the lock-out protection is enabled,
+        If the sun shading is cancelled, the door contact is open and the lockout protection is enabled,
         the blind does not move from the shading position to the ventilation position.
         Instead, the roller blind is opened.
 
@@ -930,7 +887,7 @@ blueprint:
 
           - <ins>Enable delay after contacts are closed:</ins>
             <br />
-            Normally, when the window contact is closed, there is no delay in the upcoming movements. If you do want this, you can activate it here.
+            Normally, when the window contact is closed, there is no delay in the upcoming drives. If you do want this, you can activate it here.
             <br /><br />
             The "Fixed Drive Delay" and "Random Drive Delay" settings which are already used everywhere are then used.
             <br /><br />
@@ -1326,13 +1283,13 @@ blueprint:
       selector:
         select:
           options:
-            - label: "🔼 Ignore opening after manual position changes"
+            - label: "🔼 Ignore next automatic opening after manual position changes"
               value: "ignore_opening_after_manual"
-            - label: "🔻 Ignore closing after manual position changes"
+            - label: "🔻 Ignore next automatic closing after manual position changes"
               value: "ignore_closing_after_manual"
-            - label: "💨 Ignore ventilation after manual position changes"
+            - label: "💨 Ignore next automatic ventilation after manual position changes"
               value: "ignore_ventilation_after_manual"
-            - label: "🥵 Ignore sun shading after manual position changes"
+            - label: "🥵 Ignore next automatic sun shading after manual position changes"
               value: "ignore_shading_after_manual"
           multiple: true
           sort: false
@@ -1347,11 +1304,12 @@ blueprint:
         <details>
         <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
 
-          - <ins>Prevent 'set_cover_position' and 'set_cover_tilt_position'</ins>
-            There are devices that have problems when the two services 'set_cover_position' and 'set_cover_tilt_position' are executed directly one after the other.
-            For example, there are Shelly devices that use the script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066) here.
-            Or Homematic blind actuators, which can better use their own service for this: [homematicip_local.set_cover_combined_position](https://github.com/danielperna84/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position).
-            This option can be used to disable the standard services and allows the control to be implemented individually via the addtional actions.
+
+        <ins>Prevent 'set_cover_position' and 'set_cover_tilt_position'</ins><br />
+        There are devices that have problems when the two services 'set_cover_position' and 'set_cover_tilt_position' are executed directly one after the other.
+        For example, there are Shelly devices that use the script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066) here.
+        Or Homematic blind actuators, which can better use their own service for this: [homematicip_local.set_cover_combined_position](https://github.com/danielperna84/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position).
+        This option can be used to disable the standard services and allows the control to be implemented individually via the addtional actions.
 
         </details>
 
@@ -1371,12 +1329,14 @@ blueprint:
               value: "prevent_shading_end_if_closed"
             - label: "🚫 Prevent the use of 'set_cover_position' and 'set_cover_tilt_position' and only use the additional actions"
               value: "prevent_default_cover_actions"
-            - label: "🟩 Allow the cover to be opened several times a day"
-              value: "allow_opening_multiple_times"
-            - label: "🟩 Allow the cover to be closed several times a day"
-              value: "allow_closing_multiple_times"
-            - label: "🟩 Allow the sun shading to be activated several times a day"
-              value: "allow_shading_multiple_times"
+            - label: "🚫 Prevent the cover from being opened several times a day"
+              value: "prevent_opening_multiple_times"
+            - label: "🚫 Prevent the cover from being closed several times a day"
+              value: "prevent_closing_multiple_times"
+            - label: "🚫 Prevent the cover from being shaded several times a day"
+              value: "prevent_shading_multiple_times"
+            - label: "🚫 Prevent automatic closing due to the resident sensor"
+              value: "prevent_closing_by_resident"
           multiple: true
           sort: false
           custom_value: false
@@ -1479,7 +1439,7 @@ trigger_variables:
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
 
 variables:
-  version: "2024.05.xx-01"
+  version: "2024.05.23-01"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1542,8 +1502,6 @@ variables:
   # Cover Status Helper
   cover_status_options: !input cover_status_options
   cover_status_helper: !input cover_status_helper
-
-  # Own code helper
   is_status_helper_enabled: >-
     {{
       'cover_helper_enabled' in cover_status_options and
@@ -1656,9 +1614,10 @@ variables:
   prevent_forecast_service: "{{ 'prevent_forecast_service' in individual_config }}"
   prevent_shading_end_if_closed: "{{ 'prevent_shading_end_if_closed' in individual_config }}"
   prevent_default_cover_actions: "{{ 'prevent_default_cover_actions' in individual_config }}"
-  allow_shading_multiple_times: "{{ 'allow_shading_multiple_times' in individual_config }}"
-  allow_opening_multiple_times: "{{ 'allow_opening_multiple_times' in individual_config }}"
-  allow_closing_multiple_times: "{{ 'allow_closing_multiple_times' in individual_config }}"
+  prevent_shading_multiple_times: "{{ 'prevent_shading_multiple_times' in individual_config }}"
+  prevent_opening_multiple_times: "{{ 'prevent_opening_multiple_times' in individual_config }}"
+  prevent_closing_multiple_times: "{{ 'prevent_closing_multiple_times' in individual_config }}"
+  prevent_closing_by_resident: "{{ 'prevent_closing_by_resident' in individual_config }}"
 
   ignore_after_manual_config: !input ignore_after_manual_config
   ignore_opening_after_manual: "{{ 'ignore_opening_after_manual' in ignore_after_manual_config }}"
@@ -1870,7 +1829,7 @@ trigger:
     id: "t_so_1"
 
   ########################################
-  # Trigger for manual cover movements
+  # Trigger for manual cover controls
   ########################################
 
   - platform: state
@@ -1888,12 +1847,18 @@ condition:
   - "{{ trigger.to_state.state not in ['unavailable', 'unknown','none', 'query failed'] }}" # The following values are not valid to trigger
   - "{{ state_attr(this.entity_id,'current') | int(99) == 0 }}" # Avoid multiple triggering
 
-  ########################################
-  # Action
-  ########################################
+  ###############################################################################################
+  # ACTION
+  #
+  #   Note: I really have a lot of repetitive YAML code here in the blueprint.
+  #   I'm not used to this and I would like to encapsulate it in functions or something similar
+  #   or make the process more generic. Unfortunately, my hands are tied in an HA blueprint
+  #   and there is this really large amount of - actually nonsensical - repetition.
+  #   So please don't be surprised. I don't like that either. :-)
+  ###############################################################################################
 
 action:
-  # We have to call a service for forecast due to HA changes
+  # Querying the weather forecast
   - if:
       - "{{ is_shading_enabled }}"
       - "{{ not prevent_forecast_service }}"
@@ -1934,7 +1899,7 @@ action:
             %}
             {{ dict_var | to_json }}
 
-  # Upgrade helper to JSON v4
+  # Upgrade JSON-helper to current version
   - if:
       - "{{ is_status_helper_enabled }}"
       - "{{ (states(cover_status_helper)|from_json).v != 4 }}"
@@ -1960,9 +1925,10 @@ action:
   - choose:
       ############################################################
       # ANCHOR: OPEN
-      # Source: All (Open, Close, Ventilation, Shading)
-      # Target: Open, Shading
+      #   Source: All (Open, Close, Ventilation, Shading)
+      #   Target: Open, Shading
       ############################################################
+
       - alias: "Check for opening"
         conditions:
           - "{{ is_up_enabled }}"
@@ -1987,8 +1953,8 @@ action:
               - "{{ is_status_helper_enabled and is_cover_manual and not ignore_opening_after_manual }}"
           - or: # Only once a day?
               - "{{ not is_status_helper_enabled }}"
-              - "{{ allow_opening_multiple_times }}"
-              - "{{ is_status_helper_enabled and (now().day != is_cover_open_ts|timestamp_custom('%-d')|int) }}"
+              - "{{ not prevent_opening_multiple_times }}"
+              - "{{ is_status_helper_enabled and prevent_opening_multiple_times and (now().day != is_cover_open_ts|timestamp_custom('%-d')|int) }}"
           - or:
               - "{{ resident_sensor == [] }}"
               - "{{ is_state(resident_sensor, ['false', 'off']) }}"
@@ -2026,612 +1992,16 @@ action:
         sequence:
           - delay:
               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
           - choose:
+              ###################################
               # Cover should be shaded
-              - conditions:
+              ###################################
+              - alias: "Shading detected. Move to shading position"
+                conditions:
                   - "{{ is_cover_shaded }}"
-                sequence:
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'close':{'a':false,'t':dict_var.close.t},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'locked':{'a':false,'t':dict_var.locked.t},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-                  - if:
-                      - "{{ not prevent_default_cover_actions}}"
-                    then:
-                      - repeat:
-                          for_each: "{{ blind_entities|list }}"
-                          sequence:
-                            - alias: "Moving the cover to shading position"
-                              service: cover.set_cover_position
-                              data:
-                                position: !input shading_position
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                            - if:
-                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                              then:
-                                - alias: "Tilt Delay"
-                                  delay:
-                                    seconds: !input tilt_delay
-                                - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
-                                  data:
-                                    tilt_position: !input shading_tilt_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
-                                seconds: "{{ (range(1, 3)|random|int) }}"
-
-                  - choose: []
-                    default: !input auto_shading_start_action
-
-                  - stop: "Stop automation: Shading activated instead opening"
-
-          - choose:
-              # Cover should be opened
-              - conditions:
-                  - "{{ not is_cover_open }}" # TODO: Twice as much
-                sequence:
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'close':{'a':false,'t':dict_var.close.t},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':false,'t':dict_var.shading.t},
-                              'locked':{'a':false,'t':dict_var.locked.t},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-                  - if:
-                      - "{{ not prevent_default_cover_actions}}"
-                    then:
-                      - repeat:
-                          for_each: "{{ blind_entities|list }}"
-                          sequence:
-                            - if:
-                                - "{{ open_position == 100 }}"
-                              then:
-                                - alias: "Moving the cover to open position"
-                                  service: cover.open_cover
-                                  data: {}
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                              else:
-                                - alias: "Moving the cover to open position"
-                                  service: cover.set_cover_position
-                                  data:
-                                    position: !input open_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - if:
-                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                              then:
-                                - alias: "Tilt Delay"
-                                  delay:
-                                    seconds: !input tilt_delay
-                                - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
-                                  data:
-                                    tilt_position: !input open_tilt_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
-                                seconds: "{{ (range(1, 3)|random|int) }}"
-
-                  - choose: []
-                    default: !input auto_up_action
-
-                  - stop: "Stop automation: Activate opening"
-
-          - stop: "Stop automation: Opening"
-
-      ############################################################
-      # ANCHOR: CLOSE
-      # Source: All (Open, Close, Ventilation, Shading)
-      # Target: Close, Lockout, Ventilation
-      ############################################################
-      - alias: "Check for closing cover"
-        conditions:
-          - "{{ is_down_enabled }}"
-          - condition: !input auto_down_condition
-          - condition: trigger
-            id:
-              - "t_bc_1"
-              - "t_bc_2"
-              - "t_bc_3"
-              - "t_bc_4"
-              - "t_bc_5"
-              - "t_bc_6"
-          - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
-          - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
-          - or: # Optional: Continue if cover is shaded and close position is lower than shading position
-              - "{{ not prevent_higher_position_shading_end }}"
-              - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
-              - "{{ not in_shading_position }}" # Continue if cover is not shaded
-              - and:
                   - "{{ is_status_helper_enabled }}"
-                  - "{{ prevent_higher_position_shading_end }}"
-                  - "{{ is_cover_shaded }}"
-                  - "{{ close_position < shading_position }}"
-              - and: # Always, no further checks for 'is_status_helper_enabled'
-                  - "{{ prevent_higher_position_shading_end }}"
-                  - "{{ in_shading_position }}"
-                  - "{{ close_position < shading_position }}"
-          - or: # Optional: Continue if close-position is higher than the current position
-              - "{{ not prevent_higher_position_closing }}"
-              - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
-          - or: # Check the current positions
-              - "{{ is_status_helper_enabled and not is_cover_closed }}"
-              - "{{ in_open_position }}"
-          - or: # Ignore check
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ is_status_helper_enabled and not is_cover_manual }}"
-              - "{{ is_status_helper_enabled and ignore_closing_after_manual }}"
-              - "{{ is_status_helper_enabled and is_cover_manual and not ignore_closing_after_manual }}"
-          - or: # Only once a day?
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ allow_closing_multiple_times }}"
-              - "{{ is_status_helper_enabled and (is_cover_closed_ts < today_at(time_down_early_today) | as_timestamp) }}"
-          - or:
-              - and: # Closing - Down late reached
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() >= today_at(time_down_late_today) }}"
-              - and: # Closing - Scheduler changes to off
-                  - "{{ is_schedule_helper_enabled }}"
-                  - "{{ time_schedule_helper != [] }}"
-                  - "{{ is_state(time_schedule_helper, 'off') }}"
-                  - condition: trigger
-                    id: "t_bc_3"
-              - and: # Closing - Down early reached and brightness/sun below minimum
-                  - or:
-                      - and:
-                          - "{{ is_time_field_enabled }}"
-                          - "{{ now() >= today_at(time_down_early_today) }}"
-                          - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
-                      - and:
-                          - "{{ is_schedule_helper_enabled }}"
-                          - "{{ time_schedule_helper != [] }}"
-                          - "{{ is_state(time_schedule_helper, 'on') }}"
-                          - "{{ now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) }}"
-                          - "{{ now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5) }}"
-                  - or:
-                      - or:
-                          - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
-                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) }}"
-                      - or:
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
-                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) < sun_elevation_down) }}"
-              - and: # Closing - due to resident goes sleeping
-                  - condition: trigger
-                    id: t_bc_6
-                  - "{{ resident_sensor != [] }}"
-                  - "{{ is_state(resident_sensor, ['true', 'on']) }}"
-
-        sequence:
-          - choose:
-              # Consider lockout protection
-              - conditions:
-                  - "{{ is_lockout_protection_enabled }}"
-                  - "{{ contact_sensor_lockout != [] }}"
-                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
                 sequence:
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':false,'t':dict_var.open.t},
-                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':false,'t':dict_var.shading.t},
-                              'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-                  - stop: "Stop automation: Lockout-protection"
-
-              # Ventilation
-              - conditions:
-                  - "{{ is_ventilation_enabled }}"
-                  - "{{ contact_sensor != [] }}"
-                  - "{{ is_state(contact_sensor, ['true', 'on']) }}"
-                sequence:
-                  - delay:
-                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':false,'t':dict_var.open.t},
-                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'shading':{'a':false,'t':dict_var.shading.t},
-                              'locked':{'a':false,'t':dict_var.locked.t},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-
-                  - if:
-                      - "{{ not prevent_default_cover_actions}}"
-                    then:
-                      - repeat:
-                          for_each: "{{ blind_entities|list }}"
-                          sequence:
-                            - alias: "Moving the cover to ventilate position"
-                              service: cover.set_cover_position
-                              data:
-                                position: !input ventilate_position
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                            - if:
-                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                              then:
-                                - alias: "Tilt Delay"
-                                  delay:
-                                    seconds: !input tilt_delay
-                                - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
-                                  data:
-                                    tilt_position: !input ventilate_tilt_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
-                                seconds: "{{ (range(1, 3)|random|int) }}"
-
-                  - choose: []
-                    default: !input auto_ventilate_action
-
-                  - stop: "Stop automation: Moved to ventilation position during the closing process"
-
-              # Activate closing
-              - conditions:
-                  - "{{ is_down_enabled }}" # TODO FIXME - better placeholder
-                sequence:
-                  - delay:
-                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':false,'t':dict_var.open.t},
-                              'close':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':false,'t':dict_var.shading.t},
-                              'locked':{'a':false,'t':dict_var.locked.t},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-
-                  - if:
-                      - "{{ not prevent_default_cover_actions}}"
-                    then:
-                      - repeat:
-                          for_each: "{{ blind_entities|list }}"
-                          sequence:
-                            - if:
-                                - "{{ close_position == 0 }}"
-                              then:
-                                - alias: "Moving the cover to close position"
-                                  service: cover.close_cover
-                                  data: {}
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                              else:
-                                - alias: "Moving the cover to close position"
-                                  service: cover.set_cover_position
-                                  data:
-                                    position: !input close_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - if:
-                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                              then:
-                                - alias: "Tilt Delay"
-                                  delay:
-                                    seconds: !input tilt_delay
-                                - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
-                                  data:
-                                    tilt_position: !input close_tilt_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
-                                seconds: "{{ (range(1, 3)|random|int) }}"
-
-                  - choose: []
-                    default: !input auto_down_action
-
-                  - stop: "Stop automation: Moved to closing position"
-
-          - stop: "Stop automation: Closing"
-
-      ############################################################
-      # ANCHOR: SHADING START
-      # Source: Open (all gt shading_position)
-      # Target: Shading, Lockout
-      ############################################################
-      - alias: "Check for shading start"
-        conditions:
-          - "{{ is_shading_enabled }}"
-          - condition: !input auto_shading_start_condition
-          - condition: trigger
-            id:
-              - "t_si_1"
-              - "t_bo_1" # time_up_early
-              - "t_bo_3" # schedule helper state change
-          - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
-          - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
-          - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
-          - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
-          - or: # Check the current positions
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ is_status_helper_enabled and not is_cover_shaded }}"
-              - "{{ is_status_helper_enabled and not (is_cover_ventilated or is_cover_locked) }}"
-          - or: # Ignore check
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ is_status_helper_enabled and not is_cover_manual }}"
-              - "{{ is_status_helper_enabled and ignore_shading_after_manual }}"
-              - "{{ is_status_helper_enabled and is_cover_manual and not ignore_shading_after_manual }}"
-          - or: # Only once a day?
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ allow_shading_multiple_times }}"
-              - "{{ is_status_helper_enabled and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
-          - or:
-              - and:
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() >= today_at(time_up_early_today) }}"
-                  - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
-              - and:
-                  - "{{ is_schedule_helper_enabled }}"
-                  - "{{ time_schedule_helper != [] }}"
-                  - "{{ is_state(time_schedule_helper, 'on') }}"
-          - or:
-              - "{{ shading_temperatur_sensor1 == [] }}"
-              - "{{ states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 }}"
-          - or:
-              - "{{ shading_temperatur_sensor2 == [] }}"
-              - "{{ states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 }}"
-          - or:
-              - "{{ shading_brightness_sensor == [] }}"
-              - "{{ states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start }}"
-          - or:
-              - "{{ prevent_forecast_service }}"
-              - "{{ shading_forecast_sensor == [] }}"
-              - "{{ shading_forecast_temp == [] }}"
-              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp }}"
-          - or:
-              - "{{ prevent_forecast_service }}"
-              - "{{ shading_forecast_sensor == [] }}"
-              - "{{ shading_weather_conditions == [] }}"
-              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions }}"
-          - or:
-              - "{{ resident_sensor == [] }}"
-              - "{{ is_state(resident_sensor, ['false', 'off']) }}"
-
-        sequence:
-          - choose:
-              # Consider lockout protection
-              - conditions:
-                  - "{{ is_lockout_protection_enabled }}"
-                  - "{{ contact_sensor_lockout != [] }}"
-                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
-                sequence:
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':false,'t':dict_var.open.t},
-                              'close':{'a':false,'t':dict_var.close.t},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-                  - stop: "Stop automation: Lockout-protection while shading start"
-
-              # Start Shading
-              - conditions:
-                  - "{{ current_position | int(default=101) > shading_position }}"
-                sequence:
-                  - delay:
-                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'close':{'a':false,'t':dict_var.close.t},
-                              'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'locked':{'a':false,'t':dict_var.locked.t},
-                              'manual':{'a':false,'t':dict_var.manual.t},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-                  - if:
-                      - "{{ not prevent_default_cover_actions}}"
-                    then:
-                      - repeat:
-                          for_each: "{{ blind_entities|list }}"
-                          sequence:
-                            - alias: "Moving the cover to shading position"
-                              service: cover.set_cover_position
-                              data:
-                                position: !input shading_position
-                              target:
-                                entity_id: "{{ repeat.item }}"
-                            - if:
-                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                              then:
-                                - alias: "Tilt Delay"
-                                  delay:
-                                    seconds: !input tilt_delay
-                                - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
-                                  data:
-                                    tilt_position: !input shading_tilt_position
-                                  target:
-                                    entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
-                                seconds: "{{ (range(1, 3)|random|int) }}"
-
-                  - choose: []
-                    default: !input auto_shading_start_action
-
-                  - stop: "Stop automation: Shading activated"
-
-              # Save Shading state
-              - conditions:
-                  - "{{ is_cover_closed }}"
-                sequence:
-                  - if:
-                      - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                    then:
-                      - service: input_text.set_value
-                        data:
-                          entity_id: !input cover_status_helper
-                          value: |
-                            {% set dict_var = states(cover_status_helper) | from_json %}
-                            {% set dict_new = dict(dict_var, **{
-                              'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                              'p':current_position,
-                              'v':4,
-                              't':as_timestamp(now()) | round(0)
-                              })
-                            %}
-                            {{ dict_new | to_json }}
-
-                  - stop: "Stop automation: Shading state saved for the future"
-
-          - stop: "Stop automation: Shading-start"
-
-      ############################################################
-      # ANCHOR: SHADING END
-      # Source: Shading
-      # Target: Open, Ventilation, Lockout
-      ############################################################
-      - alias: "Check for shading end" # TODO: No forecast sensor trigger atm
-        conditions:
-          - "{{ is_shading_enabled }}"
-          - condition: !input auto_shading_end_condition
-          - condition: trigger
-            id: "t_so_1"
-          - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
-          - or:
-              - and:
-                  - "{{ is_time_field_enabled }}"
-                  - "{{ now() >= today_at(time_up_early_today) }}"
-                  - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
-              - and:
-                  - "{{ is_schedule_helper_enabled }}"
-                  - "{{ time_schedule_helper != [] }}"
-                  - "{{ is_state(time_schedule_helper, 'on') }}"
-          - or: # Ignore check
-              - "{{ not is_status_helper_enabled }}"
-              - "{{ is_status_helper_enabled and not is_cover_manual }}"
-              - "{{ is_status_helper_enabled and ignore_shading_after_manual }}"
-              - "{{ is_status_helper_enabled and is_cover_manual and not ignore_shading_after_manual }}"
-          - or:
-              - "{{ is_status_helper_enabled and is_cover_shaded }}"
-              - "{{ in_shading_position }}" # Be careful if the tolerance value is too high!
-          - or: # Optional: Continue if cover is not already closed
-              - "{{ not prevent_shading_end_if_closed }}"
-              - or:
-                  - and:
-                      - "{{ is_status_helper_enabled }}"
-                      - "{{ prevent_shading_end_if_closed }}"
-                      - "{{ not is_cover_closed }}"
-                  - and: # Always, no further checks for 'is_status_helper_enabled'
-                      - "{{ prevent_shading_end_if_closed }}"
-                      - "{{ not in_close_position }}"
-
-        sequence:
-          # Consider lockout protection
-          - if:
-              - "{{ is_lockout_protection_enabled }}"
-              - "{{ contact_sensor_lockout != [] }}"
-              - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
-            then:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
                   - service: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -2641,40 +2011,7 @@ action:
                           'open':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'close':{'a':false,'t':dict_var.close.t},
                           'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                          'shading':{'a':false,'t':dict_var.shading.t},
-                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'manual':{'a':false,'t':dict_var.manual.t},
-                          'p':current_position,
-                          'v':4,
-                          't':as_timestamp(now()) | round(0)
-                          })
-                        %}
-                        {{ dict_new | to_json }}
-              - stop: "Stop automation: Lockout-protection while shading end"
-
-          # Ventilation after shading end
-          - if:
-              - "{{ is_ventilation_enabled }}"
-              - "{{ contact_sensor != [] }}"
-              - "{{ is_state(contact_sensor, ['true', 'on']) }}"
-              - or: # The cover is not allowed to be lowered when the lockout protection is enabled
-                  - "{{ not is_lockout_protection_enabled }}"
-                  - "{{ contact_sensor_lockout == [] }}"
-                  - "{{ is_state(contact_sensor_lockout, ['false', 'off']) }}"
-            then:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
-                then:
-                  - service: input_text.set_value
-                    data:
-                      entity_id: !input cover_status_helper
-                      value: |
-                        {% set dict_var = states(cover_status_helper) | from_json %}
-                        {% set dict_new = dict(dict_var, **{
-                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'close':{'a':false,'t':dict_var.close.t},
-                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
                           'locked':{'a':false,'t':dict_var.locked.t},
                           'manual':{'a':false,'t':dict_var.manual.t},
                           'p':current_position,
@@ -2684,40 +2021,43 @@ action:
                         %}
                         {{ dict_new | to_json }}
 
-              - if:
-                  - "{{ not prevent_default_cover_actions}}"
-                then:
-                  - repeat:
-                      for_each: "{{ blind_entities|list }}"
-                      sequence:
-                        - alias: "Moving the cover to ventilate position"
-                          service: cover.set_cover_position
-                          data:
-                            position: !input ventilate_position
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                        - if:
-                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
-                          then:
-                            - alias: "Tilt Delay"
-                              delay:
-                                seconds: !input tilt_delay
-                            - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to shading position"
+                              service: cover.set_cover_position
                               data:
-                                tilt_position: !input ventilate_tilt_position
+                                position: !input shading_position
                               target:
                                 entity_id: "{{ repeat.item }}"
-                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                          delay:
-                            seconds: "{{ (range(1, 3)|random|int) }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input shading_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
 
-              - choose: []
-                default: !input auto_ventilate_action
+                  - choose: []
+                    default: !input auto_shading_start_action
 
-            else:
-              - if:
-                  - "{{ 'cover_helper_enabled' in cover_status_options }}"
+            ###################################
+            # Cover should be opened
+            ###################################
+            default:
+              - alias: "Normal opening of the cover"
+                if:
+                  - "{{ is_status_helper_enabled }}"
                 then:
                   - service: input_text.set_value
                     data:
@@ -2771,23 +2111,637 @@ action:
                                 tilt_position: !input open_tilt_position
                               target:
                                 entity_id: "{{ repeat.item }}"
-                        - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                          delay:
+                        - delay:
+                            seconds: "{{ (range(1, 3)|random|int) }}"
+
+              - choose: []
+                default: !input auto_up_action
+
+          - stop: "Stop automation: OPEN"
+
+      ############################################################
+      # ANCHOR: CLOSE
+      #   Source: All (Open, Close, Ventilation, Shading)
+      #   Target: Close, Lockout, Ventilation
+      ############################################################
+
+      - alias: "Check for closing cover"
+        conditions:
+          - "{{ is_down_enabled }}"
+          - condition: !input auto_down_condition
+          - condition: trigger
+            id:
+              - "t_bc_1"
+              - "t_bc_2"
+              - "t_bc_3"
+              - "t_bc_4"
+              - "t_bc_5"
+              - "t_bc_6"
+          - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
+          - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
+          - or: # Optional: Continue if cover is shaded and close position is lower than shading position
+              - "{{ not prevent_higher_position_shading_end }}"
+              - "{{ not is_cover_shaded }}" # Continue if cover is not shaded
+              - "{{ not in_shading_position }}" # Continue if cover is not shaded
+              - and:
+                  - "{{ is_status_helper_enabled }}"
+                  - "{{ prevent_higher_position_shading_end }}"
+                  - "{{ is_cover_shaded }}"
+                  - "{{ close_position < shading_position }}"
+              - and: # Always, no further checks for 'is_status_helper_enabled'
+                  - "{{ prevent_higher_position_shading_end }}"
+                  - "{{ in_shading_position }}"
+                  - "{{ close_position < shading_position }}"
+          - or: # Optional: Continue if close-position is higher than the current position
+              - "{{ not prevent_higher_position_closing }}"
+              - "{{ prevent_higher_position_closing and (current_position | int(default=101) >= close_position) }}"
+          - or: # Check the current positions
+              - "{{ is_status_helper_enabled and not is_cover_closed }}"
+              - "{{ in_open_position }}"
+          - or: # Ignore check
+              - "{{ not is_status_helper_enabled }}"
+              - "{{ is_status_helper_enabled and not is_cover_manual }}"
+              - "{{ is_status_helper_enabled and ignore_closing_after_manual }}"
+              - "{{ is_status_helper_enabled and is_cover_manual and not ignore_closing_after_manual }}"
+          - or: # Only once a day?
+              - "{{ not is_status_helper_enabled }}"
+              - "{{ not prevent_closing_multiple_times }}"
+              - "{{ is_status_helper_enabled and prevent_closing_multiple_times and (is_cover_closed_ts < today_at(time_down_early_today) | as_timestamp) }}"
+          - or:
+              - and: # Closing - Down late reached
+                  - "{{ is_time_field_enabled }}"
+                  - "{{ now() >= today_at(time_down_late_today) }}"
+              - and: # Closing - Scheduler changes to off
+                  - "{{ is_schedule_helper_enabled }}"
+                  - "{{ time_schedule_helper != [] }}"
+                  - "{{ is_state(time_schedule_helper, 'off') }}"
+                  - condition: trigger
+                    id: "t_bc_3"
+              - and: # Closing - Down early reached and brightness/sun below minimum
+                  - or:
+                      - and:
+                          - "{{ is_time_field_enabled }}"
+                          - "{{ now() >= today_at(time_down_early_today) }}"
+                          - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
+                      - and:
+                          - "{{ is_schedule_helper_enabled }}"
+                          - "{{ time_schedule_helper != [] }}"
+                          - "{{ is_state(time_schedule_helper, 'on') }}"
+                          - "{{ now() >= today_at([time_down_early, time_down_early_non_workday] | min) - timedelta(seconds = 5) }}"
+                          - "{{ now() <= today_at([time_down_late, time_down_late_non_workday] | max) + timedelta(seconds = 5) }}"
+                  - or:
+                      - or:
+                          - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
+                          - "{{ is_brightness_enabled and default_brightness_sensor != [] and (states(default_brightness_sensor) | float(default=brightness_down) < brightness_down) }}"
+                      - or:
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor == [] }}"
+                          - "{{ is_sun_elevation_enabled and default_sun_sensor != [] and (current_sun_elevation | float(default=sun_elevation_down) < sun_elevation_down) }}"
+              - and: # Closing - due to resident goes sleeping
+                  - condition: trigger
+                    id: t_bc_6
+                  - "{{ resident_sensor != [] }}"
+                  - "{{ is_state(resident_sensor, ['true', 'on']) }}"
+                  - "{{ not prevent_closing_by_resident }}"
+
+        sequence:
+          - choose:
+              ###################################
+              # Consider lockout protection
+              ###################################
+              - alias: "Consider lockout protection"
+                conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                  - "{{ is_status_helper_enabled }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              ###################################
+              # Move to ventilation position
+              ###################################
+              - alias: "Move to ventilation position"
+                conditions:
+                  - "{{ is_ventilation_enabled }}"
+                  - "{{ contact_sensor != [] }}"
+                  - "{{ is_state(contact_sensor, ['true', 'on']) }}"
+                  - "{{ is_status_helper_enabled }}"
+                sequence:
+                  - delay:
+                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to ventilate position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input ventilate_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input ventilate_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_ventilate_action
+
+            ###################################
+            # Normal closing of the cover
+            ###################################
+            default:
+              - alias: "Normal closing of the cover"
+                delay:
+                  seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
+              - if:
+                  - "{{ is_status_helper_enabled }}"
+                then:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - if:
+                            - "{{ close_position == 0 }}"
+                          then:
+                            - alias: "Moving the cover to close position"
+                              service: cover.close_cover
+                              data: {}
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                          else:
+                            - alias: "Moving the cover to close position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input close_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Tilt Delay"
+                              delay:
+                                seconds: !input tilt_delay
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input close_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - delay:
+                            seconds: "{{ (range(1, 3)|random|int) }}"
+
+              - choose: []
+                default: !input auto_down_action
+
+          - stop: "Stop automation: CLOSE"
+
+      ############################################################
+      # ANCHOR: SHADING START
+      #   Source: Open (all gt shading_position)
+      #   Target: Shading, Lockout
+      ############################################################
+
+      - alias: "Check for shading start"
+        conditions:
+          - "{{ is_shading_enabled }}"
+          - "{{ is_status_helper_enabled }}"
+          - condition: !input auto_shading_start_condition
+          - condition: trigger
+            id:
+              - "t_si_1"
+              - "t_bo_1" # time_up_early
+              - "t_bo_3" # schedule helper state change
+          - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
+          - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
+          - "{{ current_sun_azimuth > shading_azimuth_start and current_sun_azimuth < shading_azimuth_end }}"
+          - "{{ current_sun_elevation > shading_elevation_min and current_sun_elevation < shading_elevation_max }}"
+          - or: # Check the current positions
+              - "{{ not is_cover_shaded }}"
+              - "{{ not (is_cover_ventilated or is_cover_locked) }}"
+          - or: # Ignore check
+              - "{{ not is_cover_manual }}"
+              - "{{ ignore_shading_after_manual }}"
+              - "{{ is_cover_manual and not ignore_shading_after_manual }}"
+          - or: # Only once a day?
+              - "{{ not prevent_shading_multiple_times }}"
+              - "{{ prevent_shading_multiple_times and (now().day != is_cover_shaded_ts|timestamp_custom('%-d')|int) }}"
+          - or:
+              - and:
+                  - "{{ is_time_field_enabled }}"
+                  - "{{ now() >= today_at(time_up_early_today) }}"
+                  - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
+              - and:
+                  - "{{ is_schedule_helper_enabled }}"
+                  - "{{ time_schedule_helper != [] }}"
+                  - "{{ is_state(time_schedule_helper, 'on') }}"
+          - or:
+              - "{{ shading_temperatur_sensor1 == [] }}"
+              - "{{ states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > shading_min_temperatur1 }}"
+          - or:
+              - "{{ shading_temperatur_sensor2 == [] }}"
+              - "{{ states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > shading_min_temperatur2 }}"
+          - or:
+              - "{{ shading_brightness_sensor == [] }}"
+              - "{{ states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > shading_sun_brightness_start }}"
+          - or:
+              - "{{ prevent_forecast_service }}"
+              - "{{ shading_forecast_sensor == [] }}"
+              - "{{ shading_forecast_temp == [] }}"
+              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].temperature | float(default=shading_forecast_temp) > shading_forecast_temp }}"
+          - or:
+              - "{{ prevent_forecast_service }}"
+              - "{{ shading_forecast_sensor == [] }}"
+              - "{{ shading_weather_conditions == [] }}"
+              - "{{ (not prevent_forecast_service) and weather_forecast[shading_forecast_sensor].forecast[0].condition in shading_weather_conditions }}"
+          - or:
+              - "{{ resident_sensor == [] }}"
+              - "{{ is_state(resident_sensor, ['false', 'off']) }}"
+
+        sequence:
+          - choose:
+              ###################################
+              # Consider lockout protection
+              ###################################
+              - alias: "Consider lockout protection"
+                conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':false,'t':dict_var.open.t},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              ###################################
+              # Start Shading
+              ###################################
+              - alias: "Start Shading"
+                conditions:
+                  - "{{ current_position | int(default=101) > shading_position }}"
+                sequence:
+                  - delay:
+                      seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to shading position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input shading_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input shading_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_shading_start_action
+
+              ###################################
+              # Save shading state for the future
+              ###################################
+              - alias: "Save shading state for the future"
+                conditions:
+                  - "{{ is_cover_closed }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+          - stop: "Stop automation: SHADING START"
+
+      ############################################################
+      # ANCHOR: SHADING END
+      #   Source: Shading
+      #   Target: Open, Ventilation, Lockout
+      ############################################################
+
+      - alias: "Check for shading end" # TODO: No forecast sensor trigger atm
+        conditions:
+          - "{{ is_shading_enabled }}"
+          - "{{ is_status_helper_enabled }}"
+          - condition: !input auto_shading_end_condition
+          - condition: trigger
+            id: "t_so_1"
+          - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
+          - or:
+              - and:
+                  - "{{ is_time_field_enabled }}"
+                  - "{{ now() >= today_at(time_up_early_today) }}"
+                  - "{{ now() <= today_at(time_down_late_today) + timedelta(seconds = 5) }}"
+              - and:
+                  - "{{ is_schedule_helper_enabled }}"
+                  - "{{ time_schedule_helper != [] }}"
+                  - "{{ is_state(time_schedule_helper, 'on') }}"
+          - or: # Ignore check
+              - "{{ not is_cover_manual }}"
+              - "{{ ignore_shading_after_manual }}"
+              - "{{ is_cover_manual and not ignore_shading_after_manual }}"
+          - or:
+              - "{{ is_cover_shaded }}"
+              - "{{ in_shading_position }}" # Be careful if the tolerance value is too high!
+          - or: # Optional: Continue if cover is not already closed
+              - "{{ not prevent_shading_end_if_closed }}"
+              - "{{ prevent_shading_end_if_closed and  not in_close_position}}"
+
+        sequence:
+          - choose:
+              ###################################
+              # Consider lockout protection
+              ###################################
+              - alias: "Consider lockout protection"
+                conditions:
+                  - "{{ is_lockout_protection_enabled }}"
+                  - "{{ contact_sensor_lockout != [] }}"
+                  - "{{ is_state(contact_sensor_lockout, ['true', 'on']) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+              ###################################
+              # Ventilation after shading end
+              ###################################
+              - alias: "Ventilation after shading end"
+                conditions:
+                  - "{{ is_ventilation_enabled }}"
+                  - "{{ contact_sensor != [] }}"
+                  - "{{ is_state(contact_sensor, ['true', 'on']) }}"
+                  - or: # The cover is not allowed to be lowered when the lockout protection is enabled
+                      - "{{ not is_lockout_protection_enabled }}"
+                      - "{{ contact_sensor_lockout == [] }}"
+                      - "{{ is_state(contact_sensor_lockout, ['false', 'off']) }}"
+                sequence:
+                  - service: input_text.set_value
+                    data:
+                      entity_id: !input cover_status_helper
+                      value: |
+                        {% set dict_var = states(cover_status_helper) | from_json %}
+                        {% set dict_new = dict(dict_var, **{
+                          'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'close':{'a':false,'t':dict_var.close.t},
+                          'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                          'shading':{'a':false,'t':dict_var.shading.t},
+                          'locked':{'a':false,'t':dict_var.locked.t},
+                          'manual':{'a':false,'t':dict_var.manual.t},
+                          'p':current_position,
+                          'v':4,
+                          't':as_timestamp(now()) | round(0)
+                          })
+                        %}
+                        {{ dict_new | to_json }}
+
+                  - if:
+                      - "{{ not prevent_default_cover_actions}}"
+                    then:
+                      - repeat:
+                          for_each: "{{ blind_entities|list }}"
+                          sequence:
+                            - alias: "Moving the cover to ventilate position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input ventilate_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                            - if:
+                                - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                              then:
+                                - alias: "Tilt Delay"
+                                  delay:
+                                    seconds: !input tilt_delay
+                                - alias: "Moving the cover to tilt position"
+                                  service: cover.set_cover_tilt_position
+                                  data:
+                                    tilt_position: !input ventilate_tilt_position
+                                  target:
+                                    entity_id: "{{ repeat.item }}"
+                            - delay:
+                                seconds: "{{ (range(1, 3)|random|int) }}"
+
+                  - choose: []
+                    default: !input auto_ventilate_action
+
+            ###################################
+            # Move cover to open position
+            ###################################
+            default:
+              - alias: "Move cover to open position"
+                service: input_text.set_value
+                data:
+                  entity_id: !input cover_status_helper
+                  value: |
+                    {% set dict_var = states(cover_status_helper) | from_json %}
+                    {% set dict_new = dict(dict_var, **{
+                      'open':{'a':true,'t':as_timestamp(now()) | round(0)},
+                      'close':{'a':false,'t':dict_var.close.t},
+                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                      'shading':{'a':false,'t':dict_var.shading.t},
+                      'locked':{'a':false,'t':dict_var.locked.t},
+                      'manual':{'a':false,'t':dict_var.manual.t},
+                      'p':current_position,
+                      'v':4,
+                      't':as_timestamp(now()) | round(0)
+                      })
+                    %}
+                    {{ dict_new | to_json }}
+
+              - if:
+                  - "{{ not prevent_default_cover_actions}}"
+                then:
+                  - repeat:
+                      for_each: "{{ blind_entities|list }}"
+                      sequence:
+                        - if:
+                            - "{{ open_position == 100 }}"
+                          then:
+                            - alias: "Moving the cover to open position"
+                              service: cover.open_cover
+                              data: {}
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                          else:
+                            - alias: "Moving the cover to open position"
+                              service: cover.set_cover_position
+                              data:
+                                position: !input open_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - if:
+                            - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
+                          then:
+                            - alias: "Tilt Delay"
+                              delay:
+                                seconds: !input tilt_delay
+                            - alias: "Moving the cover to tilt position"
+                              service: cover.set_cover_tilt_position
+                              data:
+                                tilt_position: !input open_tilt_position
+                              target:
+                                entity_id: "{{ repeat.item }}"
+                        - delay:
                             seconds: "{{ (range(1, 3)|random|int) }}"
 
               - choose: []
                 default: !input auto_shading_end_action
 
-          - stop: "Stop automation: Shading-end"
+          - stop: "Stop automation: SHADING END"
 
       ############################################################
       # ANCHOR: CONTACT OPEN
-      # Source: Shading, Close
-      # Target: Ventilation
+      #   Source: Shading, Close
+      #   Target: Ventilation
       ############################################################
+
       - alias: "Contact sensor opened"
         conditions:
           - "{{ is_ventilation_enabled }}"
+          - "{{ is_status_helper_enabled }}"
           - condition: !input auto_ventilate_condition
           - condition: trigger
             id: "t_ct_vent_open"
@@ -2798,29 +2752,26 @@ action:
           - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
           - or:
               - or: # Source: Close
-                  - "{{ is_status_helper_enabled and is_cover_closed }}"
+                  - "{{ is_cover_closed }}"
                   - "{{ in_close_position }}" # Always and independently of the helper
                   - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) < ventilate_position) }}"
               - or: # Source: Shading
-                  - "{{ is_status_helper_enabled and is_cover_shaded }}"
+                  - "{{ is_cover_shaded }}"
                   - "{{ in_shading_position }}" # Always and independently of the helper
         sequence:
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+          - service: input_text.set_value
+            data:
+              entity_id: !input cover_status_helper
+              value: |
+                {% set dict_var = states(cover_status_helper) | from_json %}
+                {% set dict_new = dict(dict_var, **{
+                  'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                  'p':current_position,
+                  'v':4,
+                  't':as_timestamp(now()) | round(0)
+                  })
+                %}
+                {{ dict_new | to_json }}
 
           - if:
               - "{{ not prevent_default_cover_actions}}"
@@ -2846,24 +2797,24 @@ action:
                             tilt_position: !input ventilate_tilt_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
+                    - delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
           - choose: []
             default: !input auto_ventilate_action
 
-          - stop: "Stop automation: Contact sensor has been opened"
+          - stop: "Stop automation: CONTACT OPEN"
 
       ############################################################
       # ANCHOR: CONTACT CLOSED
-      # Source: Ventilation, Lockout
-      # Target: Open, Close, Shading
+      #   Source: Ventilation, Lockout
+      #   Target: Open, Close, Shading
       ############################################################
+
       - alias: "Contact sensor closed"
         conditions:
           - "{{ is_down_enabled }}" # Only close if it is allowed
-          - "{{ is_status_helper_enabled }}" # Sorry, it is mandatory now!
+          - "{{ is_status_helper_enabled }}"
           - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
           - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
           - "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
@@ -2898,8 +2849,11 @@ action:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
           - choose:
-              # Contact closed > Opening
-              - conditions:
+              ########################################
+              # Contact sensor closed. Open the cover
+              ########################################
+              - alias: "Contact sensor closed. Open the cover"
+                conditions:
                   - "{{ is_cover_open }}"
                 sequence:
                   - service: input_text.set_value
@@ -2920,6 +2874,7 @@ action:
                           })
                         %}
                         {{ dict_new | to_json }}
+
                   - if:
                       - "{{ not prevent_default_cover_actions}}"
                     then:
@@ -2953,17 +2908,17 @@ action:
                                     tilt_position: !input open_tilt_position
                                   target:
                                     entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
+                            - delay:
                                 seconds: "{{ (range(1, 3)|random|int) }}"
 
                   - choose: []
                     default: !input auto_up_action
 
-                  - stop: "Stop automation: Opening after ventilation or after lockout-protection"
-
-              # Contact closed > Closing
-              - conditions:
+              ########################################
+              # Contact sensor closed. Close the cover
+              ########################################
+              - alias: "Contact sensor closed. Close the cover"
+                conditions:
                   - "{{ is_cover_closed }}"
                 sequence:
                   - service: input_text.set_value
@@ -2984,6 +2939,7 @@ action:
                           })
                         %}
                         {{ dict_new | to_json }}
+
                   - if:
                       - "{{ not prevent_default_cover_actions}}"
                     then:
@@ -3017,17 +2973,17 @@ action:
                                     tilt_position: !input close_tilt_position
                                   target:
                                     entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
+                            - delay:
                                 seconds: "{{ (range(1, 3)|random|int) }}"
 
                   - choose: []
                     default: !input auto_down_action
 
-                  - stop: "Stop automation: Closing after ventilation or after lockout-protection"
-
-              # Contact closed > Shading
-              - conditions:
+              ##########################################
+              # Contact sensor closed. Activate shading
+              ##########################################
+              - alias: "Contact sensor closed. Activate shading"
+                conditions:
                   - "{{ is_cover_shaded }}"
                 sequence:
                   - service: input_text.set_value
@@ -3092,20 +3048,18 @@ action:
                                     tilt_position: !input shading_tilt_position
                                   target:
                                     entity_id: "{{ repeat.item }}"
-                            - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                              delay:
+                            - delay:
                                 seconds: "{{ (range(1, 3)|random|int) }}"
 
                   - choose: []
                     default: !input auto_shading_start_action
 
-                  - stop: "Stop automation: Shading-start after ventilation or after lockout-protection"
-
-          - stop: "Stop automation: Contact closed"
+          - stop: "Stop automation: CONTACT CLOSED"
 
       ############################################################
       # ANCHOR: FORCE OPEN
       ############################################################
+
       - alias: "Forced opening of the cover"
         conditions:
           - condition: trigger
@@ -3113,7 +3067,7 @@ action:
           - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
         sequence:
           - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+              - "{{ is_status_helper_enabled }}"
             then:
               - service: input_text.set_value
                 data:
@@ -3167,18 +3121,18 @@ action:
                             tilt_position: !input open_tilt_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
+                    - delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
           - choose: []
             default: !input auto_up_action
 
-          - stop: "Stop automation: Forced Opening"
+          - stop: "Stop automation: FORCE OPEN"
 
       ############################################################
       # ANCHOR: FORCE CLOSE
       ############################################################
+
       - alias: "Forced closing of the cover"
         conditions:
           - condition: trigger
@@ -3186,7 +3140,7 @@ action:
           - "{{ auto_down_force != [] and is_state(auto_down_force, ['true', 'on']) }}"
         sequence:
           - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
+              - "{{ is_status_helper_enabled }}"
             then:
               - service: input_text.set_value
                 data:
@@ -3240,45 +3194,43 @@ action:
                             tilt_position: !input close_tilt_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
+                    - delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
           - choose: []
             default: !input auto_down_action
 
-          - stop: "Stop automation: Forced Closing"
+          - stop: "Stop automation: FORCE CLOSE"
 
       ############################################################
       # ANCHOR: FORCE VENTILATION
       ############################################################
+
       - alias: "Forced ventilation of the cover"
         conditions:
           - condition: trigger
             id: "t_ve_force"
           - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
+          - "{{ is_status_helper_enabled }}"
         sequence:
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'shading':{'a':false,'t':dict_var.shading.t},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+          - service: input_text.set_value
+            data:
+              entity_id: !input cover_status_helper
+              value: |
+                {% set dict_var = states(cover_status_helper) | from_json %}
+                {% set dict_new = dict(dict_var, **{
+                  'open':{'a':false,'t':dict_var.open.t},
+                  'close':{'a':false,'t':dict_var.close.t},
+                  'ventilate':{'a':true,'t':as_timestamp(now()) | round(0)},
+                  'shading':{'a':false,'t':dict_var.shading.t},
+                  'locked':{'a':false,'t':dict_var.locked.t},
+                  'manual':{'a':false,'t':dict_var.manual.t},
+                  'p':current_position,
+                  'v':4,
+                  't':as_timestamp(now()) | round(0)
+                  })
+                %}
+                {{ dict_new | to_json }}
 
           - if:
               - "{{ not prevent_default_cover_actions}}"
@@ -3304,45 +3256,43 @@ action:
                             tilt_position: !input ventilate_tilt_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
+                    - delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
           - choose: []
             default: !input auto_ventilate_action
 
-          - stop: "Stop automation: Forced Ventilation"
+          - stop: "Stop automation: FORCE VENTILATION"
 
       ############################################################
       # ANCHOR: FORCE SHADING START
       ############################################################
+
       - alias: "Forced activating of the sun shading"
         conditions:
           - condition: trigger
             id: "t_si_force"
           - "{{ auto_shading_start_force != [] and is_state(auto_shading_start_force, ['true', 'on']) }}"
+          - "{{ is_status_helper_enabled }}"
         sequence:
-          - if:
-              - "{{ 'cover_helper_enabled' in cover_status_options }}"
-            then:
-              - service: input_text.set_value
-                data:
-                  entity_id: !input cover_status_helper
-                  value: |
-                    {% set dict_var = states(cover_status_helper) | from_json %}
-                    {% set dict_new = dict(dict_var, **{
-                      'open':{'a':false,'t':dict_var.open.t},
-                      'close':{'a':false,'t':dict_var.close.t},
-                      'ventilate':{'a':false,'t':dict_var.ventilate.t},
-                      'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
-                      'locked':{'a':false,'t':dict_var.locked.t},
-                      'manual':{'a':false,'t':dict_var.manual.t},
-                      'p':current_position,
-                      'v':4,
-                      't':as_timestamp(now()) | round(0)
-                      })
-                    %}
-                    {{ dict_new | to_json }}
+          - service: input_text.set_value
+            data:
+              entity_id: !input cover_status_helper
+              value: |
+                {% set dict_var = states(cover_status_helper) | from_json %}
+                {% set dict_new = dict(dict_var, **{
+                  'open':{'a':false,'t':dict_var.open.t},
+                  'close':{'a':false,'t':dict_var.close.t},
+                  'ventilate':{'a':false,'t':dict_var.ventilate.t},
+                  'shading':{'a':true,'t':as_timestamp(now()) | round(0)},
+                  'locked':{'a':false,'t':dict_var.locked.t},
+                  'manual':{'a':false,'t':dict_var.manual.t},
+                  'p':current_position,
+                  'v':4,
+                  't':as_timestamp(now()) | round(0)
+                  })
+                %}
+                {{ dict_new | to_json }}
 
           - if:
               - "{{ not prevent_default_cover_actions}}"
@@ -3368,19 +3318,19 @@ action:
                             tilt_position: !input shading_tilt_position
                           target:
                             entity_id: "{{ repeat.item }}"
-                    - alias: "Wait 1-5 random seconds to prevent sending to many commands to covers at same time"
-                      delay:
+                    - delay:
                         seconds: "{{ (range(1, 3)|random|int) }}"
 
           - choose: []
             default: !input auto_shading_start_action
 
-          - stop: "Stop automation: Forced Shading-start"
+          - stop: "Stop automation: FORCE SHADING START"
 
       ############################################################
       # ANCHOR: MANUAL
       ############################################################
-      - alias: "Cover movement - Checking for manual position changes"
+
+      - alias: "Checking for manual position changes"
         conditions:
           - "{{ 'cover_helper_enabled' in cover_status_options }}" # Do not use 'is_status_helper_enabled' (with the embedded regex here), because it could be set after variable declaration
           - "{{ cover_status_helper != [] }}"
@@ -3680,4 +3630,4 @@ action:
                   message: "Cover Control Automation (CCA): Config issue: Wrong length of the cover status helper - {{this.entity_id}}"
                   logger: "blueprints.hvorragend.cover_control_automation"
 
-      - stop: "Stopping the automation - Reset"
+      - stop: "Stopping the automation - DEFAULT"


### PR DESCRIPTION
    2024.05.28-01:
      - Complete restructuring and logic change for shading, lockout protection and ventilation:
          - When the cover is opened, the system checks whether a sun shading is already in place. If this is the case, the cover is not opened but moved directly into the shading position.
          - If the cover is to be closed and the contact is open, either lockout protection or ventilation mode is activated.
          - If the cover is closed and the corresponding contact is opened, the ventilation position is activated.
          - When the sun shading is activated, the lockout protection is taken into account if the contact is open. If the contact is closed, the cover moves back to the shading position.
          - When the sun shading is stopped, the lockout protection is checked. It is also possible to move to the ventilation position when the contact is open. If the contact is closed here, the cover is opened.

          <ins>Summary:</ins> CCA saves the temporary status (ventilation, lockout protection and shading) and the actual target status in the Cover Status Helper.
          - This means that the cover is simply opened or closed as before.
          - And it does <ins>not</ins> always return to the previous state (which may have changed in the meantime).
          - Instead, it switches to the state that should actually be current.
      - Fixed: Incorrect position detection during manual drives if shading_position is smaller than close_position
      - Added: Shading activation before opening. The cover can now move into the shading during the opening process. #4
      - Added: Prevent automatic closing due to the resident sensor #63
      - Added: Option to deactivate time control. This means that the system can now also be controlled exclusively via the brightness and the height of the sun. I
      - <strong>BREAKING CHANGES:</strong>
          - Cover Status Helper is now mandatory for ventilation, lockout protection and shading!
          - Invert the status of some options #61 ("Prevent the cover from being ... several times a day" instead of "Allow the cover to be ... several times a day")