### PR TITLE
Feature: Add an alarm trigger

### DIFF
--- a/blueprints/automation/cover_control_automation_beta.yaml
+++ b/blueprints/automation/cover_control_automation_beta.yaml
@@ -723,7 +723,7 @@ blueprint:
           description: >-
             You can specify an additional timestamp sensor (e.g. the alarm sensor of your phone).
             This will open the cover no matter what time it is.
-            This is usefull, if your working time changes and you are using your phone to set an alarm every day.
+            This is useful, if your working time changes and you are using your phone to set an alarm every day.
           default: false
           selector:
             boolean: {}

--- a/blueprints/automation/cover_control_automation_beta.yaml
+++ b/blueprints/automation/cover_control_automation_beta.yaml
@@ -1233,6 +1233,176 @@ blueprint:
               max: 3600
               unit_of_measurement: seconds
 
+    resident_section:
+      name: "Resident Settings"
+      icon: mdi:human-male-female
+      collapsed: true
+      input:
+        resident_sensor:
+          name: "🛌 Resident Mode"
+          description: >-
+            Overwrite mode for opening and unplannend closing.
+            <details>
+            <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
+            This switch can be used to override the automatic opening of the cover.
+            If this sensor (input_boolean or binary_sensor) is set to ON, the cover will not open automatically.
+            This can be used e.g. to define a resident for the room. In this case, the cover only opens when the resident is no longer asleep.
+            <br />
+            For this it is necessary to use a boolean sensor that returns TRUE/ON for sleeping and FALSE/OFF for non-sleeping.
+            <br />
+            The cover will also close (without checking the defined times) if this sensor switches to TRUE/ON (because the resident is sleeping).
+            </details>
+            <br /><code>Optional</code>
+          default: []
+          selector:
+            entity:
+              domain:
+                - input_boolean
+                - binary_sensor
+
+        resident_config:
+          name: "🛌 Resident Configuration"
+          description: "A few fine adjustments"
+          default: []
+          selector:
+            select:
+              options:
+                - label: "🔻 Automatic closing due to the resident sensor"
+                  value: "resident_closing_enabled"
+                - label: "🥵 Allow sun protection when resident is still present"
+                  value: "resident_shading_enabled"
+              multiple: true
+              sort: false
+              custom_value: false
+              mode: list
+
+    override_section:
+      name: "Manual Override"
+      description: >-
+        <center><code>A Cover Status Helper is required!</code></center><br />
+      icon: mdi:debug-step-over
+      collapsed: true
+      input:
+        ignore_after_manual_config:
+          name: "🖐️ Ignoring/override after manual position changes"
+          description: >-
+            Ignore or override the following actions after manual position changes.
+            <details>
+            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
+            Ultimately, this means that the cover will not be opened, closed, etc.
+            if a manual interaction has previously been made, e.g. using a wall switch.
+            The reason behind this is that the human being wins with his decision and his
+            conscious decision is weighted higher than the upcoming action of the automation.
+            As soon as a cover has been moved manually, the status is recorded in the Cover Status Helper.
+            This usually means that a person has deliberately decided against a status.
+              - If option is not activated: The covers are moved even if a manual correction has been made.
+              - If option is activated: The action to open, close, etc. is not performed because a conscious decision was made to do otherwise due to a manual intervention.
+            A Cover Status Helper is required!
+            </details>
+          default: []
+          selector:
+            select:
+              options:
+                - label: "🔼 Ignore/override next automatic opening after manual position changes"
+                  value: "ignore_opening_after_manual"
+                - label: "🔻 Ignore/override next automatic closing after manual position changes"
+                  value: "ignore_closing_after_manual"
+                - label: "💨 Ignore/override next automatic ventilation after manual position changes"
+                  value: "ignore_ventilation_after_manual"
+                - label: "🥵 Ignore/override next automatic sun shading after manual position changes"
+                  value: "ignore_shading_after_manual"
+              multiple: true
+              sort: false
+              custom_value: false
+              mode: list
+
+        reset_override_config:
+          name: "🗑️ Reset manual override"
+          description: >-
+            If the detection of the manual position change was activated above, you may need a way to reset this status.
+            Otherwise, the next cover movements will be permanently ignored or overridden.
+            Or you have not activated an individual action, e.g. when closing the covers, which resets the status.
+          default: reset_disabled
+          selector:
+            select:
+              options:
+                - label: "No timed reset for manual override"
+                  value: "reset_disabled"
+                - label: "Reset at a specified time (see below)"
+                  value: "reset_time"
+                - label: "Reset after a timeout in minutes (see below)"
+                  value: "reset_timeout"
+              multiple: false
+              sort: false
+              custom_value: false
+              mode: list
+
+        reset_override_time:
+          name: "🗑️ Time to reset manual override"
+          description: "At what time do you want the manual detection to be reset?"
+          default: "00:01:00"
+          selector:
+            time: {}
+
+        reset_override_timeout:
+          name: "🗑️ Number of minutes until reset manual override"
+          description: "After how many minutes should it be reset?"
+          default: 360
+          selector:
+            number:
+              min: 0
+              max: 1440
+              unit_of_measurement: minutes
+
+    delay_section:
+      name: "Delay Settings"
+      icon: mdi:timer-outline
+      collapsed: true
+      input:
+        drive_delay_fix:
+          name: "🕛 Fixed Drive Delay"
+          description: >-
+            Fixed drive delay to avoid radio interferences.
+            <br /><br />`Optional`
+          default: 0
+          selector:
+            number:
+              min: 0.0
+              max: 600.0
+              unit_of_measurement: seconds
+              step: 1.0
+              mode: slider
+
+        drive_delay_random:
+          name: "🕛 Random Drive Delay"
+          description: >-
+            Additional random delay.
+            <br /><br />`Optional`
+          default: 5
+          selector:
+            number:
+              min: 0.0
+              max: 600.0
+              unit_of_measurement: seconds
+              step: 1.0
+              mode: slider
+
+        tilt_delay:
+          name: "🕛 Tilt Delay"
+          description: >-
+            Delay between <em>set_cover_position</em> and <em>set_cover_tilt_position</em>.
+            Only necessary when using the tilt functions.
+            This separates the two commands in terms of time.
+            <br /><br />`Optional`
+          default: 0
+          selector:
+            number:
+              min: 0.0
+              max: 600.0
+              unit_of_measurement: seconds
+              step: 1.0
+              mode: slider
+
     condition_section:
       name: "Additional Conditions"
       description: >-

--- a/blueprints/automation/cover_control_automation_beta.yaml
+++ b/blueprints/automation/cover_control_automation_beta.yaml
@@ -1244,13 +1244,17 @@ blueprint:
             Overwrite mode for opening and unplannend closing.
             <details>
             <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
+
+
             This switch can be used to override the automatic opening of the cover.
             If this sensor (input_boolean or binary_sensor) is set to ON, the cover will not open automatically.
+
             This can be used e.g. to define a resident for the room. In this case, the cover only opens when the resident is no longer asleep.
             <br />
             For this it is necessary to use a boolean sensor that returns TRUE/ON for sleeping and FALSE/OFF for non-sleeping.
             <br />
             The cover will also close (without checking the defined times) if this sensor switches to TRUE/ON (because the resident is sleeping).
+
             </details>
             <br /><code>Optional</code>
           default: []
@@ -1287,18 +1291,30 @@ blueprint:
           name: "🖐️ Ignoring/override after manual position changes"
           description: >-
             Ignore or override the following actions after manual position changes.
+
             <details>
             <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
+
+
             Ultimately, this means that the cover will not be opened, closed, etc.
             if a manual interaction has previously been made, e.g. using a wall switch.
+
+
             The reason behind this is that the human being wins with his decision and his
             conscious decision is weighted higher than the upcoming action of the automation.
+
+
             As soon as a cover has been moved manually, the status is recorded in the Cover Status Helper.
             This usually means that a person has deliberately decided against a status.
+
               - If option is not activated: The covers are moved even if a manual correction has been made.
               - If option is activated: The action to open, close, etc. is not performed because a conscious decision was made to do otherwise due to a manual intervention.
+
+
             A Cover Status Helper is required!
+
             </details>
+
           default: []
           selector:
             select:
@@ -1463,8 +1479,6 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>shading-OUT-automation</ins> of the cover.
             This can be useful if you want to temporarily disable automation (e.g. because of control by other automations).
-            <br /><br />`Optional`
-            <br /><br />`Shading`
           default: []
           selector:
             condition: {}

--- a/blueprints/automation/cover_control_automation_beta.yaml
+++ b/blueprints/automation/cover_control_automation_beta.yaml
@@ -718,6 +718,28 @@ blueprint:
           selector:
             time: {}
 
+        time_control_alarm:
+          name: "⏲️ Use an additional timestamp sensor"
+          description: >-
+            You can specify an additional timestamp sensor (e.g. the alarm sensor of your phone).
+            This will open the cover no matter what time it is.
+            This is usefull, if your working time changes and you are using your phone to set an alarm every day.
+          default: false
+          selector:
+            boolean: {}
+
+        time_alarm_helper:
+          name: "⏲️ Cover driving time alarm helper"
+          description: >-
+            If enabled above, please select a timestamp sensor here.
+          default: []
+          selector:
+            entity:
+              filter:
+                domain: sensor
+                device_class: timestamp
+              multiple: false
+
     brightness_section:
       name: "Brightness Configuration"
       description: >-
@@ -1211,192 +1233,6 @@ blueprint:
               max: 3600
               unit_of_measurement: seconds
 
-    resident_section:
-      name: "Resident Settings"
-      icon: mdi:human-male-female
-      collapsed: true
-      input:
-        resident_sensor:
-          name: "🛌 Resident Mode"
-          description: >-
-            Overwrite mode for opening and unplannend closing.
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
-
-
-            This switch can be used to override the automatic opening of the cover.
-            If this sensor (input_boolean or binary_sensor) is set to ON, the cover will not open automatically.
-
-            This can be used e.g. to define a resident for the room. In this case, the cover only opens when the resident is no longer asleep.
-            <br />
-            For this it is necessary to use a boolean sensor that returns TRUE/ON for sleeping and FALSE/OFF for non-sleeping.
-            <br />
-            The cover will also close (without checking the defined times) if this sensor switches to TRUE/ON (because the resident is sleeping).
-
-            </details>
-            <br /><code>Optional</code>
-          default: []
-          selector:
-            entity:
-              domain:
-                - input_boolean
-                - binary_sensor
-
-        resident_config:
-          name: "🛌 Resident Configuration"
-          description: "A few fine adjustments"
-          default: []
-          selector:
-            select:
-              options:
-                - label: "🔻 Automatic closing due to the resident sensor"
-                  value: "resident_closing_enabled"
-                - label: "🥵 Allow sun protection when resident is still present"
-                  value: "resident_shading_enabled"
-              multiple: true
-              sort: false
-              custom_value: false
-              mode: list
-
-    override_section:
-      name: "Manual Override"
-      description: >-
-        <center><code>A Cover Status Helper is required!</code></center><br />
-      icon: mdi:debug-step-over
-      collapsed: true
-      input:
-        ignore_after_manual_config:
-          name: "🖐️ Ignoring/override after manual position changes"
-          description: >-
-            Ignore or override the following actions after manual position changes.
-
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
-
-
-            Ultimately, this means that the cover will not be opened, closed, etc.
-            if a manual interaction has previously been made, e.g. using a wall switch.
-
-
-            The reason behind this is that the human being wins with his decision and his
-            conscious decision is weighted higher than the upcoming action of the automation.
-
-
-            As soon as a cover has been moved manually, the status is recorded in the Cover Status Helper.
-            This usually means that a person has deliberately decided against a status.
-
-              - If option is not activated: The covers are moved even if a manual correction has been made.
-              - If option is activated: The action to open, close, etc. is not performed because a conscious decision was made to do otherwise due to a manual intervention.
-
-
-            A Cover Status Helper is required!
-
-            </details>
-
-          default: []
-          selector:
-            select:
-              options:
-                - label: "🔼 Ignore/override next automatic opening after manual position changes"
-                  value: "ignore_opening_after_manual"
-                - label: "🔻 Ignore/override next automatic closing after manual position changes"
-                  value: "ignore_closing_after_manual"
-                - label: "💨 Ignore/override next automatic ventilation after manual position changes"
-                  value: "ignore_ventilation_after_manual"
-                - label: "🥵 Ignore/override next automatic sun shading after manual position changes"
-                  value: "ignore_shading_after_manual"
-              multiple: true
-              sort: false
-              custom_value: false
-              mode: list
-
-        reset_override_config:
-          name: "🗑️ Reset manual override"
-          description: >-
-            If the detection of the manual position change was activated above, you may need a way to reset this status.
-            Otherwise, the next cover movements will be permanently ignored or overridden.
-            Or you have not activated an individual action, e.g. when closing the covers, which resets the status.
-          default: reset_disabled
-          selector:
-            select:
-              options:
-                - label: "No timed reset for manual override"
-                  value: "reset_disabled"
-                - label: "Reset at a specified time (see below)"
-                  value: "reset_time"
-                - label: "Reset after a timeout in minutes (see below)"
-                  value: "reset_timeout"
-              multiple: false
-              sort: false
-              custom_value: false
-              mode: list
-
-        reset_override_time:
-          name: "🗑️ Time to reset manual override"
-          description: "At what time do you want the manual detection to be reset?"
-          default: "00:01:00"
-          selector:
-            time: {}
-
-        reset_override_timeout:
-          name: "🗑️ Number of minutes until reset manual override"
-          description: "After how many minutes should it be reset?"
-          default: 360
-          selector:
-            number:
-              min: 0
-              max: 1440
-              unit_of_measurement: minutes
-
-    delay_section:
-      name: "Delay Settings"
-      icon: mdi:timer-outline
-      collapsed: true
-      input:
-        drive_delay_fix:
-          name: "🕛 Fixed Drive Delay"
-          description: >-
-            Fixed drive delay to avoid radio interferences.
-            <br /><br />`Optional`
-          default: 0
-          selector:
-            number:
-              min: 0.0
-              max: 600.0
-              unit_of_measurement: seconds
-              step: 1.0
-              mode: slider
-
-        drive_delay_random:
-          name: "🕛 Random Drive Delay"
-          description: >-
-            Additional random delay.
-            <br /><br />`Optional`
-          default: 5
-          selector:
-            number:
-              min: 0.0
-              max: 600.0
-              unit_of_measurement: seconds
-              step: 1.0
-              mode: slider
-
-        tilt_delay:
-          name: "🕛 Tilt Delay"
-          description: >-
-            Delay between <em>set_cover_position</em> and <em>set_cover_tilt_position</em>.
-            Only necessary when using the tilt functions.
-            This separates the two commands in terms of time.
-            <br /><br />`Optional`
-          default: 0
-          selector:
-            number:
-              min: 0.0
-              max: 600.0
-              unit_of_measurement: seconds
-              step: 1.0
-              mode: slider
-
     condition_section:
       name: "Additional Conditions"
       description: >-
@@ -1457,6 +1293,8 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>shading-OUT-automation</ins> of the cover.
             This can be useful if you want to temporarily disable automation (e.g. because of control by other automations).
+            <br /><br />`Optional`
+            <br /><br />`Shading`
           default: []
           selector:
             condition: {}
@@ -1656,6 +1494,7 @@ trigger_variables:
   # Time controls
   time_control: !input time_control
   time_schedule_helper: !input time_schedule_helper
+  time_alarm_helper: !input time_alarm_helper
 
   # Shading
   shading_brightness_sensor: !input shading_brightness_sensor
@@ -1683,6 +1522,7 @@ trigger_variables:
   is_ventilation_enabled: "{{ 'auto_ventilate_enabled' in auto_options }}"
   is_time_field_enabled: "{{ 'time_control_input' in time_control }}"
   is_schedule_helper_enabled: "{{ 'time_control_schedule' in time_control and time_schedule_helper != [] }}"
+  is_alarm_helper_enabled: !input time_control_alarm
   is_time_control_disabled: "{{ 'time_control_disabled' in time_control }}"
 
   reset_override_config: !input reset_override_config
@@ -1932,24 +1772,30 @@ trigger:
     id: "t_open_3"
 
   - platform: template
+    value_template: "{{ as_timestamp(now()) - 10 <= as_timestamp(states(time_alarm_helper)) <= as_timestamp(now()) + 10 }}"
+    # value_template: "{{ as_timestamp(now()) == as_timestamp(states(time_alarm_helper)) }}"
+    enabled: "{{ is_alarm_helper_enabled and time_alarm_helper != [] }}"
+    id: "t_open_4"
+
+  - platform: template
     value_template: "{{ states(default_brightness_sensor) | float(default=brightness_up) > brightness_up }}"
     for:
       seconds: !input brightness_time_duration
     enabled: "{{ is_brightness_enabled and default_brightness_sensor != [] }}"
-    id: "t_open_4"
+    id: "t_open_5"
 
   - platform: template
     value_template: "{{ state_attr(default_sun_sensor, 'elevation') | float(default=sun_elevation_up) > sun_elevation_up }}"
     for:
       seconds: !input sun_time_duration
     enabled: "{{ is_sun_elevation_enabled and default_sun_sensor != [] }}"
-    id: "t_open_5"
+    id: "t_open_6"
 
   - platform: state
     entity_id: !input resident_sensor
     from: "on"
     to: "off"
-    id: "t_open_6"
+    id: "t_open_7"
 
   - platform: state
     entity_id: !input auto_up_force
@@ -2163,8 +2009,9 @@ action:
           - "t_shading_start_1"
           - "t_open_1"
           - "t_open_3"
+          - "t_open_4"
     then:
-      - service: weather.get_forecasts
+      - action: weather.get_forecasts
         target:
           entity_id: !input shading_forecast_sensor
         data:
@@ -2179,7 +2026,7 @@ action:
           - '{{ not states(cover_status_helper) | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") }}'
           - '{{ states(cover_status_helper) in ["unavailable", "none", "unknown"] }}'
     then:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: !input cover_status_helper
           value: |
@@ -2202,7 +2049,7 @@ action:
       - "{{ is_status_helper_enabled }}"
       - "{{ (states(cover_status_helper)|from_json).v != 4 }}" # TODO Remove locked and upgrade to v5
     then:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: !input cover_status_helper
           value: |
@@ -2240,6 +2087,7 @@ action:
               - "t_open_4"
               - "t_open_5"
               - "t_open_6"
+              - "t_open_7"
           - and:
               - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
               - "{{ auto_ventilate_force == [] or auto_ventilate_force != [] and is_state(auto_ventilate_force, ['false', 'off']) }}"
@@ -2270,7 +2118,13 @@ action:
                   - condition: trigger
                     id:
                       - "t_open_3" # Scheduler -> true
-                      - "t_open_6" # Resident -> false
+                      - "t_open_7" # Resident -> false
+              - and: # Opening - Alarm is ringing
+                  - "{{ is_alarm_helper_enabled }}"
+                  - "{{ time_alarm_helper != [] }}"
+                  - condition: trigger
+                    id:
+                      - "t_open_4"
               - and: # Opening - Up early reached or schedule helper is on and brightness/sun above minimum
                   - or:
                       - and:
@@ -2306,7 +2160,7 @@ action:
                   - "{{ is_cover_helper_shaded }}"
                   - "{{ is_status_helper_enabled }}"
                 sequence:
-                  - service: input_text.set_value # Set shading to true, but do not overwrite shading time
+                  - action: input_text.set_value # Set shading to true, but do not overwrite shading time
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2332,7 +2186,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to shading position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input shading_position
                               target:
@@ -2344,7 +2198,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input shading_tilt_position
                                   target:
@@ -2363,7 +2217,7 @@ action:
                 if:
                   - "{{ is_status_helper_enabled }}"
                 then:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2392,13 +2246,13 @@ action:
                             - "{{ open_position == 100 }}"
                           then:
                             - alias: "Moving the cover to open position"
-                              service: cover.open_cover
+                              action: cover.open_cover
                               data: {}
                               target:
                                 entity_id: "{{ repeat.item }}"
                           else:
                             - alias: "Moving the cover to open position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input open_position
                               target:
@@ -2410,7 +2264,7 @@ action:
                               delay:
                                 seconds: !input tilt_delay
                             - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
+                              action: cover.set_cover_tilt_position
                               data:
                                 tilt_position: !input open_tilt_position
                               target:
@@ -2512,7 +2366,7 @@ action:
                           - "{{ contact_window_tilted != [] }}"
                           - "{{ is_state(contact_window_tilted, ['true', 'on']) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2549,7 +2403,7 @@ action:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2575,7 +2429,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to ventilate position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input ventilate_position
                               target:
@@ -2587,7 +2441,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input ventilate_tilt_position
                                   target:
@@ -2620,7 +2474,7 @@ action:
                   - if:
                       - "{{ is_status_helper_enabled }}"
                     then:
-                      - service: input_text.set_value
+                      - action: input_text.set_value
                         data:
                           entity_id: !input cover_status_helper # Manual not set here! Keep old value
                           value: |
@@ -2649,7 +2503,7 @@ action:
               - if:
                   - "{{ is_status_helper_enabled }}"
                 then:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2678,13 +2532,13 @@ action:
                             - "{{ close_position == 0 }}"
                           then:
                             - alias: "Moving the cover to close position"
-                              service: cover.close_cover
+                              action: cover.close_cover
                               data: {}
                               target:
                                 entity_id: "{{ repeat.item }}"
                           else:
                             - alias: "Moving the cover to close position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input close_position
                               target:
@@ -2696,7 +2550,7 @@ action:
                               delay:
                                 seconds: !input tilt_delay
                             - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
+                              action: cover.set_cover_tilt_position
                               data:
                                 tilt_position: !input close_tilt_position
                               target:
@@ -2726,6 +2580,7 @@ action:
               - "t_shading_start_1"
               - "t_open_1" # time_up_early
               - "t_open_3" # schedule helper state change
+              - "t_open_4" # alarm is ringing
           - and:
               - "{{ auto_up_force == [] or auto_up_force != [] and is_state(auto_up_force, ['false', 'off']) }}"
               - "{{ auto_down_force == [] or auto_down_force != [] and is_state(auto_down_force, ['false', 'off']) }}"
@@ -2782,7 +2637,7 @@ action:
                           - "{{ contact_window_tilted != [] }}"
                           - "{{ is_state(contact_window_tilted, ['true', 'on']) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2822,7 +2677,7 @@ action:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2848,7 +2703,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to shading position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input shading_position
                               target:
@@ -2860,7 +2715,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input shading_tilt_position
                                   target:
@@ -2878,7 +2733,7 @@ action:
                 conditions:
                   - "{{ is_cover_helper_closed }}" # At this point, the times for shading are not taken into account so that the correct value is available when the cover is opened.
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2953,7 +2808,7 @@ action:
                           - "{{ is_state(contact_window_tilted, ['true', 'on']) }}"
                           - "{{ lockout_tilted_when_shading_ends }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -2992,7 +2847,7 @@ action:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3018,7 +2873,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to ventilate position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input ventilate_position
                               target:
@@ -3030,7 +2885,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input ventilate_tilt_position
                                   target:
@@ -3049,7 +2904,7 @@ action:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
               - alias: "Move cover to open position"
-                service: input_text.set_value
+                action: input_text.set_value
                 data:
                   entity_id: !input cover_status_helper
                   value: |
@@ -3078,13 +2933,13 @@ action:
                             - "{{ open_position == 100 }}"
                           then:
                             - alias: "Moving the cover to open position"
-                              service: cover.open_cover
+                              action: cover.open_cover
                               data: {}
                               target:
                                 entity_id: "{{ repeat.item }}"
                           else:
                             - alias: "Moving the cover to open position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input open_position
                               target:
@@ -3096,7 +2951,7 @@ action:
                               delay:
                                 seconds: !input tilt_delay
                             - alias: "Moving the cover to tilt position"
-                              service: cover.set_cover_tilt_position
+                              action: cover.set_cover_tilt_position
                               data:
                                 tilt_position: !input open_tilt_position
                               target:
@@ -3153,7 +3008,7 @@ action:
                     id:
                       - "t_contact_opened_on"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3178,13 +3033,13 @@ action:
                                 - "{{ open_position == 100 }}"
                               then:
                                 - alias: "Moving the cover to open position"
-                                  service: cover.open_cover
+                                  action: cover.open_cover
                                   data: {}
                                   target:
                                     entity_id: "{{ repeat.item }}"
                               else:
                                 - alias: "Moving the cover to open position"
-                                  service: cover.set_cover_position
+                                  action: cover.set_cover_position
                                   data:
                                     position: !input open_position
                                   target:
@@ -3196,7 +3051,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input open_tilt_position
                                   target:
@@ -3218,7 +3073,7 @@ action:
                       - "{{ (current_position | int(default=101) < ventilate_position) }}"
                       - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) >= ventilate_position) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3239,7 +3094,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to ventilate position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input ventilate_position
                               target:
@@ -3251,7 +3106,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input ventilate_tilt_position
                                   target:
@@ -3317,7 +3172,7 @@ action:
                       - "{{ in_shading_position }}"
                       - "{{ (current_position | int(default=101) == shading_position) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3343,7 +3198,7 @@ action:
                           for_each: "{{ blind_entities|list }}"
                           sequence:
                             - alias: "Moving the cover to shading position"
-                              service: cover.set_cover_position
+                              action: cover.set_cover_position
                               data:
                                 position: !input shading_position
                               target:
@@ -3355,7 +3210,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input shading_tilt_position
                                   target:
@@ -3378,7 +3233,7 @@ action:
                       - "{{ (current_position | int(default=101) >= open_position) }}"
                       - "{{ (current_position | int(default=101) == 100) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3407,13 +3262,13 @@ action:
                                 - "{{ open_position == 100 }}"
                               then:
                                 - alias: "Moving the cover to open position"
-                                  service: cover.open_cover
+                                  action: cover.open_cover
                                   data: {}
                                   target:
                                     entity_id: "{{ repeat.item }}"
                               else:
                                 - alias: "Moving the cover to open position"
-                                  service: cover.set_cover_position
+                                  action: cover.set_cover_position
                                   data:
                                     position: !input open_position
                                   target:
@@ -3425,7 +3280,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input open_tilt_position
                                   target:
@@ -3447,7 +3302,7 @@ action:
                       - "{{ (current_position | int(default=101) <= close_position) }}"
                       - "{{ (current_position | int(default=101) == 0) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3476,13 +3331,13 @@ action:
                                 - "{{ close_position == 0 }}"
                               then:
                                 - alias: "Moving the cover to close position"
-                                  service: cover.close_cover
+                                  action: cover.close_cover
                                   data: {}
                                   target:
                                     entity_id: "{{ repeat.item }}"
                               else:
                                 - alias: "Moving the cover to close position"
-                                  service: cover.set_cover_position
+                                  action: cover.set_cover_position
                                   data:
                                     position: !input close_position
                                   target:
@@ -3494,7 +3349,7 @@ action:
                                   delay:
                                     seconds: !input tilt_delay
                                 - alias: "Moving the cover to tilt position"
-                                  service: cover.set_cover_tilt_position
+                                  action: cover.set_cover_tilt_position
                                   data:
                                     tilt_position: !input close_tilt_position
                                   target:
@@ -3521,7 +3376,7 @@ action:
           - if:
               - "{{ is_status_helper_enabled }}"
             then:
-              - service: input_text.set_value
+              - action: input_text.set_value
                 data:
                   entity_id: !input cover_status_helper
                   value: |
@@ -3550,13 +3405,13 @@ action:
                         - "{{ open_position == 100 }}"
                       then:
                         - alias: "Moving the cover to open position"
-                          service: cover.open_cover
+                          action: cover.open_cover
                           data: {}
                           target:
                             entity_id: "{{ repeat.item }}"
                       else:
                         - alias: "Moving the cover to open position"
-                          service: cover.set_cover_position
+                          action: cover.set_cover_position
                           data:
                             position: !input open_position
                           target:
@@ -3568,7 +3423,7 @@ action:
                           delay:
                             seconds: !input tilt_delay
                         - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+                          action: cover.set_cover_tilt_position
                           data:
                             tilt_position: !input open_tilt_position
                           target:
@@ -3595,7 +3450,7 @@ action:
           - if:
               - "{{ is_status_helper_enabled }}"
             then:
-              - service: input_text.set_value
+              - action: input_text.set_value
                 data:
                   entity_id: !input cover_status_helper
                   value: |
@@ -3624,13 +3479,13 @@ action:
                         - "{{ close_position == 0 }}"
                       then:
                         - alias: "Moving the cover to close position"
-                          service: cover.close_cover
+                          action: cover.close_cover
                           data: {}
                           target:
                             entity_id: "{{ repeat.item }}"
                       else:
                         - alias: "Moving the cover to close position"
-                          service: cover.set_cover_position
+                          action: cover.set_cover_position
                           data:
                             position: !input close_position
                           target:
@@ -3642,7 +3497,7 @@ action:
                           delay:
                             seconds: !input tilt_delay
                         - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+                          action: cover.set_cover_tilt_position
                           data:
                             tilt_position: !input close_tilt_position
                           target:
@@ -3667,7 +3522,7 @@ action:
           - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
           - "{{ is_status_helper_enabled }}"
         sequence:
-          - service: input_text.set_value
+          - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper
               value: |
@@ -3693,7 +3548,7 @@ action:
                   for_each: "{{ blind_entities|list }}"
                   sequence:
                     - alias: "Moving the cover to ventilate position"
-                      service: cover.set_cover_position
+                      action: cover.set_cover_position
                       data:
                         position: !input ventilate_position
                       target:
@@ -3705,7 +3560,7 @@ action:
                           delay:
                             seconds: !input tilt_delay
                         - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+                          action: cover.set_cover_tilt_position
                           data:
                             tilt_position: !input ventilate_tilt_position
                           target:
@@ -3730,7 +3585,7 @@ action:
           - "{{ auto_shading_start_force != [] and is_state(auto_shading_start_force, ['true', 'on']) }}"
           - "{{ is_status_helper_enabled }}"
         sequence:
-          - service: input_text.set_value
+          - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper
               value: |
@@ -3756,7 +3611,7 @@ action:
                   for_each: "{{ blind_entities|list }}"
                   sequence:
                     - alias: "Moving the cover to shading position"
-                      service: cover.set_cover_position
+                      action: cover.set_cover_position
                       data:
                         position: !input shading_position
                       target:
@@ -3768,7 +3623,7 @@ action:
                           delay:
                             seconds: !input tilt_delay
                         - alias: "Moving the cover to tilt position"
-                          service: cover.set_cover_tilt_position
+                          action: cover.set_cover_tilt_position
                           data:
                             tilt_position: !input shading_tilt_position
                           target:
@@ -3808,7 +3663,7 @@ action:
                       - "{{ (current_position | int(default=101) >= open_position) }}"
                       - "{{ (current_position | int(default=101) == 100) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3834,7 +3689,7 @@ action:
                   - "{{ in_ventilate_position }}"
                   - "{{ not in_open_position }}" # If ventilate_position and open_position are too close together, the ventilation-status should not be assigned.
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3859,7 +3714,7 @@ action:
                   - "{{ is_shading_enabled }}"
                   - "{{ in_shading_position }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3889,7 +3744,7 @@ action:
                       - "{{ (current_position | int(default=101) <= close_position) }}"
                       - "{{ (current_position | int(default=101) == 0) }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3917,7 +3772,7 @@ action:
                       - "{{ is_ventilation_enabled and in_ventilate_position }}"
                       - "{{ is_shading_enabled and in_shading_position }}"
                 sequence:
-                  - service: input_text.set_value
+                  - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
                       value: |
@@ -3951,7 +3806,7 @@ action:
               - "t_manual_2"
               - "t_manual_3"
         sequence:
-          - service: input_text.set_value
+          - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper
               value: |
@@ -3982,7 +3837,7 @@ action:
         sequence:
           - delay:
               seconds: "{{ (range(0, 60)|random|int) }}"
-          - service: input_text.set_value
+          - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper
               value: |
@@ -4008,7 +3863,7 @@ action:
           - if:
               - "{{ not is_time_control_disabled and (today_at(time_up_early) >= today_at(time_up_late)) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: time_up_early should be earlier than time_up_late - {{this.entity_id}}"
@@ -4016,7 +3871,7 @@ action:
           - if:
               - "{{ not is_time_control_disabled and (today_at(time_up_early_non_workday) >= today_at(time_up_late_non_workday)) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: time_up_early_non_workday should be earlier than time_up_late_non_workday - {{this.entity_id}}"
@@ -4024,7 +3879,7 @@ action:
           - if:
               - "{{ not is_time_control_disabled and (today_at(time_down_early) >= today_at(time_down_late)) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: time_down_early should be earlier than time_down_late - {{this.entity_id}}"
@@ -4032,7 +3887,7 @@ action:
           - if:
               - "{{ not is_time_control_disabled and (today_at(time_down_early_non_workday) >= today_at(time_down_late_non_workday)) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: time_down_early_non_workday should be earlier than time_down_late_non_workday - {{this.entity_id}}"
@@ -4041,7 +3896,7 @@ action:
           - if:
               - "{{ shading_azimuth_start >= shading_azimuth_end }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: shading_azimuth_start should be lower than shading_azimuth_end - {{this.entity_id}}"
@@ -4049,7 +3904,7 @@ action:
           - if:
               - "{{ shading_elevation_min >= shading_elevation_max }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: shading_elevation_min should be lower than - {{this.entity_id}}"
@@ -4057,7 +3912,7 @@ action:
           - if:
               - "{{ shading_sun_brightness_start <= shading_sun_brightness_end }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: shading_sun_brightness_start should be higher than shading_sun_brightness_end - {{this.entity_id}}"
@@ -4067,7 +3922,7 @@ action:
           # - if:
           #     - "{{ (open_position - position_tolerance) <= (close_position + position_tolerance) }}"
           #   then:
-          #     - service: system_log.write
+          #     - action: system_log.write
           #       data:
           #         level: "{{ check_config_debuglevel }}"
           #         message: "Cover Control Automation (CCA): Config issue: open_position should be higher than close_position - {{this.entity_id}}"
@@ -4075,7 +3930,7 @@ action:
           # - if:
           #     - "{{ (open_position - position_tolerance) <= (ventilate_position + position_tolerance) }}"
           #   then:
-          #     - service: system_log.write
+          #     - action: system_log.write
           #       data:
           #         level: "{{ check_config_debuglevel }}"
           #         message: "Cover Control Automation (CCA): Config issue: open_position should be higher than ventilate_position - {{this.entity_id}}"
@@ -4083,7 +3938,7 @@ action:
           # - if:
           #     - "{{ (close_position + position_tolerance) >= (ventilate_position - position_tolerance) }}"
           #   then:
-          #     - service: system_log.write
+          #     - action: system_log.write
           #       data:
           #         level: "{{ check_config_debuglevel }}"
           #         message: "Cover Control Automation (CCA): Config issue: close_position should be lower than ventilate_position - {{this.entity_id}}"
@@ -4091,7 +3946,7 @@ action:
           # - if:
           #     - "{{ (shading_position - position_tolerance) <= (close_position + position_tolerance)}}"
           #   then:
-          #     - service: system_log.write
+          #     - action: system_log.write
           #       data:
           #         level: "{{ check_config_debuglevel }}"
           #         message: "Cover Control Automation (CCA): Config issue: shading_position should be higher than close_position - {{this.entity_id}}"
@@ -4099,7 +3954,7 @@ action:
           # - if:
           #     - "{{ (shading_position + position_tolerance) >= (open_position - position_tolerance) }}"
           #   then:
-          #     - service: system_log.write
+          #     - action: system_log.write
           #       data:
           #         level: "{{ check_config_debuglevel }}"
           #         message: "Cover Control Automation (CCA): Config issue: shading_position should be lower than open_position - {{this.entity_id}}"
@@ -4107,7 +3962,7 @@ action:
           - if:
               - "{{ ( (resident_sensor != [] ) and (not is_state(resident_sensor, ['false', 'off','true', 'on'])) ) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: resident_sensor is only allowed to be on/off/true/false - {{this.entity_id}}"
@@ -4116,7 +3971,7 @@ action:
           - if:
               - "{{ state_attr(blind, 'current_position') is none }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: cover is missing attribute current_position - {{this.entity_id}}"
@@ -4125,7 +3980,7 @@ action:
           - if:
               - "{{ state_attr(default_sun_sensor, 'elevation') is none }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: sun sensor is missing attribute elevation - {{this.entity_id}}"
@@ -4133,7 +3988,7 @@ action:
           - if:
               - "{{ state_attr(default_sun_sensor, 'azimuth') is none }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: sun sensor is missing attribute azimuth - {{this.entity_id}}"
@@ -4144,7 +3999,7 @@ action:
                   - "{{ is_brightness_enabled and default_brightness_sensor == [] }}"
                   - "{{ is_brightness_enabled and not is_number(states(default_brightness_sensor)) }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: brightness sensor not defined or state is not numeric - {{this.entity_id}}"
@@ -4154,7 +4009,7 @@ action:
               - "{{ 'cover_helper_enabled' in cover_status_options }}"
               - "{{ state_attr(cover_status_helper, 'max') < 254 }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: Wrong length of the cover status helper - {{this.entity_id}}"
@@ -4166,7 +4021,7 @@ action:
                   - "{{ is_ventilation_enabled }}"
               - "{{ not is_status_helper_enabled }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: Shading, ventilation and lockout protection require a cover status helper to be configured - {{this.entity_id}}"
@@ -4176,7 +4031,7 @@ action:
               - "{{ is_schedule_helper_enabled }}"
               - "{{ time_schedule_helper == [] }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: Schedule mode selected but no schedule helper specified - {{this.entity_id}}"
@@ -4185,7 +4040,7 @@ action:
           - if:
               - "{{ [in_open_position, in_close_position, in_shading_position, in_ventilate_position].count(True) > 1 }}"
             then:
-              - service: system_log.write
+              - action: system_log.write
                 data:
                   level: "{{ check_config_debuglevel }}"
                   message: "Cover Control Automation (CCA): Config issue: Please revise the position values ​​and take the tolerance values ​​into account. The values ​​must not overlap - {{this.entity_id}}"


### PR DESCRIPTION
I've added an alarm trigger. At the moment, I'm still testing but it seems to work.
This can be helpful, if you have to wake-up at different times every day.
I would recommended to use the "sensor.\<phone\>_next_alarm" sensor (provided by the Home Assistant app).

It is implemented to have the exact same functionality as the time schedule helper.
I also changed `service:` to `action:` because this is the newest standard.

I'm not happy with the naming, but I tried to follow the existing names, variables and triggers.
I'm also not happy to use a template trigger, because 
```
- platform: time
  at: !input time_alarm_helper
```
would be the resource friendly version, but this causes the condition
```
'{{ state_attr(this.entity_id,''current'') | int(99) == 0 }}'
```
to throw an error. Why does this condition exist?