### PR TITLE
Added check for a shading shading start/end time > 0

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2141,7 +2141,8 @@ trigger:
         states(cover_status_helper) | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") and
         states(cover_status_helper) not in ["unavailable", "none", "unknown"] and
         states(cover_status_helper)|from_json|regex_search('shading') and
-        (states(cover_status_helper)|from_json).shading.p is defined
+        (states(cover_status_helper)|from_json).shading.p is defined and
+        (states(cover_status_helper)|from_json).shading.p > 0
       %}
         {{ now() >= ( (states(cover_status_helper)|from_json).shading.p) | as_datetime | as_local }}
       {% endif %}
@@ -2199,7 +2200,8 @@ trigger:
         states(cover_status_helper) | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") and
         states(cover_status_helper) not in ["unavailable", "none", "unknown"] and
         states(cover_status_helper)|from_json|regex_search('shading') and
-        (states(cover_status_helper)|from_json).shading.q is defined
+        (states(cover_status_helper)|from_json).shading.q is defined and
+        (states(cover_status_helper)|from_json).shading.q > 0
       %}
         {{ now() >= ( (states(cover_status_helper)|from_json).shading.q) | as_datetime | as_local }}
       {% endif %}


### PR DESCRIPTION
I have a setup with lock protection/ventialtion and shading configured.

When the shading is executed, in the helper for shading "p" and "q" are set to 0. 

But than directly the t_shading_start trigger is executed because it only checks for "p" defined, which is also the case for p=0. 

When I got the new logic right. adding a check for p (or q for shading end) > 0 clould help (at least now the binds stay shaded in my setup).