### PR TITLE
Fix description typo

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1717,7 +1717,7 @@ blueprint:
           name: "✔️ Check Configuration"
           description: >-
             With this boolean, you can enable or disable the basic plausibility check for the configuration.
-            he check only takes place if the automation is executed manually.
+            The check only takes place if the automation is executed manually.
           default: false
           selector:
             boolean: {}


### PR DESCRIPTION
Fix a typo in the description of the configcheck section.