### PR TITLE
Merge Dev-branch

### DIFF
--- a/blueprints/automation/CHANGELOG.md
+++ b/blueprints/automation/CHANGELOG.md
@@ -319,3 +319,16 @@
   - Added: Additional Condition For Disabling Ventilation
   - Fixed: Small scheduler fix and description also updated
   - Update: Update of the logic and documentation for the resident sensor #158
+
+2025.04.18:
+  - Updated: Just to be more bulletproof, the tilt position control can now be specifically switched on or off. Please activate if necessary. #163
+  - Updated: There is no default value for "Sun Shading Forecast Temperature" here now. To not compare the forecast temperature, leave this field empty. #179
+  - Added: Allow entities of the switch domain as resident sensor or with the force entities #167
+  - Added: New additional actions: Commands can now be executed before opening, closing, shading and ventilation #166
+  - Fixed: Fixed problems resetting manual override #184
+  - Fixed: Make sure that the reset of the manual override is only executed once #178
+  - Fixed: Problems with lockout protection and partial ventilation solved #181
+  - Fixed: There was no latest time for closing the cover when the scheduler was used with sun/brightness #170
+  - Added: Added Sun elevation examples into the description #175
+  - Added: New feature 'Allow opening the cover when resident is still present' #192
+  - Breaking change: Please reconfigure "Allow sun protection when resident is still present" ('resident_shading_enabled' was renamed)

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -498,53 +498,6 @@ blueprint:
       icon: mdi:image-filter-tilt-shift
       collapsed: true
       input:
-        cover_action:
-          name: Cover Action 1
-          selector:
-            object: {}
-          default: >
-            action: cover.set_cover_position
-
-            target:
-              entity_id: "{{ repeat.item }}"
-            data:
-              position: "{{ open_position }}"
-
-        cover_action2:
-          name: Cover Action 2
-          selector:
-            template:
-          default: >
-            action: cover.set_cover_position
-
-            target:
-              entity_id: {{ repeat.item }}
-            data:
-              position: {{ open_position }}
-
-        cover_action3:
-          name: Cover Action 3
-          selector:
-            template:
-          default:
-            "{{ backup_type | title }}Backup: {{\n  now().strftime(\n    \"%A,
-            \"\n    ~ iif(backup_type == \"hourly\", \"%-I:%M %p, \", \"\")\n    ~ \"%B
-            %-d, %Y\"\n  )\n}}\n{# HourlyBackup: Monday, 3:04 PM, January 2, 2006 #}\n{#
-            DailyBackup: Monday, January 2, 2006 #}\n"
-
-        # action: homematicip_local.set_cover_combined_position
-        # data:
-        #   position: {{ open_position }}
-        #   tilt_position: {{ open_tilt_position }}
-        # target:
-        #   entity_id: {{ repeat.item }}
-
-        # action: script.cover_position_tilt
-        # data:
-        #   entity_id: {{ repeat.item }}
-        #   position: {{ open_position }}
-        #   tilt_position: {{ open_tilt_position }}
-
         cover_tilt_config:
           name: "📐 Tilt Position Feature"
           description: >-

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -75,11 +75,17 @@ blueprint:
     **Full Changelog**: [CHANGELOG.md](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/CHANGELOG.md)
 
     2025.04.18:
+      - Updated: Just to be more bulletproof, the tilt position control can now be specifically switched on or off. Please activate if necessary. #163
+      - Updated: There is no default value for "Sun Shading Forecast Temperature" here now. To not compare the forecast temperature, leave this field empty. #179
       - Added: Allow entities of the switch domain as resident sensor or with the force entities #167
-      - Update: Just to be more bulletproof, the tilt position control can now be specifically switched on or off. Please activate if necessary. #163
-      - Update: There is no default value for "Sun Shading Forecast Temperature" here now. To not compare the forecast temperature, leave this field empty. #179
+      - Added: New additional actions: Commands can now be executed before opening, closing, shading and ventilation #166
       - Fixed: Fixed problems resetting manual override #184
       - Fixed: Make sure that the reset of the manual override is only executed once #178
+      - Fixed: Problems with lockout protection and partial ventilation solved #181
+      - Fixed: There was no latest time for closing the cover when the scheduler was used with sun/brightness #170
+      - Added: Added Sun elevation examples into the description #175
+      - Added: New feature 'Allow opening the cover when resident is still present' #192
+      - Breaking change: Please reconfigure "Allow sun protection when resident is still present" ('resident_shading_enabled' was renamed)
 
     2024.12.20:
       - Added: Additional Condition For Disabling Ventilation
@@ -722,11 +728,11 @@ blueprint:
 
               - <ins>Without brightness or sun elevation control:</ins>
                 As soon as the helper state is switched from <strong>OFF</strong> to <strong>ON</strong>, the cover is opened.
-                The cover is closed when the helper state changes from <strong>OFF</strong> to <strong>ON</strong>.
+                The cover is closed when the helper state changes from <strong>ON</strong> to <strong>OFF</strong>.
 
               - <ins>With brightness or sun elevation control:</ins>
                 The cover opens when the threshold is exceeded and the helper is <strong>ON</strong>.
-                The cover closes when the level is below the threshold and the helper is <strong>ON</strong>.
+                The cover closes when the level is below the threshold and the helper is <strong>ON</strong>, or when the schedule helper changes from <strong>ON</strong> to <strong>OFF</strong> (Latest time for closing the cover).
 
             Unfortunately, the HA core currently only has a 30-minute time grid for the time configuration.
 
@@ -827,9 +833,19 @@ blueprint:
             Which sensors provides attributes with current azimuth and elevation of sun.
             I strongly suggest to use sun.sun ([Sun integration](https://www.home-assistant.io/integrations/sun/)).
             Please make sure that the integration is activated and provides the attributes.
-            <br />
             This sensor is also used for sun protection / sunshade control.
-            <br /><br />`Optional` / `Shading`
+            <br /><br />
+            <ins>A few examples of threshold values:</ins>
+            <ul>
+            <li>+18° Astronomical Dusk</li>
+            <li>+12° Nautical Dusk</li>
+            <li>+6° Dusk</li>
+            <li>0° Sunrise/Sunset</li>
+            <li>-6° Civil Dawn</li>
+            <li>-12° Nautical Dawn</li>
+            <li>-18° Astronomical Dawn/Night</li>
+            </ul>
+            <br />`Optional` / `Shading`
           default: "sun.sun"
           selector:
             entity:
@@ -1331,7 +1347,9 @@ blueprint:
                 - label: "🔻 Close the cover immediately when the sensor goes to 'on/true'?"
                   value: "resident_closing_enabled"
                 - label: "🥵 Allow sun protection when resident is still present"
-                  value: "resident_shading_enabled"
+                  value: "resident_allow_shading"
+                - label: "🔼 Allow opening the cover when resident is still present"
+                  value: "resident_allow_opening"
               multiple: true
               sort: false
               custom_value: false
@@ -1663,37 +1681,72 @@ blueprint:
       icon: mdi:run
       collapsed: true
       input:
+        auto_up_action_before:
+          name: "🔼 Additional Actions Before Opening The Cover"
+          description: "Additional actions to run <ins>before</ins> opening the cover"
+          default: []
+          selector:
+            action: {}
+
         auto_up_action:
           name: "🔼 Additional Actions After Opening The Cover"
-          description: "Additional actions to run after opening the cover"
+          description: "Additional actions to run <ins>after</ins> opening the cover"
+          default: []
+          selector:
+            action: {}
+
+        auto_down_action_before:
+          name: "🔻 Additional Actions Before Closing The Cover"
+          description: "Additional actions to run <ins>before</ins> closing the cover"
           default: []
           selector:
             action: {}
 
         auto_down_action:
           name: "🔻 Additional Actions After Closing The Cover"
-          description: "Additional actions to run after closing the cover"
+          description: "Additional actions to run <ins>after</ins> closing the cover"
+          default: []
+          selector:
+            action: {}
+
+        auto_ventilate_action_before:
+          name: "💨 Additional Actions Before Ventilating The Cover"
+          description: "Additional actions to run <ins>before</ins> ventilating the cover"
           default: []
           selector:
             action: {}
 
         auto_ventilate_action:
           name: "💨 Additional Actions After Ventilating The Cover"
-          description: "Additional actions to run after ventilating the cover"
+          description: "Additional actions to run <ins>after</ins> ventilating the cover"
+          default: []
+          selector:
+            action: {}
+
+        auto_shading_start_action_before:
+          name: "🥵 Additional Actions Before Activating Sun Shading"
+          description: "Additional actions to run <ins>before</ins> activating sun shading"
           default: []
           selector:
             action: {}
 
         auto_shading_start_action:
           name: "🥵 Additional Actions After Activating Sun Shading"
-          description: "Additional actions to run after activating sun shading"
+          description: "Additional actions to run <ins>after</ins> activating sun shading"
+          default: []
+          selector:
+            action: {}
+
+        auto_shading_end_action_before:
+          name: "🥵 Additional Actions Before Disabling Sun Shading"
+          description: "Additional actions to run <ins>before</ins> disabling sun shading"
           default: []
           selector:
             action: {}
 
         auto_shading_end_action:
           name: "🥵 Additional Actions After Disabling Sun Shading"
-          description: "Additional actions to run after disabling sun shading"
+          description: "Additional actions to run <ins>after</ins> disabling sun shading"
           default: []
           selector:
             action: {}
@@ -2034,7 +2087,8 @@ variables:
   resident_config: !input resident_config
   resident_opening_enabled: "{{ 'resident_opening_enabled' in resident_config }}"
   resident_closing_enabled: "{{ 'resident_closing_enabled' in resident_config }}"
-  resident_shading_enabled: "{{ 'resident_shading_enabled' in resident_config }}"
+  resident_allow_shading: "{{ 'resident_allow_shading' in resident_config }}"
+  resident_allow_opening: "{{ 'resident_allow_opening' in resident_config }}"
 
   ignore_after_manual_config: !input ignore_after_manual_config
   override_opening_after_manual: "{{ 'ignore_opening_after_manual' in ignore_after_manual_config }}"
@@ -2475,6 +2529,9 @@ actions:
           - or: # Resident status must always be checked
               - "{{ resident_sensor == [] }}"
               - "{{ is_state(resident_sensor, ['false', 'off']) }}"
+              - and:
+                  - "{{ resident_allow_opening }}"
+                  - "{{ is_state(resident_sensor, ['true', 'on']) }}"
           - or: # Now we have to check different opening scenarios
               - and: # Control via times disabled
                   - "{{ is_time_control_disabled }}"
@@ -2488,7 +2545,7 @@ actions:
                   - "{{ not is_brightness_enabled }}" # Only if stand-alone w/o brightness and sun. The cover is then opened on the ON trigger.
                   - "{{ not is_sun_elevation_enabled }}"
                   - "{{ is_state(time_schedule_helper, 'on') }}"
-                  - "{{ trigger.id in ['t_open_3', 't_open_6'] }}" # Scheduler -> true / Resident -> false
+                  - "{{ trigger.id in ['t_open_3', 't_open_6'] }}" # Scheduler -> true / Resident -> false # TODO Why is the resident trigger here?
               - and: # Opening - Up early reached or schedule helper is on and brightness/sun above minimum
                   - or:
                       - and:
@@ -2524,6 +2581,9 @@ actions:
                   - "{{ is_cover_helper_shaded }}"
                   - "{{ is_status_helper_enabled }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_shading_start_action_before
+
                   - action: input_text.set_value # Set shading to true, but do not overwrite shading time
                     data:
                       entity_id: !input cover_status_helper
@@ -2576,6 +2636,9 @@ actions:
             # Cover should be opened
             ###################################
             default:
+              - choose: []
+                default: !input auto_up_action_before
+
               - alias: "Normal opening of the cover"
                 if:
                   - "{{ is_status_helper_enabled }}"
@@ -2673,8 +2736,11 @@ actions:
               - and: # Closing - Scheduler changes to off
                   - "{{ is_schedule_helper_enabled }}"
                   - "{{ time_schedule_helper != [] }}"
-                  - "{{ not is_brightness_enabled }}" # Only if stand-alone w/o brightness and sun. The cover is then opened on the ON trigger.
-                  - "{{ not is_sun_elevation_enabled }}"
+                  # Commented out due to #170.
+                  # Always shut down when the scheduler becomes inactive. This is effectively the “at the latest at” time.
+                  # Otherwise it could happen that the blind does not close if it is still too bright.
+                  # - "{{ not is_brightness_enabled }}" # Only if stand-alone w/o brightness and sun. The cover is then opened on the ON trigger.
+                  # - "{{ not is_sun_elevation_enabled }}"
                   - "{{ is_state(time_schedule_helper, 'off') }}"
                   - "{{ trigger.id == 't_close_3' }}"
               - and: # Closing - Down early reached and brightness/sun below minimum
@@ -2754,6 +2820,9 @@ actions:
                       - "{{ is_state(contact_window_opened, ['false', 'off']) }}"
 
                 sequence:
+                  - choose: []
+                    default: !input auto_ventilate_action_before
+
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
@@ -2847,6 +2916,9 @@ actions:
             # Normal closing of the cover
             ###################################
             default:
+              - choose: []
+                default: !input auto_down_action_before
+
               - alias: "Normal closing of the cover"
                 delay:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -2963,7 +3035,7 @@ actions:
               - "{{ resident_sensor == [] }}"
               - "{{ is_state(resident_sensor, ['false', 'off']) }}"
               - and: # Issue 131
-                  - "{{ resident_shading_enabled }}"
+                  - "{{ resident_allow_shading }}"
                   - "{{ is_state(resident_sensor, ['true', 'on']) }}"
 
         sequence:
@@ -3040,6 +3112,8 @@ actions:
                 sequence:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                  - choose: []
+                    default: !input auto_shading_start_action_before
 
                   - action: input_text.set_value
                     data:
@@ -3227,6 +3301,9 @@ actions:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
 
+                  - choose: []
+                    default: !input auto_ventilate_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3284,6 +3361,9 @@ actions:
                 sequence:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+
+                  - choose: []
+                    default: !input auto_shading_end_action_before
 
                   - alias: "Move cover to open position"
                     action: input_text.set_value
@@ -3440,6 +3520,9 @@ actions:
                       - "{{ (current_position | int(default=101) < ventilate_position) }}"
                       - "{{ ventilation_if_lower_enabled and (current_position | int(default=101) >= ventilate_position) }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_ventilate_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3515,6 +3598,17 @@ actions:
                       - "{{ is_cover_helper_partially_ventilated }}" # Status check
                       - "{{ in_ventilate_position }}" # Position check
               - and:
+               # Workaround for #181
+               # If the contact_window_tilted-sensor is used and 'lockout_tilted_when_closing' is enabled, when closing,
+               # 'vfull' is set in the helper.
+               # This must remain the case because the position of the cover remains at 100.
+               # But the return from this must be taken into account somehow.
+                  - "{{ trigger.id == 't_contact_tilted_off' }}"
+                  - "{{ contact_window_tilted != [] }}"
+                  - "{{ is_state(contact_window_tilted, ['false', 'off']) }}"
+                  - "{{ lockout_tilted_when_closing }}"
+                  - "{{ is_cover_helper_fully_ventilated }}"
+              - and:
                   - "{{ trigger.id == 't_contact_opened_off' }}"
                   - "{{ contact_window_opened != [] }}"
                   - "{{ is_state(contact_window_opened, ['false', 'off']) }}"
@@ -3540,6 +3634,9 @@ actions:
                   - "{{ contact_window_tilted != [] }}"
                   - "{{ is_state(contact_window_tilted, ['true', 'on']) }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_ventilate_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3591,6 +3688,9 @@ actions:
                 conditions:
                   - "{{ is_cover_helper_shaded }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_shading_start_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3647,6 +3747,9 @@ actions:
                   - "{{ is_cover_helper_open }}"
                   - "{{ not is_cover_helper_shaded }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_up_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3711,6 +3814,9 @@ actions:
                 conditions:
                   - "{{ is_cover_helper_closed }}"
                 sequence:
+                  - choose: []
+                    default: !input auto_down_action_before
+
                   - action: input_text.set_value
                     data:
                       entity_id: !input cover_status_helper
@@ -3780,6 +3886,9 @@ actions:
           - "{{ trigger.id == 't_force_open' }}"
           # - "{{ auto_up_force != [] and is_state(auto_up_force, ['true', 'on']) }}"
         sequence:
+          - choose: []
+            default: !input auto_up_action_before
+
           - if:
               - "{{ is_status_helper_enabled }}"
             then:
@@ -3852,6 +3961,9 @@ actions:
           - "{{ trigger.id == 't_force_close' }}"
           # - "{{ auto_down_force != [] and is_state(auto_down_force, ['true', 'on']) }}"
         sequence:
+          - choose: []
+            default: !input auto_down_action_before
+
           - if:
               - "{{ is_status_helper_enabled }}"
             then:
@@ -3925,6 +4037,9 @@ actions:
           # - "{{ auto_ventilate_force != [] and is_state(auto_ventilate_force, ['true', 'on']) }}"
           - "{{ is_status_helper_enabled }}"
         sequence:
+          - choose: []
+            default: !input auto_ventilate_action_before
+
           - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper
@@ -3986,6 +4101,9 @@ actions:
           # - "{{ auto_shading_start_force != [] and is_state(auto_shading_start_force, ['true', 'on']) }}"
           - "{{ is_status_helper_enabled }}"
         sequence:
+          - choose: []
+            default: !input auto_shading_start_action_before
+
           - action: input_text.set_value
             data:
               entity_id: !input cover_status_helper # ‘Open’ is not additionally set to True, because we don't know where it should actually go after forcing.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     ### A comprehensive and highly configurable blueprint for roller shutters and roller blinds
 
-    **Version**: 2024.12.20
+    **Version**: 2025.04.18
     **Help**: [Community Thread](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539) | **Source Code**: [github.com/hvorragend](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/cover_control_automation.yaml) | **Tickets**: [Issues](https://github.com/hvorragend/ha-blueprints/issues)
 
     **If you would like to support me or say thank you, please click here:**
@@ -50,7 +50,7 @@ blueprint:
     <details>
     <summary><strong>Important notes</strong></summary>
 
-    - It is <ins>not</ins> possible to execute this automation manually!
+    - <strong>It is <ins>not</ins> possible to execute this automation manually!</strong>
     - If you want to use sun elevation and/or azimuth it's strongly advised to use sun.sun. And please make sure your sun.sun entity is enabled!
     - `time_up_early` should be earlier than `time_up_late`
     - `time_up_early_non_workday` should be earlier than `time_up_late_non_workday`
@@ -73,6 +73,13 @@ blueprint:
     <summary><strong>Latest changes</strong></summary>
 
     **Full Changelog**: [CHANGELOG.md](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/CHANGELOG.md)
+
+    2025.04.18:
+      - Added: Allow entities of the switch domain as resident sensor or with the force entities #167
+      - Update: Just to be more bulletproof, the tilt position control can now be specifically switched on or off. Please activate if necessary. #163
+      - Update: There is no default value for "Sun Shading Forecast Temperature" here now. To not compare the forecast temperature, leave this field empty. #179
+      - Fixed: Fixed problems resetting manual override #184
+      - Fixed: Make sure that the reset of the manual override is only executed once #178
 
     2024.12.20:
       - Added: Additional Condition For Disabling Ventilation
@@ -243,30 +250,36 @@ blueprint:
         auto_options:
           name: "👉 Automation Options"
           description: >-
-            This basically determines whether the cover is allowed to open or close.
+            The options on the right-hand side determine whether the cover is allowed to open or to close.
             <br /><br />
-            Normally, the daily opening and closing of the roller blinds is controlled by a timer (see below).
-            These first two options must be activated so that the blinds can be opened or closed at all.
+            Typically, the opening and closing of the roller blinds is managed by a timer (see below).
+            Activation of these initial two options (1 and 2) is necessary for the blinds to function.
             <br /><br />
-            <ins>In addition to the time control</ins>, the height of the sun and a brightness sensor can also influence the daily opening and closing.
-            In this case, options 3 or 4 must be activated.
-            <br />
-            Up to this point, <ins>none of this has anything to do with sun protection</ins>.
-            This is activated in the last option.
+            <ins>In addition to the time control</ins>, the height of the sun and a brightness sensor can also play
+            a role in regulating the opening and closing of the blinds.
+            To access options 3 or 4, activation is required. Up to this point, <ins>none</ins> of these settings
+            pertain to the protection of the sun. This is activated in the last option.
             <br /><br />
-            <strong>Important note:</strong>
-            The configuration of the Cover Status Helper is <ins>mandatory</ins> if you want to use the the ventilation mode or sun protection / sunshade control.
+            <strong>Important Note:</strong> Configuring the Cover Status Helper is <ins>mandatory</ins> for utilizing
+            ventilation mode or for sun protection and sunshade control.
+            <br /><br />
+            This can can be enhanced with additional conditions (see below).
+            However, it’s crucial that options are remain activated; otherwise, the specified conditions will not function.
+            <br /><br />
+            Please ensure that the relevant sensors are are also included.
+            For instance, the brightness control will only operate if a brightness sensor is specified.
 
+            </details>
+            <br /><br />
             <details>
-            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
+            <summary><code><strong>CLICK HERE:</strong> Some notes on multiple triggering</code></summary>
 
 
-            This can be extended by further conditions (see below). However, it is important that the options are still activated here.
-            Otherwise the conditions will not take effect.
+            Even if multiple opening, closing, shading, etc. is activated, this only works if a trigger is available.
+            However, the numeric state triggers only trigger under certain circumstances.
+            Please see notes here [Numeric state triggers](https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger)
 
-
-            **Please ensure that the corresponding sensors are also specified.**
-            For example, the brightness control only works if a brightness sensor is also specified.
+            <em>Crossing the threshold means that the trigger only fires if the state wasn't previously within the threshold. If the current state of your entity is `50` and you set the threshold to `below: 75`, the trigger would not fire if the state changed to e.g. `49` or `72` because the threshold was never crossed. The state would first have to change to e.g. `76` and then to e.g. `74` for the trigger to fire.</em>
 
             </details>
           default:
@@ -308,23 +321,10 @@ blueprint:
             <ins>Prevent 'set_cover_position' and 'set_cover_tilt_position'</ins><br />
             There are devices that have problems when the two services 'set_cover_position' and 'set_cover_tilt_position' are executed directly one after the other.
             For example, there are Shelly devices that use the script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066) here.
-            Or Homematic blind actuators, which can better use their own service for this: [homematicip_local.set_cover_combined_position](https://github.com/danielperna84/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position).
+            Or Homematic blind actuators, which can better use their own service for this: [homematicip_local.set_cover_combined_position](https://github.com/SukramJ/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position).
             This option can be used to disable the standard services and allows the control to be implemented individually via the addtional actions.
 
             </details>
-            <br /><br />
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Some notes on multiple triggering</code></summary>
-
-
-            Even if multiple opening, closing, shading, etc. is activated, this only works if a trigger is available.
-            However, the numeric state triggers only trigger under certain circumstances.
-            Please see notes here [Numeric state triggers](https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger)
-
-            > <em>Crossing the threshold means that the trigger only fires if the state wasn't previously within the threshold. If the current state of your entity is `50` and you set the threshold to `below: 75`, the trigger would not fire if the state changed to e.g. `49` or `72` because the threshold was never crossed. The state would first have to change to e.g. `76` and then to e.g. `74` for the trigger to fire.</em>
-
-            </details>
-
           default: []
           selector:
             select:
@@ -421,7 +421,7 @@ blueprint:
               mode: slider
 
     position_section:
-      name: "Position Configuration"
+      name: "Cover Position Settings"
       icon: mdi:window-shutter-settings
       collapsed: true
       input:
@@ -435,26 +435,6 @@ blueprint:
               max: 100.0
               unit_of_measurement: "%"
 
-        open_tilt_position:
-          name: "🔼 Open Tilt Position"
-          description: >-
-            To which tilt position should the cover be moved when opening?
-
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
-
-
-            If the cover and the integration support it, the tilt position can be used.
-            However, the attribute 'current_position' is used for position detection and
-            'current_tilt_position' is not used or taken into account.
-
-            </details>
-          default: 50
-          selector:
-            number:
-              min: 0
-              max: 100
-              unit_of_measurement: "%"
         close_position:
           name: "🔻 Close Position"
           description: "What position should the cover be moved into when closing?"
@@ -463,27 +443,6 @@ blueprint:
             number:
               min: 0.0
               max: 100.0
-              unit_of_measurement: "%"
-
-        close_tilt_position:
-          name: "🔻 Close Tilt Position"
-          description: >-
-            To which tilt position should the cover be moved when closing?
-
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
-
-
-            If the cover and the integration support it, the tilt position can be used.
-            However, the attribute 'current_position' is used for position detection and
-            'current_tilt_position' is not used or taken into account.
-
-            </details>
-          default: 50
-          selector:
-            number:
-              min: 0
-              max: 100
               unit_of_measurement: "%"
 
         ventilate_position:
@@ -499,27 +458,6 @@ blueprint:
               max: 100.0
               unit_of_measurement: "%"
 
-        ventilate_tilt_position:
-          name: "💨 Ventilate Tilt Position"
-          description: >-
-            To which tilt position should the cover be moved for ventilation?
-
-            <details>
-            <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
-
-
-            If the cover and the integration support it, the tilt position can be used.
-            However, the attribute 'current_position' is used for position detection and
-            'current_tilt_position' is not used or taken into account.
-
-            </details>
-          default: 50
-          selector:
-            number:
-              min: 0
-              max: 100
-              unit_of_measurement: "%"
-
         shading_position:
           name: "🥵 Sun Shading Position"
           description: "To which position should the cover be moved for shading?"
@@ -528,16 +466,6 @@ blueprint:
             number:
               min: 0.0
               max: 100.0
-              unit_of_measurement: "%"
-
-        shading_tilt_position:
-          name: "🥵 Sun Shading Tilt Position"
-          description: "To which tilt position should the cover be moved for shading?"
-          default: 50
-          selector:
-            number:
-              min: 0
-              max: 100
               unit_of_measurement: "%"
 
         position_tolerance:
@@ -563,6 +491,113 @@ blueprint:
             number:
               min: 0.0
               max: 20.0
+              unit_of_measurement: "%"
+
+    tilt_position_section:
+      name: "Cover Tilt Position Settings"
+      icon: mdi:image-filter-tilt-shift
+      collapsed: true
+      input:
+        cover_action:
+          name: Cover Action 1
+          selector:
+            object: {}
+          default: >
+            action: cover.set_cover_position
+
+            target:
+              entity_id: "{{ repeat.item }}"
+            data:
+              position: "{{ open_position }}"
+
+        cover_action2:
+          name: Cover Action 2
+          selector:
+            template:
+          default: >
+            action: cover.set_cover_position
+
+            target:
+              entity_id: {{ repeat.item }}
+            data:
+              position: {{ open_position }}
+
+        cover_action3:
+          name: Cover Action 3
+          selector:
+            template:
+          default:
+            "{{ backup_type | title }}Backup: {{\n  now().strftime(\n    \"%A,
+            \"\n    ~ iif(backup_type == \"hourly\", \"%-I:%M %p, \", \"\")\n    ~ \"%B
+            %-d, %Y\"\n  )\n}}\n{# HourlyBackup: Monday, 3:04 PM, January 2, 2006 #}\n{#
+            DailyBackup: Monday, January 2, 2006 #}\n"
+
+        # action: homematicip_local.set_cover_combined_position
+        # data:
+        #   position: {{ open_position }}
+        #   tilt_position: {{ open_tilt_position }}
+        # target:
+        #   entity_id: {{ repeat.item }}
+
+        # action: script.cover_position_tilt
+        # data:
+        #   entity_id: {{ repeat.item }}
+        #   position: {{ open_position }}
+        #   tilt_position: {{ open_tilt_position }}
+
+        cover_tilt_config:
+          name: "📐 Tilt Position Feature"
+          description: >-
+            If the cover and the integration support it, the tilt position of the cover can be set. The standard attribute ‘current_tilt_position’ is used for this.
+            However, the ‘current_position’ attribute is still used exclusively for the actual position detection in the blueprint.
+          default: cover_tilt_disabled
+          selector:
+            select:
+              options:
+                - label: "✅ Enable Tilt Position Control"
+                  value: "cover_tilt_enabled"
+                - label: "❌ Disable Tilt Position Control"
+                  value: "cover_tilt_disabled"
+              multiple: false
+              sort: false
+              custom_value: false
+              mode: list
+
+        open_tilt_position:
+          name: "🔼 Open Tilt Position"
+          description: "To which tilt position should the cover be moved when opening?"
+          default: 50
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+        close_tilt_position:
+          name: "🔻 Close Tilt Position"
+          description: "To which tilt position should the cover be moved when closing?"
+          default: 50
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+        ventilate_tilt_position:
+          name: "💨 Ventilate Tilt Position"
+          description: "To which tilt position should the cover be moved for ventilation?"
+          default: 50
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+        shading_tilt_position:
+          name: "🥵 Sun Shading Tilt Position"
+          description: "To which tilt position should the cover be moved for shading?"
+          default: 50
+          selector:
+            number:
+              min: 0
+              max: 100
               unit_of_measurement: "%"
 
     time_section:
@@ -1146,7 +1181,7 @@ blueprint:
 
         shading_temperatur_sensor2:
           name: "🥵 Sun Shading Temperature Sensor 2 (eg. outdoor)"
-          description: "This is a secondary temperature sensor. (Here, for example, the current outdoor temperature can be used as a condition). This sensor has another function. Please read the notes in the <ins>Sun Shading Forecast Temperatur Value</ins> entry below."
+          description: "This is a secondary temperature sensor. (Here, for example, the current outdoor temperature can be used as a condition). This sensor has another function. Please read the notes in the <ins>Sun Shading Forecast Temperature Value</ins> entry below."
           default: []
           selector:
             entity:
@@ -1175,7 +1210,7 @@ blueprint:
             <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
-            The idea is that it can happen, especially in spring, that the value of the <em>Forecast Temperatur Value</em> exceeded by
+            The idea is that it can happen, especially in spring, that the value of the <em>Forecast Temperature Value</em> exceeded by
             strong solar radiation and the shading would be started.
             However, in spring you may not want shading, but the solar radiation as a welcome, free heating is desired.
             So you can define via the forecast sensor that shading is only started at an expected daily maximum temperature.
@@ -1212,27 +1247,33 @@ blueprint:
                   value: "weather_attributes"
 
         shading_forecast_temp:
-          name: "🥵 Sun Shading Forecast Temperatur Value"
+          name: "🥵 Sun Shading Forecast Temperature Value"
           description: >-
-            Minimum temperature for forecast sensor above which shading should occur.
-            <br />
+            This is the minimum temperature at which shading should be activated.
+            When the forecasted temperature rises above this threshold, the shading mechanism will engage.
             There is a special feature when comparing the shading forecast temperature. Please continue reading!
-
+            <br /><br />
             <details>
-            <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
+            <summary><code><strong>CLICK HERE:</strong> Special Feature</code></summary>
 
-
-            The forecast is not always correct. For this reason, the Sun Shading Temperature Sensor No.2 is compared in addition to this value.
+            To enhance the reliability of the shading response, the system includes a comparison mechanism.
+            The forecasted shading temperature is evaluated against two temperature sensors to ensure optimal performance.
             <br /><br />
-            <strong>Conclusion:</strong>
-            The returned value of the weather forecast for today is compared with
-            <br />- <ins>Sun Shading Temperature Sensor 2</ins> and
-            <br />- <ins>Sun Shading Forecast Temperatur Value</ins>.
+            <strong>Comparison Mechanism:</strong> The forecast value is evaluated in relation to:
+            <br />- <ins>Shading Forecast Temperature Value (this input field)</ins>
+            <br />- <ins>Shading Temperature Sensor 2 (e.g. outdoor)</ins>
             <br /><br />
-            It is sufficient if one of the two exceeds the configured value.
+            For shading to be triggered, it suffices for either of the two sensor values to exceed the
+            configured shading forecast temperature value.
+            There is no default temperature value here since February 2025.
+            To <ins>not</ins> compare the forecast temperature, leave this field empty.
+            <br /><br />
+            <strong>Important Notes:</strong>
+            Weather forecasts are not always accurate.
+            Therefore, incorporating multiple temperature sensors allows for a more dependable reading before activating the shading system.
 
             </details>
-          default: 20
+          default:
           selector:
             number:
               min: 0.0
@@ -1323,6 +1364,7 @@ blueprint:
               domain:
                 - input_boolean
                 - binary_sensor
+                - switch
 
         resident_config:
           name: "🛌 Resident Configuration"
@@ -1408,7 +1450,7 @@ blueprint:
                 - label: "No timed reset for manual override"
                   value: "reset_disabled"
                 - label: "Reset at a specified time (see below)"
-                  value: "reset_time"
+                  value: "reset_fixed_time"
                 - label: "Reset after a timeout in minutes (see below)"
                   value: "reset_timeout"
               multiple: false
@@ -1426,7 +1468,7 @@ blueprint:
         reset_override_timeout:
           name: "🗑️ Number of minutes until reset manual override"
           description: "After how many minutes should it be reset?"
-          default: 360
+          default: 5
           selector:
             number:
               min: 0
@@ -1497,8 +1539,7 @@ blueprint:
           name: "❓ Additional Condition for the entire automation"
           description: >-
             This condition allows you to control the execution of the <ins>entire</ins> automation dynamically and outside of the blueprint configuration.
-            With this option you could enable a party mode.<br /><br />
-            This is the only condition that is also taken into account in the force features.
+            With this option you could enable a party mode. The result of this condition must be <ins>true</ins>.<br /><br />
             Forcing Open/Close/Shading/Ventilation is therefore only possible if this condition remains empty or becomes valid.
           default: []
           selector:
@@ -1509,6 +1550,7 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>opening</ins> of the cover.
             You can use this, for example, if the covers normally don't open, but you really want to do it on vacation.
+            The result of this condition must be <ins>true</ins>.
           default: []
           selector:
             condition: {}
@@ -1518,6 +1560,7 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>closing</ins> of the cover.
             You can use this, for example, at Christmas time or if you want the covers to behave differently while on vacation.
+            The result of this condition must be <ins>true</ins>.
           default: []
           selector:
             condition: {}
@@ -1526,6 +1569,7 @@ blueprint:
           name: "💨 Additional Condition For Activating Ventilation"
           description: >-
             This condition can be used to dynamically control the <ins>start of the ventilation</ins> of the cover.
+            The result of this condition must be <ins>true</ins>.
           default: []
           selector:
             condition: {}
@@ -1534,6 +1578,7 @@ blueprint:
           name: "💨 Additional Condition For Disabling Ventilation"
           description: >-
             This condition can be used to dynamically control the <ins>end of the ventilation</ins> of the cover.
+            The result of this condition must be <ins>true</ins>.
           default: []
           selector:
             condition: {}
@@ -1543,6 +1588,7 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>shading-IN-automation</ins> of the cover.
             This can be useful if you want to temporarily disable automation (e.g. because of control by other automations).
+            The result of this condition must be <ins>true</ins>.
             <br />
             Another example: Here you could also set that the shading is only triggered in the summer season.
           default: []
@@ -1554,6 +1600,7 @@ blueprint:
           description: >-
             This condition can be used to dynamically control the <ins>shading-OUT-automation</ins> of the cover.
             This can be useful if you want to temporarily disable automation (e.g. because of control by other automations).
+            The result of this condition must be <ins>true</ins>.
           default: []
           selector:
             condition: {}
@@ -1585,6 +1632,7 @@ blueprint:
               domain:
                 - input_boolean
                 - binary_sensor
+                - switch
 
         # auto_up_force_trigger:
         #   name: "🔼 Force Immediate Opening via Custom Triggers"
@@ -1604,6 +1652,7 @@ blueprint:
               domain:
                 - input_boolean
                 - binary_sensor
+                - switch
 
         # auto_down_force_trigger:
         #   name: "🔻 Force Immediate Closing via Custom Triggers"
@@ -1623,6 +1672,7 @@ blueprint:
               domain:
                 - input_boolean
                 - binary_sensor
+                - switch
 
         # auto_ventilate_force_trigger:
         #   name: "💨 Force Immediate Ventilation via Custom Triggers"
@@ -1642,6 +1692,7 @@ blueprint:
               domain:
                 - input_boolean
                 - binary_sensor
+                - switch
 
         # auto_shading_start_force_trigger:
         #   name: "🥵 Force Activation Sun Shading via Custom Triggers"
@@ -1717,7 +1768,7 @@ blueprint:
           name: "✔️ Check Configuration"
           description: >-
             With this boolean, you can enable or disable the basic plausibility check for the configuration.
-            he check only takes place if the automation is executed manually.
+            The check only takes place if the automation is executed manually.
           default: false
           selector:
             boolean: {}
@@ -1826,7 +1877,7 @@ trigger_variables:
   cover_status_helper: !input cover_status_helper
 
 variables:
-  version: "2024.12.20"
+  version: "2025.04.18"
 
   blind_entities: "{{ expand(blind) | map(attribute='entity_id') | list }}"
   current_position: "{{ state_attr(blind, 'current_position') if state_attr(blind, 'current_position') is not none else state_attr(blind, 'position') }}"
@@ -1879,6 +1930,8 @@ variables:
   close_tilt_position: !input close_tilt_position
   ventilate_position: !input ventilate_position
   ventilate_tilt_position: !input ventilate_tilt_position
+  cover_tilt_config: !input cover_tilt_config
+  is_cover_tilt_enabled: "{{ 'cover_tilt_enabled' in cover_tilt_config }}"
 
   # Force
   auto_up_force: !input auto_up_force
@@ -2343,6 +2396,7 @@ triggers:
     value_template: "{{ now() >= today_at(reset_override_time) }}"
     enabled: "{{ is_reset_fixed_time }}"
     id: "t_manual_2"
+    for: "00:00:02"
 
   - platform: template
     value_template: >-
@@ -2351,12 +2405,15 @@ triggers:
         states(cover_status_helper) | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") and
         states(cover_status_helper) not in ["unavailable", "none", "unknown"] and
         states(cover_status_helper)|from_json|regex_search('manual') and
-        (states(cover_status_helper)|from_json).manual.t is defined
+        (states(cover_status_helper)|from_json).manual.t is defined and
+        (states(cover_status_helper)|from_json).manual.a is defined and
+        (states(cover_status_helper)|from_json).manual.a | bool is true
       %}
         {{ now() >= ( (states(cover_status_helper)|from_json).manual.t + 60 * reset_override_timeout) | as_datetime | as_local }}
       {% endif %}
     enabled: "{{ is_reset_timeout and cover_status_helper != [] }}"
     id: "t_manual_3"
+    for: "00:00:02"
 
 ########################################
 # Global conditions
@@ -2544,6 +2601,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -2608,6 +2666,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                         - if:
+                            - "{{ is_cover_tilt_enabled }}"
                             - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                           then:
                             - alias: "Tilt Delay"
@@ -2775,6 +2834,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -2880,6 +2940,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                         - if:
+                            - "{{ is_cover_tilt_enabled }}"
                             - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                           then:
                             - alias: "Tilt Delay"
@@ -3057,6 +3118,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3242,6 +3304,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3309,6 +3372,7 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3396,6 +3460,7 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3448,6 +3513,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3547,6 +3613,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3601,6 +3668,7 @@ actions:
                               target:
                                 entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3665,6 +3733,7 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3728,6 +3797,7 @@ actions:
                                   target:
                                     entity_id: "{{ repeat.item }}"
                             - if:
+                                - "{{ is_cover_tilt_enabled }}"
                                 - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                               then:
                                 - alias: "Tilt Delay"
@@ -3799,6 +3869,7 @@ actions:
                           target:
                             entity_id: "{{ repeat.item }}"
                     - if:
+                        - "{{ is_cover_tilt_enabled }}"
                         - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                       then:
                         - alias: "Tilt Delay"
@@ -3870,6 +3941,7 @@ actions:
                           target:
                             entity_id: "{{ repeat.item }}"
                     - if:
+                        - "{{ is_cover_tilt_enabled }}"
                         - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                       then:
                         - alias: "Tilt Delay"
@@ -3930,6 +4002,7 @@ actions:
                       target:
                         entity_id: "{{ repeat.item }}"
                     - if:
+                        - "{{ is_cover_tilt_enabled }}"
                         - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                       then:
                         - alias: "Tilt Delay"
@@ -3990,6 +4063,7 @@ actions:
                       target:
                         entity_id: "{{ repeat.item }}"
                     - if:
+                        - "{{ is_cover_tilt_enabled }}"
                         - "{{ state_attr(repeat.item, 'current_tilt_position') != none }}"
                       then:
                         - alias: "Tilt Delay"


### PR DESCRIPTION
    2025.04.18:
      - Updated: Just to be more bulletproof, the tilt position control can now be specifically switched on or off. Please activate if necessary. #163
      - Updated: There is no default value for "Sun Shading Forecast Temperature" here now. To not compare the forecast temperature, leave this field empty. #179
      - Added: Allow entities of the switch domain as resident sensor or with the force entities #167
      - Added: New additional actions: Commands can now be executed before opening, closing, shading and ventilation #166
      - Fixed: Fixed problems resetting manual override #184
      - Fixed: Make sure that the reset of the manual override is only executed once #178
      - Fixed: Problems with lockout protection and partial ventilation solved #181
      - Fixed: There was no latest time for closing the cover when the scheduler was used with sun/brightness #170
      - Added: Added Sun elevation examples into the description #175
      - Added: New feature 'Allow opening the cover when resident is still present' #192
      - Breaking change: Please reconfigure "Allow sun protection when resident is still present" ('resident_shading_enabled' was renamed)