### PR TITLE
Feature #213: Optional feature to prevent any opening movement of a cover while still allowing closing movements, could be used to force drying of a cover

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1935,10 +1935,10 @@ blueprint:
                 - binary_sensor
                 - switch
 
-        auto_prevent_cover_to_up_position_force:
+        auto_prevent_opening_force:
           name: "🚫🔼 Force prevent opening of cover via Entity"
           description: >-
-            If the status of this entity changes to on or true, the cover can only move to a more closed position and will skip all opening movements.
+            If the status of this entity changes to on or true, the cover can only move to a more closed position and will skip all opening movements. Note that this also implicitly means that all tilt changes after opening will also be skipped.
           default: []
           selector:
             entity:
@@ -2220,13 +2220,13 @@ variables:
   auto_down_force: !input auto_down_force
   auto_ventilate_force: !input auto_ventilate_force
   auto_shading_start_force: !input auto_shading_start_force
-  auto_prevent_cover_to_up_position_force: !input auto_prevent_cover_to_up_position_force
+  auto_prevent_opening_force: !input auto_prevent_opening_force
 
   auto_up_force_disabled: "{{ auto_up_force == [] or (auto_up_force != [] and states(auto_up_force) in ['false', 'off']) }}"
   auto_down_force_disabled: "{{ auto_down_force == [] or (auto_down_force != [] and states(auto_down_force) in ['false', 'off']) }}"
   auto_ventilate_force_disabled: "{{ auto_ventilate_force == [] or (auto_ventilate_force != [] and states(auto_ventilate_force) in ['false', 'off']) }}"
   auto_shading_start_force_disabled: "{{ auto_shading_start_force == [] or (auto_shading_start_force != [] and states(auto_shading_start_force) in ['false', 'off']) }}"
-  auto_prevent_cover_to_up_position_force_disabled: "{{ auto_prevent_cover_to_up_position_force == [] or (auto_prevent_cover_to_up_position_force != [] and is_state(auto_prevent_cover_to_up_position_force, ['false', 'off'])) }}"
+  auto_prevent_opening_force_disabled: "{{ auto_prevent_opening_force == [] or (auto_prevent_opening_force != [] and is_state(auto_prevent_opening_force, ['false', 'off'])) }}"
 
   # Tilt
   is_cover_tilt_enabled_and_possible: "{{ is_cover_tilt_enabled and state_attr(blind, 'current_tilt_position') != none }}"
@@ -3021,7 +3021,7 @@ actions:
               - alias: "Normal opening of the cover"
                 conditions:
                   - "{{ not in_shading_position }}" # In this part, there is no plan for an open roller blind to switch from Shading to Open. I cannot check the helper here because Open+Shading could be set to true there.
-                  - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
+                  - "{{ auto_prevent_opening_force_disabled }}"
                   - or:
                       - "{{ is_status_helper_enabled and not is_helper_open }}" # including ventilation, window open-status and more possibilities
                       - "{{ not in_open_position }}"
@@ -3719,7 +3719,7 @@ actions:
               - "{{ auto_up_force_disabled }}"
               - "{{ auto_down_force_disabled }}"
               - "{{ auto_shading_start_force_disabled }}"
-              - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
+              - "{{ auto_prevent_opening_force_disabled }}"
           - or:
               - "{{ resident_sensor == [] }}"
               - "{{ states(resident_sensor) in ['false', 'off'] }}"
@@ -3739,7 +3739,7 @@ actions:
                   - "{{ states(contact_window_opened) in  ['true', 'on'] }}"
                   - "{{ trigger.id == 't_contact_opened_on' }}"
                   - "{{ not in_open_position }}"
-                  - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
+                  - "{{ auto_prevent_opening_force_disabled }}"
                 sequence:
                   - variables:
                       target_position: !input open_position
@@ -3957,7 +3957,7 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_open' }}"
-          - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
+          - "{{ auto_prevent_opening_force_disabled }}"
         sequence:
           - choose: []
             default: !input auto_up_action_before

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2884,7 +2884,7 @@ actions:
             - and:
                 - or:
                     - "{{ prevent_opening_movement_disabled }}"
-                    - "{{ not prevent_opening_movement_disabled and (current_position >= target_position) }}"
+                    - "{{ not prevent_opening_movement_disabled and (current_position >= target_position | default(101)) }}"
                 - or:
                     - "{{ should_cover_move_and_tilt is not defined }}"
                     - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}"
@@ -2900,7 +2900,7 @@ actions:
                 - and:
                     - or:
                         - "{{ prevent_opening_movement_disabled }}"
-                        - "{{ not prevent_opening_movement_disabled and (current_position >= target_position) }}"
+                        - "{{ not prevent_opening_movement_disabled and (current_position >= target_position | default(101)) }}"
                     - or:
                         - "{{ should_cover_move_and_tilt is not defined }}"
                         - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2995,6 +2995,9 @@ actions:
                   - "{{ is_status_helper_enabled }}"
                   - "{{ is_helper_shaded }}"
                   - "{{ not in_shading_position }}" # Even if this is hardly possible, there may be situations that require it. Purely as a precautionary measure in case the target state and actual state do not match.
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_shading_start_action_before
@@ -3021,10 +3024,12 @@ actions:
               - alias: "Normal opening of the cover"
                 conditions:
                   - "{{ not in_shading_position }}" # In this part, there is no plan for an open roller blind to switch from Shading to Open. I cannot check the helper here because Open+Shading could be set to true there.
-                  - "{{ auto_prevent_opening_force_disabled }}"
                   - or:
                       - "{{ is_status_helper_enabled and not is_helper_open }}" # including ventilation, window open-status and more possibilities
                       - "{{ not in_open_position }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
                 sequence:
                   - choose: []
                     default: !input auto_up_action_before
@@ -3631,6 +3636,9 @@ actions:
                   - or:
                       - "{{ (current_position < ventilate_position) }}"
                       - "{{ ventilation_if_lower_enabled and (current_position >= ventilate_position) }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= ventilate_position)  }}"
                 sequence:
                   - delay: # TODO: I can no longer recognize the original trigger here. That might be a bad idea here.
                       seconds: >
@@ -3719,7 +3727,6 @@ actions:
               - "{{ auto_up_force_disabled }}"
               - "{{ auto_down_force_disabled }}"
               - "{{ auto_shading_start_force_disabled }}"
-              - "{{ auto_prevent_opening_force_disabled }}"
           - or:
               - "{{ resident_sensor == [] }}"
               - "{{ states(resident_sensor) in ['false', 'off'] }}"
@@ -3739,7 +3746,9 @@ actions:
                   - "{{ states(contact_window_opened) in  ['true', 'on'] }}"
                   - "{{ trigger.id == 't_contact_opened_on' }}"
                   - "{{ not in_open_position }}"
-                  - "{{ auto_prevent_opening_force_disabled }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position) }}"
                 sequence:
                   - variables:
                       target_position: !input open_position
@@ -3871,6 +3880,9 @@ actions:
               - alias: "Contact sensor closed. Activate shading"
                 conditions:
                   - "{{ is_helper_shaded }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_shading_start_action_before
@@ -3957,7 +3969,9 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_open' }}"
-          - "{{ auto_prevent_opening_force_disabled }}"
+          - or:
+              - "{{ auto_prevent_opening_force_disabled }}"
+              - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
         sequence:
           - choose: []
             default: !input auto_up_action_before
@@ -4017,6 +4031,9 @@ actions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_vent' }}"
           - "{{ is_status_helper_enabled }}"
+          - or:
+              - "{{ auto_prevent_opening_force_disabled }}"
+              - "{{ not auto_prevent_opening_force_disabled and (current_position >= ventilate_position) }}"
         sequence:
           - choose: []
             default: !input auto_ventilate_action_before
@@ -4047,6 +4064,9 @@ actions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_shading_start' }}"
           - "{{ is_status_helper_enabled }}"
+          - or:
+              - "{{ auto_prevent_opening_force_disabled }}"
+              - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
         sequence:
           - choose: []
             default: !input auto_shading_start_action_before

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2873,6 +2873,12 @@ actions:
                 {% set dict_new = dict(dict_var, **(update_values | default({})) ) %}
                 {{ dict_new | to_json }}
 
+      ######################################################################################
+      # What target positions and how the helper should be updated is defined in all actions
+      # In this step there is an additional check whether the cover should move and tilt
+      # In some case the cover should NOT move/tilt, but the helper should be still updated
+      # This is regulated via should_cover_move_and_tilt
+      ######################################################################################
       cover_move_and_tilt_and_update_helper: &cover_move_and_tilt_and_update_helper
         - if:
             - and:
@@ -3029,7 +3035,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_start_action
 
@@ -3056,7 +3062,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_up_action
 
@@ -3189,7 +3195,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3243,7 +3249,7 @@ actions:
                     vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                     manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                     t: "{{ as_timestamp(now()) | round(0) }}"
-              - *cover_move_and_tilt_and_update_helper
+              - sequence: *cover_move_and_tilt_and_update_helper
               - choose: []
                 default: !input auto_down_action
 
@@ -3415,7 +3421,7 @@ actions:
                             vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                             manual: { a: 0, t: "{{ helper_state_json.manual.t }}" } # TODO: Do I really want to overwrite the status here?
                             t: "{{ as_timestamp(now()) | round(0) }}"
-                      - *cover_move_and_tilt_and_update_helper
+                      - sequence: *cover_move_and_tilt_and_update_helper
                       - choose: []
                         default: !input auto_shading_start_action
 
@@ -3662,7 +3668,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3697,7 +3703,7 @@ actions:
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
                       should_cover_move_and_tilt: "{{ not prevent_opening_after_shading_end }}"  
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_end_action
 
@@ -3749,7 +3755,7 @@ actions:
                         vpart: { a: 0, t: "{{ helper_state_json.vpart.t }}" }
                         vfull: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
 
               ############################################################################
               # Window handle to tilt. Move the cover to the partial ventilation position
@@ -3776,7 +3782,7 @@ actions:
                         vpart: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3856,7 +3862,7 @@ actions:
                         vpart: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3880,7 +3886,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_start_action
 
@@ -3906,7 +3912,7 @@ actions:
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
                       should_cover_move_and_tilt: "{{ not prevent_opening_after_ventilation_end }}"  
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_up_action
 
@@ -3930,7 +3936,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_and_tilt_and_update_helper
+                  - sequence: *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_down_action
 
@@ -3958,7 +3964,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_and_tilt_and_update_helper
+          - sequence: *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_up_action
           # - stop: "Stop automation: FORCE OPEN"
@@ -3985,7 +3991,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_and_tilt_and_update_helper
+          - sequence: *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_down_action
           # - stop: "Stop automation: FORCE CLOSE"
@@ -4013,7 +4019,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_and_tilt_and_update_helper
+          - sequence: *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_ventilate_action
           # - stop: "Stop automation: FORCE VENTILATION"
@@ -4041,7 +4047,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_and_tilt_and_update_helper
+          - sequence: *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_shading_start_action
           # - stop: "Stop automation: FORCE SHADING START"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2873,12 +2873,12 @@ actions:
                 {% set dict_new = dict(dict_var, **(update_values | default({})) ) %}
                 {{ dict_new | to_json }}
 
-      ######################################################################################
+      #########################################################################################
       # What target positions and how the helper should be updated is defined in all actions
-      # In this step there is an additional check whether the cover should move and tilt
-      # In some case the cover should NOT move/tilt, but the helper should be still updated
-      # This is regulated via should_cover_move_and_tilt
-      ######################################################################################
+      # In this anchor there is an additional check whether the cover should move and tilt for
+      # feature prevent_opening_movement. In some case the cover should NOT move/tilt, but the 
+      # helper should still be updated,the variable should_cover_move_and_tilt is used for this
+      #########################################################################################
       cover_move_and_tilt_and_update_helper: &cover_move_and_tilt_and_update_helper
         - if:
             - and:
@@ -2887,11 +2887,26 @@ actions:
                     - "{{ not prevent_opening_movement_disabled and (current_position >= target_position) }}"
                 - or:
                     - "{{ should_cover_move_and_tilt is not defined }}"
-                    - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}" 
+                    - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}"
           then:
             - *cover_move_action
             - *tilt_move_action
-        - *helper_update
+       # The helper should be updated if the cover was moved or tilted
+       # OR if we have created a variable in the action block should_cover_move_and_tilt
+       # This is only done when the update of the helper should happen independent of the evaluation
+       # of that expression
+        - if:
+            - or:
+                - and:
+                    - or:
+                        - "{{ prevent_opening_movement_disabled }}"
+                        - "{{ not prevent_opening_movement_disabled and (current_position >= target_position) }}"
+                    - or:
+                        - "{{ should_cover_move_and_tilt is not defined }}"
+                        - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}"
+                - "{{ should_cover_move_and_tilt is defined }}"
+          then:
+            - *helper_update
 
   # Querying the weather forecast  #############################################
   - if:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2221,7 +2221,6 @@ variables:
   auto_down_force: !input auto_down_force
   auto_ventilate_force: !input auto_ventilate_force
   auto_shading_start_force: !input auto_shading_start_force
-
   auto_up_force_disabled: "{{ auto_up_force == [] or (auto_up_force != [] and states(auto_up_force) in ['false', 'off']) }}"
   auto_down_force_disabled: "{{ auto_down_force == [] or (auto_down_force != [] and states(auto_down_force) in ['false', 'off']) }}"
   auto_ventilate_force_disabled: "{{ auto_ventilate_force == [] or (auto_ventilate_force != [] and states(auto_ventilate_force) in ['false', 'off']) }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2359,7 +2359,7 @@ variables:
   prevent_opening_multiple_times: "{{ 'prevent_opening_multiple_times' in individual_config }}"
   prevent_closing_multiple_times: "{{ 'prevent_closing_multiple_times' in individual_config }}"
   prevent_opening_movement: !input prevent_opening_movement
-  prevent_opening_movement_disabled: "{{ prevent_opening_movement == [] or (prevent_opening_movement != [] and is_state(prevent_opening_movement, ['false', 'off'])) }}"
+  prevent_opening_movement_disabled: "{{ prevent_opening_movement == [] or (prevent_opening_movement != [] and states(prevent_opening_movement) in ['false', 'off']) }}"
 
   resident_config: !input resident_config
   resident_opening_enabled: "{{ 'resident_opening_enabled' in resident_config }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2867,6 +2867,20 @@ actions:
                 {% set dict_new = dict(dict_var, **(update_values | default({})) ) %}
                 {{ dict_new | to_json }}
 
+      cover_move_and_tilt_and_update_helper: &cover_move_and_tilt_and_update_helper
+        - if:
+            - and:
+                - or:
+                    - "{{ auto_prevent_opening_force_disabled }}"
+                    - "{{ not auto_prevent_opening_force_disabled and (current_position >= target_position) }}"
+                - or:
+                    - "{{ should_cover_and_tilt_be_applied is not defined }}"
+                    - "{{ should_cover_and_tilt_be_applied is defined and should_cover_and_tilt_be_applied }}" 
+          then:
+            - *cover_move_action
+            - *tilt_move_action
+        - *helper_update
+
   # Querying the weather forecast  #############################################
   - if:
       - "{{ is_shading_enabled }}"
@@ -2995,9 +3009,6 @@ actions:
                   - "{{ is_status_helper_enabled }}"
                   - "{{ is_helper_shaded }}"
                   - "{{ not in_shading_position }}" # Even if this is hardly possible, there may be situations that require it. Purely as a precautionary measure in case the target state and actual state do not match.
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_shading_start_action_before
@@ -3012,9 +3023,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_start_action
 
@@ -3027,9 +3036,6 @@ actions:
                   - or:
                       - "{{ is_status_helper_enabled and not is_helper_open }}" # including ventilation, window open-status and more possibilities
                       - "{{ not in_open_position }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
                 sequence:
                   - choose: []
                     default: !input auto_up_action_before
@@ -3044,9 +3050,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_up_action
 
@@ -3179,9 +3183,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3222,10 +3224,6 @@ actions:
               - choose: []
                 default: !input auto_down_action_before
               - alias: "Normal closing of the cover"
-                conditions:
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position) }}"
                 delay:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
               - variables:
@@ -3239,9 +3237,7 @@ actions:
                     vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                     manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                     t: "{{ as_timestamp(now()) | round(0) }}"
-              - *cover_move_action
-              - *tilt_move_action
-              - *helper_update
+              - *cover_move_and_tilt_and_update_helper
               - choose: []
                 default: !input auto_down_action
 
@@ -3413,9 +3409,7 @@ actions:
                             vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                             manual: { a: 0, t: "{{ helper_state_json.manual.t }}" } # TODO: Do I really want to overwrite the status here?
                             t: "{{ as_timestamp(now()) | round(0) }}"
-                      - *cover_move_action
-                      - *tilt_move_action
-                      - *helper_update
+                      - *cover_move_and_tilt_and_update_helper
                       - choose: []
                         default: !input auto_shading_start_action
 
@@ -3640,9 +3634,6 @@ actions:
                   - or:
                       - "{{ (current_position < ventilate_position) }}"
                       - "{{ ventilation_if_lower_enabled and (current_position >= ventilate_position) }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= ventilate_position)  }}"
                 sequence:
                   - delay: # TODO: I can no longer recognize the original trigger here. That might be a bad idea here.
                       seconds: >
@@ -3665,9 +3656,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3701,12 +3690,8 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *helper_update
-                  - if:
-                      - "{{ not prevent_opening_after_shading_end}}"
-                    then:
-                      - *cover_move_action
-                      - *tilt_move_action
+                      should_cover_and_tilt_be_applied: "{{ not prevent_opening_after_shading_end }}"  
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_end_action
 
@@ -3750,9 +3735,6 @@ actions:
                   - "{{ states(contact_window_opened) in  ['true', 'on'] }}"
                   - "{{ trigger.id == 't_contact_opened_on' }}"
                   - "{{ not in_open_position }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position) }}"
                 sequence:
                   - variables:
                       target_position: !input open_position
@@ -3761,9 +3743,7 @@ actions:
                         vpart: { a: 0, t: "{{ helper_state_json.vpart.t }}" }
                         vfull: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
 
               ############################################################################
               # Window handle to tilt. Move the cover to the partial ventilation position
@@ -3790,9 +3770,7 @@ actions:
                         vpart: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3872,9 +3850,7 @@ actions:
                         vpart: { a: 1, t: "{{ as_timestamp(now()) | round(0) }}" }
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_ventilate_action
 
@@ -3884,9 +3860,6 @@ actions:
               - alias: "Contact sensor closed. Activate shading"
                 conditions:
                   - "{{ is_helper_shaded }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_shading_start_action_before
@@ -3901,9 +3874,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_start_action
 
@@ -3914,9 +3885,6 @@ actions:
                 conditions:
                   - "{{ is_helper_open }}"
                   - "{{ not is_helper_shaded }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
                 sequence:
                   - choose: []
                     default: !input auto_up_action_before
@@ -3931,12 +3899,8 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *helper_update
-                  - if:
-                      - "{{ not prevent_opening_after_ventilation_end }}"
-                    then:
-                      - *cover_move_action
-                      - *tilt_move_action
+                      should_cover_and_tilt_be_applied: "{{ not prevent_opening_after_ventilation_end }}"  
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_up_action
 
@@ -3946,9 +3910,6 @@ actions:
               - alias: "Contact sensor closed. Close the cover"
                 conditions:
                   - "{{ is_helper_closed }}"
-                  - or:
-                      - "{{ auto_prevent_opening_force_disabled }}"
-                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_down_action_before
@@ -3963,9 +3924,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                  - *cover_move_action
-                  - *tilt_move_action
-                  - *helper_update
+                  - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_down_action
 
@@ -3979,9 +3938,6 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_open' }}"
-          - or:
-              - "{{ auto_prevent_opening_force_disabled }}"
-              - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
         sequence:
           - choose: []
             default: !input auto_up_action_before
@@ -3996,9 +3952,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_action
-          - *tilt_move_action
-          - *helper_update
+          - *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_up_action
           # - stop: "Stop automation: FORCE OPEN"
@@ -4011,9 +3965,6 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_close' }}"
-          - or:
-              - "{{ auto_prevent_opening_force_disabled }}"
-              - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position)  }}"
         sequence:
           - choose: []
             default: !input auto_down_action_before
@@ -4028,9 +3979,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_action
-          - *tilt_move_action
-          - *helper_update
+          - *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_down_action
           # - stop: "Stop automation: FORCE CLOSE"
@@ -4044,9 +3993,6 @@ actions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_vent' }}"
           - "{{ is_status_helper_enabled }}"
-          - or:
-              - "{{ auto_prevent_opening_force_disabled }}"
-              - "{{ not auto_prevent_opening_force_disabled and (current_position >= ventilate_position) }}"
         sequence:
           - choose: []
             default: !input auto_ventilate_action_before
@@ -4061,9 +4007,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_action
-          - *tilt_move_action
-          - *helper_update
+          - *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_ventilate_action
           # - stop: "Stop automation: FORCE VENTILATION"
@@ -4077,9 +4021,6 @@ actions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_shading_start' }}"
           - "{{ is_status_helper_enabled }}"
-          - or:
-              - "{{ auto_prevent_opening_force_disabled }}"
-              - "{{ not auto_prevent_opening_force_disabled and (current_position >= shading_position) }}"
         sequence:
           - choose: []
             default: !input auto_shading_start_action_before
@@ -4094,9 +4035,7 @@ actions:
                 vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                 manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                 t: "{{ as_timestamp(now()) | round(0) }}"
-          - *cover_move_action
-          - *tilt_move_action
-          - *helper_update
+          - *cover_move_and_tilt_and_update_helper
           - choose: []
             default: !input auto_shading_start_action
           # - stop: "Stop automation: FORCE SHADING START"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3760,7 +3760,7 @@ actions:
                 conditions:
                   - "{{ contact_window_opened != [] }}"
                   - "{{ states(contact_window_opened) in  ['true', 'on'] }}"
-                  - "{{ trigger.id == 't_contact_opened_on' }}"
+                  - "{{ trigger.id in ['t_contact_opened_on', 't_open_7'] }}"
                   - "{{ not in_open_position }}"
                 sequence:
                   - variables:
@@ -3779,7 +3779,7 @@ actions:
                 conditions:
                   - "{{ contact_window_tilted != [] }}"
                   - "{{ states(contact_window_tilted) in ['true', 'on'] }}"
-                  - "{{ trigger.id == 't_contact_tilted_on' }}"
+                  - "{{ trigger.id in ['t_contact_tilted_on', 't_open_7'] }}"
                   - or:
                       - "{{ (current_position < ventilate_position) }}"
                       - and:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1935,6 +1935,18 @@ blueprint:
                 - binary_sensor
                 - switch
 
+        auto_prevent_cover_to_up_position_force:
+          name: "🚫🔼 Force prevent opening of cover via Entity"
+          description: >-
+            If the status of this entity changes to on or true, the cover can only move to a more closed position and will skip all opening movements.
+          default: []
+          selector:
+            entity:
+              domain:
+                - input_boolean
+                - binary_sensor
+                - switch
+
     actions_section:
       name: "Additional Actions"
       description: >-
@@ -2208,10 +2220,13 @@ variables:
   auto_down_force: !input auto_down_force
   auto_ventilate_force: !input auto_ventilate_force
   auto_shading_start_force: !input auto_shading_start_force
+  auto_prevent_cover_to_up_position_force: !input auto_prevent_cover_to_up_position_force
+
   auto_up_force_disabled: "{{ auto_up_force == [] or (auto_up_force != [] and states(auto_up_force) in ['false', 'off']) }}"
   auto_down_force_disabled: "{{ auto_down_force == [] or (auto_down_force != [] and states(auto_down_force) in ['false', 'off']) }}"
   auto_ventilate_force_disabled: "{{ auto_ventilate_force == [] or (auto_ventilate_force != [] and states(auto_ventilate_force) in ['false', 'off']) }}"
   auto_shading_start_force_disabled: "{{ auto_shading_start_force == [] or (auto_shading_start_force != [] and states(auto_shading_start_force) in ['false', 'off']) }}"
+  auto_prevent_cover_to_up_position_force_disabled: "{{ auto_prevent_cover_to_up_position_force == [] or (auto_prevent_cover_to_up_position_force != [] and is_state(auto_prevent_cover_to_up_position_force, ['false', 'off'])) }}"
 
   # Tilt
   is_cover_tilt_enabled_and_possible: "{{ is_cover_tilt_enabled and state_attr(blind, 'current_tilt_position') != none }}"
@@ -3006,6 +3021,7 @@ actions:
               - alias: "Normal opening of the cover"
                 conditions:
                   - "{{ not in_shading_position }}" # In this part, there is no plan for an open roller blind to switch from Shading to Open. I cannot check the helper here because Open+Shading could be set to true there.
+                  - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
                   - or:
                       - "{{ is_status_helper_enabled and not is_helper_open }}" # including ventilation, window open-status and more possibilities
                       - "{{ not in_open_position }}"
@@ -3703,6 +3719,7 @@ actions:
               - "{{ auto_up_force_disabled }}"
               - "{{ auto_down_force_disabled }}"
               - "{{ auto_shading_start_force_disabled }}"
+              - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
           - or:
               - "{{ resident_sensor == [] }}"
               - "{{ states(resident_sensor) in ['false', 'off'] }}"
@@ -3722,6 +3739,7 @@ actions:
                   - "{{ states(contact_window_opened) in  ['true', 'on'] }}"
                   - "{{ trigger.id == 't_contact_opened_on' }}"
                   - "{{ not in_open_position }}"
+                  - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
                 sequence:
                   - variables:
                       target_position: !input open_position
@@ -3939,6 +3957,7 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_open' }}"
+          - "{{ auto_prevent_cover_to_up_position_force_disabled }}"
         sequence:
           - choose: []
             default: !input auto_up_action_before

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -440,6 +440,18 @@ blueprint:
               custom_value: false
               mode: list
 
+        prevent_opening_movement:
+          name: "🚫🔼 Prevent opening of cover via Entity"
+          description: >-
+            If the status of this entity changes to on or true, the cover can only move to a more closed position and will skip all opening movements. Note that this also implicitly means that all tilt changes after opening will also be skipped. A typical use case will be when it is raining outside and you want to make sure your cover does not close while it is raining (or even a little after it stopped raining) to let the cover dry out.
+          default: []
+          selector:
+            entity:
+              domain:
+                - input_boolean
+                - binary_sensor
+                - switch
+
     helper_section:
       name: "Cover Status Helper"
       icon: mdi:form-textbox
@@ -1935,18 +1947,6 @@ blueprint:
                 - binary_sensor
                 - switch
 
-        auto_prevent_opening_force:
-          name: "🚫🔼 Force prevent opening of cover via Entity"
-          description: >-
-            If the status of this entity changes to on or true, the cover can only move to a more closed position and will skip all opening movements. Note that this also implicitly means that all tilt changes after opening will also be skipped.
-          default: []
-          selector:
-            entity:
-              domain:
-                - input_boolean
-                - binary_sensor
-                - switch
-
     actions_section:
       name: "Additional Actions"
       description: >-
@@ -2220,13 +2220,11 @@ variables:
   auto_down_force: !input auto_down_force
   auto_ventilate_force: !input auto_ventilate_force
   auto_shading_start_force: !input auto_shading_start_force
-  auto_prevent_opening_force: !input auto_prevent_opening_force
 
   auto_up_force_disabled: "{{ auto_up_force == [] or (auto_up_force != [] and states(auto_up_force) in ['false', 'off']) }}"
   auto_down_force_disabled: "{{ auto_down_force == [] or (auto_down_force != [] and states(auto_down_force) in ['false', 'off']) }}"
   auto_ventilate_force_disabled: "{{ auto_ventilate_force == [] or (auto_ventilate_force != [] and states(auto_ventilate_force) in ['false', 'off']) }}"
   auto_shading_start_force_disabled: "{{ auto_shading_start_force == [] or (auto_shading_start_force != [] and states(auto_shading_start_force) in ['false', 'off']) }}"
-  auto_prevent_opening_force_disabled: "{{ auto_prevent_opening_force == [] or (auto_prevent_opening_force != [] and is_state(auto_prevent_opening_force, ['false', 'off'])) }}"
 
   # Tilt
   is_cover_tilt_enabled_and_possible: "{{ is_cover_tilt_enabled and state_attr(blind, 'current_tilt_position') != none }}"
@@ -2360,6 +2358,8 @@ variables:
   prevent_shading_multiple_times: "{{ 'prevent_shading_multiple_times' in individual_config }}"
   prevent_opening_multiple_times: "{{ 'prevent_opening_multiple_times' in individual_config }}"
   prevent_closing_multiple_times: "{{ 'prevent_closing_multiple_times' in individual_config }}"
+  prevent_opening_movement: !input prevent_opening_movement
+  prevent_opening_movement_disabled: "{{ prevent_opening_movement == [] or (prevent_opening_movement != [] and is_state(prevent_opening_movement, ['false', 'off'])) }}"
 
   resident_config: !input resident_config
   resident_opening_enabled: "{{ 'resident_opening_enabled' in resident_config }}"
@@ -2871,11 +2871,11 @@ actions:
         - if:
             - and:
                 - or:
-                    - "{{ auto_prevent_opening_force_disabled }}"
-                    - "{{ not auto_prevent_opening_force_disabled and (current_position >= target_position) }}"
+                    - "{{ prevent_opening_movement_disabled }}"
+                    - "{{ not prevent_opening_movement_disabled and (current_position >= target_position) }}"
                 - or:
-                    - "{{ should_cover_and_tilt_be_applied is not defined }}"
-                    - "{{ should_cover_and_tilt_be_applied is defined and should_cover_and_tilt_be_applied }}" 
+                    - "{{ should_cover_move_and_tilt is not defined }}"
+                    - "{{ should_cover_move_and_tilt is defined and should_cover_move_and_tilt }}" 
           then:
             - *cover_move_action
             - *tilt_move_action
@@ -3690,7 +3690,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                      should_cover_and_tilt_be_applied: "{{ not prevent_opening_after_shading_end }}"  
+                      should_cover_move_and_tilt: "{{ not prevent_opening_after_shading_end }}"  
                   - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_shading_end_action
@@ -3899,7 +3899,7 @@ actions:
                         vfull: { a: 0, t: "{{ helper_state_json.vfull.t }}" }
                         manual: { a: 0, t: "{{ helper_state_json.manual.t }}" }
                         t: "{{ as_timestamp(now()) | round(0) }}"
-                      should_cover_and_tilt_be_applied: "{{ not prevent_opening_after_ventilation_end }}"  
+                      should_cover_move_and_tilt: "{{ not prevent_opening_after_ventilation_end }}"  
                   - *cover_move_and_tilt_and_update_helper
                   - choose: []
                     default: !input auto_up_action

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3222,6 +3222,10 @@ actions:
               - choose: []
                 default: !input auto_down_action_before
               - alias: "Normal closing of the cover"
+                conditions:
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position) }}"
                 delay:
                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
               - variables:
@@ -3910,6 +3914,9 @@ actions:
                 conditions:
                   - "{{ is_helper_open }}"
                   - "{{ not is_helper_shaded }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= open_position)  }}"
                 sequence:
                   - choose: []
                     default: !input auto_up_action_before
@@ -3939,6 +3946,9 @@ actions:
               - alias: "Contact sensor closed. Close the cover"
                 conditions:
                   - "{{ is_helper_closed }}"
+                  - or:
+                      - "{{ auto_prevent_opening_force_disabled }}"
+                      - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position) }}"
                 sequence:
                   - choose: []
                     default: !input auto_down_action_before
@@ -4001,6 +4011,9 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ trigger.id == 't_force_close' }}"
+          - or:
+              - "{{ auto_prevent_opening_force_disabled }}"
+              - "{{ not auto_prevent_opening_force_disabled and (current_position >= close_position)  }}"
         sequence:
           - choose: []
             default: !input auto_down_action_before

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2130,6 +2130,7 @@ trigger_variables:
   lockout_tilted_when_closing: "{{ 'lockout_tilted_closing' in lockout_tilted_options }}"
   lockout_tilted_when_shading_starts: "{{ 'lockout_tilted_shading_start' in lockout_tilted_options }}"
   lockout_tilted_when_shading_ends: "{{ 'lockout_tilted_shading_end' in lockout_tilted_options }}"
+  prevent_opening_movement: !input prevent_opening_movement
 
   # Time controls
   time_control: !input time_control
@@ -2438,6 +2439,12 @@ triggers:
     from: "on"
     to: "off"
     id: "t_open_6"
+
+  - platform: state
+    entity_id: !input prevent_opening_movement
+    from: "on"
+    to: "off"
+    id: "t_open_7"
 
   - platform: state
     entity_id: !input auto_up_force
@@ -3515,7 +3522,7 @@ actions:
         conditions:
           - "{{ is_shading_enabled }}"
           - "{{ trigger.id is defined }}"
-          - "{{ trigger.id | regex_match('^(t_shading_end)') }}"
+          - "{{ trigger.id | regex_match('^(t_shading_end|t_open_7)') }}" # If opening movement was not allowed upfront but shading was finished while all opening movements were blocked this needs to be triggered again
           - "{{ is_status_helper_enabled }}"
           - condition: !input auto_shading_end_condition
           - and:
@@ -3707,7 +3714,7 @@ actions:
         conditions:
           - "{{ is_ventilation_enabled }}"
           - "{{ trigger.id is defined }}"
-          - "{{ trigger.id in ['t_contact_tilted_on', 't_contact_opened_on'] }}"
+          - "{{ trigger.id in ['t_contact_tilted_on', 't_contact_opened_on', 't_open_7'] }}" # If window was opened and the cover was not allowed to move to a more open position then we need to retrigger this part
           - "{{ is_status_helper_enabled }}"
           - condition: !input auto_ventilate_condition
           - "{{ trigger.from_state.state not in ['unavailable', 'unknown', 'none', 'query failed'] }}"
@@ -4260,6 +4267,8 @@ actions:
                   message: "Sun sensor is missing attribute azimuth"
                 - condition: "{{ is_brightness_enabled and (default_brightness_sensor == [] or not is_number(states(default_brightness_sensor))) }}"
                   message: "Brightness sensor not defined or state is not numeric"
+                - condition: "{{ (prevent_opening_movement != [] ) and (not states(prevent_opening_movement) in ['false', 'off','true', 'on']) }}"
+                  message: "prevent_opening_movement is only allowed to be on/off/true/false"
 
                 # Helper checks
                 - condition: "{{ 'cover_helper_enabled' in cover_status_options and state_attr(cover_status_helper, 'max') < 254 }}"


### PR DESCRIPTION
I would like some feedback on my implementation direction. 

Some trade-offs I made:

- It has the same trade off as the other force features, the state if the option was not on/true can not be reproduced when this changes back to false
- Still in doubt if below logic should be applied to all actions where the action `cover.set_cover_position` or `cover.open/close_cover` is called. ~~I currently think did not do this for the "close" situation but this might be a mistake.~~
- if a cover is not moved because of this option, the tilt change is also not applied. I think I made it clear enough in the description that this is the behavior and as far as I can imagine this will most likely only be applied for covers that are outside and thus do not have a tilt option.
- If another force feature is applied it will still take a look at the new feature `auto_prevent_opening_force` if this force feature is allowed to happen. To me it makes the most sense if someone is using multiple force features
- I placed this feature under force since it behaves differently compared to `prevent_*` due to the fact that the state is not reproduced when this option changes to false/off.

~~I'm still testing this a bit, so might be best to wait for my confirmation that everything works OK in my case at least~~ All tests look OK