### PR TITLE
add sun shading minimum tilt position

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -609,7 +609,7 @@ blueprint:
         cover_tilt_reposition_config:
           name: "📐 Tilt Reposition Feature"
           description: >-
-            If Tilt Position Feature is enabled you can choose if the blinds are closed before tilting to a new position.
+            If Tilt Reposition Feature is enabled you can choose if the blinds are closed before tilting to a new position.
             In some cases tilting the blinds in small steps can lead to false positions. This is because of the minimum time the motor needs to run.
             If the runtime between current tilt position and target tilt position is to small the motor will not stop at the right position.
             Thus the blinds will be preclosed to 0 and then run to the target position.
@@ -653,9 +653,18 @@ blueprint:
               min: 0
               max: 100
               unit_of_measurement: "%"
+        shading_tilt_position_0:
+          name: "🥵 Sun Shading Tilt Position"
+          description: "Minimum tilt position for shading. The cover will be tilted to this position if the sun elevation is below the value of elevation 1."
+          default: 0
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
         shading_tilt_position_1:
           name: "🥵 Sun Shading Tilt Position 1"
-          description: "To which tilt position should the cover be moved for shading?"
+          description: "To which tilt position should the cover be moved for shading when the sun is above elevation 1?"
           default: 20
           selector:
             number:
@@ -664,7 +673,7 @@ blueprint:
               unit_of_measurement: "%"
         shading_tilt_elevation_1:
           name: "🥵 Sun Shading Tilt Elevation 1"
-          description: Sun elevationn for tilt position 1.
+          description: "Sun elevation for tilt position 1."
           default: 20
           selector:
             number:
@@ -675,7 +684,7 @@ blueprint:
               step: 1.0
         shading_tilt_position_2:
           name: "🥵 Sun Shading Tilt Position 2"
-          description: "To which tilt position should the cover be moved for shading?"
+          description: "To which tilt position should the cover be moved for shading when the sun is above elevation 2?"
           default: 37
           selector:
             number:
@@ -684,7 +693,7 @@ blueprint:
               unit_of_measurement: "%"
         shading_tilt_elevation_2:
           name: "🥵 Sun Shading Tilt Elevation 2"
-          description: Sun elevationn for tilt position 2.
+          description: "Sun elevation for tilt position 2."
           default: 30
           selector:
             number:
@@ -695,7 +704,7 @@ blueprint:
               step: 1.0
         shading_tilt_position_3:
           name: "🥵 Sun Shading Tilt Position 3"
-          description: "To which tilt position should the cover be moved for shading?"
+          description: "To which tilt position should the cover be moved for shading when the sun is above elevation 3?"
           default: 50
           selector:
             number:
@@ -704,7 +713,7 @@ blueprint:
               unit_of_measurement: "%"
         shading_tilt_elevation_3:
           name: "🥵 Sun Shading Tilt Elevation 3"
-          description: Sun elevationn for tilt position 3.
+          description: "Sun elevation for tilt position 3."
           default: 48
           selector:
             number:
@@ -2066,6 +2075,7 @@ trigger_variables:
   shading_tilt_elevation_1: !input shading_tilt_elevation_1
   shading_tilt_elevation_2: !input shading_tilt_elevation_2
   shading_tilt_elevation_3: !input shading_tilt_elevation_3
+  shading_tilt_position_0: !input shading_tilt_position_0
   shading_tilt_position_1: !input shading_tilt_position_1
   shading_tilt_position_2: !input shading_tilt_position_2
   shading_tilt_position_3: !input shading_tilt_position_3
@@ -2213,7 +2223,7 @@ variables:
     {% elif elevation >= shading_tilt_elevation_1 | int %}
       {{ shading_tilt_position_1 | int }}
     {% else %}
-      {{ 0 | int }}
+      {{ shading_tilt_position_0 | int }}
     {% endif %}
 
   shading_waitingtime_start: !input shading_waitingtime_start


### PR DESCRIPTION
This adds a new default sun shading tilt position. defaults to zero which has been the previous fallback value.

also extends the description to be more precise on what each value does.