### PR TITLE
In "Move cover after shading end" there is a target_position definiti…

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2257,6 +2257,25 @@ variables:
   is_tomorrow_off: "{{ workday_sensor_tomorrow != [] and is_state(workday_sensor_tomorrow, 'off') }}"
   is_tomorrow_on: "{{ workday_sensor_tomorrow != [] and is_state(workday_sensor_tomorrow, 'on') }}"
 
+  # Positions
+  open_position: !input open_position
+  close_position: !input close_position
+  ventilate_position: !input ventilate_position
+  shading_position: !input shading_position
+  position_tolerance: !input position_tolerance
+
+  # Tilt
+  open_tilt_position: !input open_tilt_position
+  close_tilt_position: !input close_tilt_position
+  ventilate_tilt_position: !input ventilate_tilt_position
+  shading_tilt_elevation_1: !input shading_tilt_elevation_1
+  shading_tilt_elevation_2: !input shading_tilt_elevation_2
+  shading_tilt_elevation_3: !input shading_tilt_elevation_3
+  shading_tilt_position_0: !input shading_tilt_position_0
+  shading_tilt_position_1: !input shading_tilt_position_1
+  shading_tilt_position_2: !input shading_tilt_position_2
+  shading_tilt_position_3: !input shading_tilt_position_3
+
   # Delays
   drive_delay_fix: !input drive_delay_fix
   drive_delay_random: !input drive_delay_random


### PR DESCRIPTION
In "Move cover after shading end" there is a target_position definition inside a sequence that used to use trigger_variables. These don't work as expected.

I rebased my [PR](https://github.com/hvorragend/ha-blueprints/pull/221) in another [branch](https://github.com/FrankTub/ha-blueprints/blob/feature/rebased-prevent-opening-of-cover/blueprints/automation/cover_control_automation.yaml) and tested the code and now I start to experience all sorts of issues. This only occurs when I don't use default values for target_position in `cover_move_and_tilt_and_update_helper` (these are currently implemented, but not in the previous version). The issue I receive was:

```
Error while executing automation automation.frummel_rolluik: UndefinedError: 'target_position' is undefined
```

According to ChatGPT:

> trigger_variables are evaluated only when the automation is triggered and are available in trigger and condition templates. This means that inside sequence: you cannot rely on open_position and close_position from trigger_variables unless they are also defined under variables: (global scope for the whole run).

The reason these issues do not show up in the log is that in the main branch the `target_position` in `cover_move_action` always looks like this:

```yaml
                        - "{{ target_position | default(101)  == 0 }}"
```

So my guess would be that in some other places in the code this also potentially could lead to issues, therefore decided to add these inputs as general variables.