### PR TITLE
fix: Add YAML parser initialization and cache-busting headers

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -4,6 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>CCA Trace Analyzer</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -11,6 +14,17 @@
         href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
         rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <script>
+        // Initialize YAML parser after CDN loads
+        window.addEventListener('DOMContentLoaded', function() {
+            if (typeof jsyaml !== 'undefined') {
+                window.YAML = jsyaml;
+                console.log("✅ YAML Parser loaded successfully from CDN:", window.YAML);
+            } else {
+                console.error("❌ YAML Parser failed to load from CDN");
+            }
+        });
+    </script>
     <style>
         :root {
             --bg-primary: #0a0a0f;


### PR DESCRIPTION
Previous fix loaded js-yaml from CDN but browser cache prevented updates and the global jsyaml variable wasn't mapped to window.YAML.

Changes:
- Add cache-busting meta tags to prevent stale cached versions
- Add initialization script that maps jsyaml to window.YAML
- Add console logging to verify YAML parser loads correctly

This ensures:
1. Browser always loads fresh version (no cache issues)
2. YAML parser is available as window.YAML for the analyzer
3. Clear console feedback about parser initialization status