### PR TITLE
fix: Switch to ESM CDN for full YAML API with parseDocument

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -13,17 +13,12 @@
     <link
         href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
-    <script>
-        // Initialize YAML parser after CDN loads
-        window.addEventListener('DOMContentLoaded', function() {
-            if (typeof jsyaml !== 'undefined') {
-                window.YAML = jsyaml;
-                console.log("✅ YAML Parser loaded successfully from CDN:", window.YAML);
-            } else {
-                console.error("❌ YAML Parser failed to load from CDN");
-            }
-        });
+    <script type="module">
+        // Load full YAML API from ESM CDN with parseDocument support
+        import * as YAML from 'https://esm.sh/yaml@2.3.4';
+        window.YAML = YAML;
+        console.log("✅ YAML Parser loaded successfully from CDN:", window.YAML);
+        console.log("✅ parseDocument available:", typeof YAML.parseDocument);
     </script>
     <style>
         :root {


### PR DESCRIPTION
The previous jsdelivr CDN version of js-yaml didn't export the parseDocument function needed for line number tracking in blueprints.

Changes:
- Switch from jsdelivr js-yaml to esm.sh yaml library
- Use ES module import for full API access
- yaml@2.3.4 includes parseDocument for CST parsing
- Add console logging to verify parseDocument availability

This fixes:
- "YAML Parser not found" despite parser being loaded
- Missing parseDocument function needed for GitHub line links
- Blueprint source line number tracking functionality