### PR TITLE
fix: Try non-minified js-yaml version for parseDocument support

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -13,13 +13,18 @@
     <link
         href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <script type="module">
-        // Load js-yaml (not yaml!) from ESM CDN with parseDocument support
-        import * as YAML from 'https://esm.sh/js-yaml@4.1.0';
-        window.YAML = YAML;
-        console.log("✅ js-yaml Parser loaded successfully from CDN:", window.YAML);
-        console.log("✅ parseDocument available:", typeof YAML.parseDocument);
-        console.log("✅ Available functions:", Object.keys(YAML));
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.js"></script>
+    <script>
+        // Map the global jsyaml to window.YAML for consistency
+        if (typeof jsyaml !== 'undefined') {
+            window.YAML = jsyaml;
+            console.log("✅ js-yaml Parser loaded successfully from CDN:", window.YAML);
+            console.log("✅ parseDocument available:", typeof window.YAML.parseDocument);
+            console.log("✅ load available:", typeof window.YAML.load);
+            console.log("✅ Available functions:", Object.keys(window.YAML).filter(k => typeof window.YAML[k] === 'function'));
+        } else {
+            console.error("❌ js-yaml failed to load from CDN");
+        }
     </script>
     <style>
         :root {


### PR DESCRIPTION
ESM CDN versions don't properly export parseDocument. Trying unminified UMD version from jsdelivr.

Changes:
- Switch back to jsdelivr CDN (UMD, not ESM)
- Use js-yaml.js (unminified) instead of js-yaml.min.js
- Keep sync script loading with jsyaml global
- Add detailed function availability logging

Testing if parseDocument is available in unminified browser build.