### PR TITLE
docs: Add Trace Compare links to all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Located in [`blueprints/automation/`](blueprints/automation/), **Cover Control A
 - 📖 [Go to CCA README](blueprints/automation/README.md)
 - 📦 [Configuration Validator](https://hvorragend.github.io/ha-blueprints/validator/)
 - 🔍 [Trace Analyzer](https://hvorragend.github.io/ha-blueprints/trace-analyzer/)
+- 🔄 [Trace Compare](https://hvorragend.github.io/ha-blueprints/trace-compare/)
 
 
 ---

--- a/blueprints/automation/README.md
+++ b/blueprints/automation/README.md
@@ -10,6 +10,7 @@
 - 📚 [Full Changelog](CHANGELOG.md)
 - 📦 [Configuration Validator](https://hvorragend.github.io/ha-blueprints/validator/)
 - 🔍 [Trace Analyzer](https://hvorragend.github.io/ha-blueprints/trace-analyzer/)
+- 🔄 [Trace Compare](https://hvorragend.github.io/ha-blueprints/trace-compare/)
 - ❓ [FAQ & Troubleshooting](FAQ.md)
 - 📖 [Time Control Visualization](TIME_CONTROL_VISUALIZATION.md)
 - 📖 [Dynamic Sun Elevation Guide](DYNAMIC_SUN_ELEVATION.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 ## 🔍 Configuration Validation
-   
+
    Before using CCA, validate your configuration:
    - **Online**: https://hvorragend.github.io/ha-blueprints/validator/
 
    Analyze CCA automation traces to understand what happened:
-   - **Online**: https://hvorragend.github.io/ha-blueprints/trace-analyzer/
+   - **Trace Analyzer**: https://hvorragend.github.io/ha-blueprints/trace-analyzer/
+   - **Trace Compare**: https://hvorragend.github.io/ha-blueprints/trace-compare/


### PR DESCRIPTION
Added links to the Trace Compare tool alongside existing Trace Analyzer links in:
- Main README.md
- docs/README.md
- blueprints/automation/README.md

The Trace Compare tool helps users compare automation traces to identify changes and differences in automation behavior.