### PR TITLE
docs: Clarify Dynamic Sun Elevation comparison logic

### DIFF
--- a/blueprints/automation/CHANGELOG.md
+++ b/blueprints/automation/CHANGELOG.md
@@ -126,8 +126,12 @@ This feature is particularly useful for emergency and weather-based scenarios wh
 - **Problem solved:** Fixed sun elevation thresholds don't work optimally year-round. In winter the sun stays lower, in summer higher. With fixed values your covers open/close at the wrong solar times.
 
 - **Solution:** Optional template sensors automatically adapt thresholds to the season. Thanks, Zanuuu, for this idea in issue #285.
-  - **Sun Elevation Up Sensor (Dynamic)** – Optional: Sensor for seasonal opening thresholds
-  - **Sun Elevation Down Sensor (Dynamic)** – Optional: Sensor for seasonal closing thresholds
+  - **Sun Elevation Up Sensor (Dynamic)** – Optional sensor for seasonal opening thresholds
+    - Cover opens when **current sun elevation is higher** than the sensor value
+    - Example: Sensor = 2.5° → Opens when sun rises above 2.5°
+  - **Sun Elevation Down Sensor (Dynamic)** – Optional sensor for seasonal closing thresholds
+    - Cover closes when **current sun elevation is lower** than the sensor value
+    - Example: Sensor = 0.5° → Closes when sun sets below 0.5°
 
 - New guide with step-by-step instructions: [Dynamic Sun Elevation Guide](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/DYNAMIC_SUN_ELEVATION.md)
 

--- a/blueprints/automation/DYNAMIC_SUN_ELEVATION.md
+++ b/blueprints/automation/DYNAMIC_SUN_ELEVATION.md
@@ -23,6 +23,23 @@ Fixed sun elevation thresholds don't work optimally throughout the year due to E
 
 **Template sensors with sinusoidal interpolation** automatically adapt thresholds based on the current date, matching the Earth's actual solar cycle.
 
+### How the Sensors Work
+
+The sensors provide **dynamic threshold values** that change throughout the year:
+
+- **Opening Sensor**: Provides the minimum sun elevation required for opening
+  - Cover opens when current sun elevation **rises above** this threshold
+  - Higher values = later opening (sun must climb higher)
+
+- **Closing Sensor**: Provides the maximum sun elevation allowed before closing
+  - Cover closes when current sun elevation **falls below** this threshold
+  - Higher values = later closing (sun can set further)
+
+**Example scenario (Berlin, 52°N):**
+- Summer solstice (June 21): Opening sensor = 5.5°, Closing sensor = 1.5°
+- Winter solstice (Dec 21): Opening sensor = -1.5°, Closing sensor = -5.5°
+- Result: Covers open/close at consistent solar times year-round, despite the sun reaching vastly different maximum elevations
+
 ### Visual Comparison
 ```
 Sun Elevation Threshold Throughout Year (50°N)
@@ -149,13 +166,31 @@ In your CCA automation configuration:
 
 ## 📊 How It Works
 
+### Understanding the Comparison Logic
+
+The dynamic sensors provide **threshold values** that are compared with the **current sun elevation**:
+
+**Opening Logic (Sun Elevation Up):**
+- ✅ Cover **opens** when: `current sun elevation > sensor value`
+- 📈 **Example**: Sensor = 2.5° → Cover opens when sun rises **above** 2.5°
+- 🔄 **Seasonal behavior**:
+  - Summer (sensor = 5.0°): Opens later (sun must climb higher)
+  - Winter (sensor = -2.0°): Opens earlier (sun below horizon is enough)
+
+**Closing Logic (Sun Elevation Down):**
+- ✅ Cover **closes** when: `current sun elevation < sensor value`
+- 📉 **Example**: Sensor = 0.5° → Cover closes when sun sets **below** 0.5°
+- 🔄 **Seasonal behavior**:
+  - Summer (sensor = 2.0°): Closes later (sun can be higher)
+  - Winter (sensor = -4.0°): Closes earlier (closes well before sunset)
+
 ### Automatic Features
 
-✅ **Reads your latitude** from `zone.home` automatically  
-✅ **Calculates optimal thresholds** for your location  
-✅ **Interpolates smoothly** between summer and winter values  
-✅ **Updates daily** to follow sun's annual path  
-✅ **No maintenance** required after initial setup  
+✅ **Reads your latitude** from `zone.home` automatically
+✅ **Calculates optimal thresholds** for your location
+✅ **Interpolates smoothly** between summer and winter values
+✅ **Updates daily** to follow sun's annual path
+✅ **No maintenance** required after initial setup
 
 ### Reference Values
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1495,6 +1495,12 @@ blueprint:
             Optional template sensor that dynamically calculates elevation threshold for opening based on season.
             If configured, this overrides the fixed 'Sun Elevation Up' value above.
             <br /><br />
+            **How it works**: The cover opens when the **current sun elevation is higher** than the value provided by this sensor.
+            The sensor value represents the minimum sun elevation (in degrees) required for opening.
+            <br /><br />
+            **Example**: Sensor value = 2.5° → Cover opens when sun rises above 2.5° elevation.
+            In summer (sensor = 5.0°) the cover opens later than in winter (sensor = -2.0°), matching seasonal sunrise times.
+            <br /><br />
             **Recommended**: Use a template sensor with seasonal interpolation to handle DST and seasonal variations.
             See [Dynamic Sun Elevation Guide](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/DYNAMIC_SUN_ELEVATION.md) for setup instructions.
             <br /><br />
@@ -1510,6 +1516,12 @@ blueprint:
           description: >-
             Optional template sensor that dynamically calculates elevation threshold for closing based on season.
             If configured, this overrides the fixed 'Sun Elevation Down' value above.
+            <br /><br />
+            **How it works**: The cover closes when the **current sun elevation is lower** than the value provided by this sensor.
+            The sensor value represents the maximum sun elevation (in degrees) allowed before closing.
+            <br /><br />
+            **Example**: Sensor value = 0.5° → Cover closes when sun sets below 0.5° elevation.
+            In summer (sensor = 2.0°) the cover closes later than in winter (sensor = -4.0°), matching seasonal sunset times.
             <br /><br />
             `Optional`
           default: []


### PR DESCRIPTION
Add detailed explanations of how sun elevation values are compared:
- Opening: cover opens when current elevation > sensor value
- Closing: cover closes when current elevation < sensor value

Updated:
- Blueprint input field descriptions with examples
- CHANGELOG.md with comparison logic details
- DYNAMIC_SUN_ELEVATION.md with comprehensive explanation

This helps end users understand exactly what is being compared and how the seasonal thresholds affect cover behavior.