### PR TITLE
docs: Enhance Dynamic Sun Elevation field descriptions

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1492,17 +1492,21 @@ blueprint:
         sun_elevation_up_sensor:
           name: "☀️ Sun Elevation Up Sensor (Dynamic - Optional)"
           description: >-
-            Optional template sensor that dynamically calculates elevation threshold for opening based on season.
+            Optional sensor that provides a **dynamic elevation threshold** for opening based on season.
+            This sensor value is compared with the **sun elevation from the sun integration** (`sun.sun` attribute `elevation`).
             If configured, this overrides the fixed 'Sun Elevation Up' value above.
             <br /><br />
-            **How it works**: The cover opens when the **current sun elevation is higher** than the value provided by this sensor.
-            The sensor value represents the minimum sun elevation (in degrees) required for opening.
+            **How it works**: The cover opens when the **current sun elevation is higher** than the threshold value provided by this sensor.
+            The sensor provides the ready-to-use threshold (in degrees) — dynamic instead of fixed in the blueprint.
             <br /><br />
-            **Example**: Sensor value = 2.5° → Cover opens when sun rises above 2.5° elevation.
+            **Example**: Sensor value = 2.5° → Cover opens when `sun.sun` elevation rises above 2.5°.
             In summer (sensor = 5.0°) the cover opens later than in winter (sensor = -2.0°), matching seasonal sunrise times.
             <br /><br />
-            **Recommended**: Use a template sensor with seasonal interpolation to handle DST and seasonal variations.
-            See [Dynamic Sun Elevation Guide](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/DYNAMIC_SUN_ELEVATION.md) for setup instructions.
+            **Multiple covers**: For different behavior per cover (e.g., east vs. west facing), create multiple template sensors with different thresholds.
+            <br /><br />
+            **Recommended options**:
+            - **Template sensor** with seasonal interpolation for automatic year-round adaptation ([Guide](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/DYNAMIC_SUN_ELEVATION.md))
+            - **Input Number helper** for manual GUI-based configuration via dashboard
             <br /><br />
             `Optional`
           default: []
@@ -1514,14 +1518,21 @@ blueprint:
         sun_elevation_down_sensor:
           name: "☀️ Sun Elevation Down Sensor (Dynamic - Optional)"
           description: >-
-            Optional template sensor that dynamically calculates elevation threshold for closing based on season.
+            Optional sensor that provides a **dynamic elevation threshold** for closing based on season.
+            This sensor value is compared with the **sun elevation from the sun integration** (`sun.sun` attribute `elevation`).
             If configured, this overrides the fixed 'Sun Elevation Down' value above.
             <br /><br />
-            **How it works**: The cover closes when the **current sun elevation is lower** than the value provided by this sensor.
-            The sensor value represents the maximum sun elevation (in degrees) allowed before closing.
+            **How it works**: The cover closes when the **current sun elevation is lower** than the threshold value provided by this sensor.
+            The sensor provides the ready-to-use threshold (in degrees) — dynamic instead of fixed in the blueprint.
             <br /><br />
-            **Example**: Sensor value = 0.5° → Cover closes when sun sets below 0.5° elevation.
+            **Example**: Sensor value = 0.5° → Cover closes when `sun.sun` elevation sets below 0.5°.
             In summer (sensor = 2.0°) the cover closes later than in winter (sensor = -4.0°), matching seasonal sunset times.
+            <br /><br />
+            **Multiple covers**: For different behavior per cover (e.g., east vs. west facing), create multiple template sensors with different thresholds.
+            <br /><br />
+            **Recommended options**:
+            - **Template sensor** with seasonal interpolation for automatic year-round adaptation ([Guide](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/DYNAMIC_SUN_ELEVATION.md))
+            - **Input Number helper** for manual GUI-based configuration via dashboard
             <br /><br />
             `Optional`
           default: []


### PR DESCRIPTION
Clarify Blueprint input field descriptions with additional details:
- Explain comparison with sun.sun elevation attribute
- Emphasize that sensors provide ready-to-use thresholds (dynamic vs. fixed)
- Add guidance for multiple covers (different template sensors per cover)
- Mention Input Number helpers as alternative for GUI-based configuration

This provides end users with complete understanding of how to use and configure the dynamic sun elevation feature.