### PR TITLE
fix: Respect manual intervention in prevent_multiple_times flags

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4703,7 +4703,7 @@ actions:
           - or: # Only once a day?
               - "{{ not is_status_helper_enabled }}"
               - "{{ not prevent_flags.opening_multiple_times }}"
-              - "{{ is_status_helper_enabled and prevent_flags.opening_multiple_times and (now().day != helper_ts.open|timestamp_custom('%-d')|int) }}"
+              - "{{ is_status_helper_enabled and prevent_flags.opening_multiple_times and ((now().day != helper_ts.open|timestamp_custom('%-d')|int) or helper_ts.manual <= helper_ts.open) }}"
           - or: # Check whether the resident trigger is allowed
               - "{{ trigger.id != 't_open_6' }}"
               - and:  # For t_open_6: check conditions
@@ -4827,7 +4827,7 @@ actions:
           - or: # Only once a day?
               - "{{ not is_status_helper_enabled }}"
               - "{{ not prevent_flags.closing_multiple_times }}"
-              - "{{ is_status_helper_enabled and prevent_flags.closing_multiple_times and (helper_ts.closed < today_at(time_down_early_today) | as_timestamp) }}"
+              - "{{ is_status_helper_enabled and prevent_flags.closing_multiple_times and ((helper_ts.closed < today_at(time_down_early_today) | as_timestamp) or helper_ts.manual <= helper_ts.closed) }}"
           - or: # Closing scenarios - works for BOTH time and calendar mode
               - "{{ is_time_control_disabled }}"
               - "{{ is_time_down_late }}"
@@ -5008,7 +5008,7 @@ actions:
           - "{{ not (helper_status.manual and override_flags.shading) }}" # Override check
           - or: # Only once a day?
               - "{{ not prevent_flags.shading_multiple_times }}"
-              - "{{ prevent_flags.shading_multiple_times and (now().day != helper_ts.shaded|timestamp_custom('%-d') | int) }}"
+              - "{{ prevent_flags.shading_multiple_times and ((now().day != helper_ts.shaded|timestamp_custom('%-d') | int) or helper_ts.manual <= helper_ts.shaded) }}"
               - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}" # Execution must not be stopped if there is a shading pending in the helper beforehand.
 
         sequence:


### PR DESCRIPTION
Enhanced prevent_*_multiple_times flags to respect manual user intervention after automation attempts. This prevents CCA from overriding user decisions while still allowing retries when the previous attempt was blocked by force conditions.

Solution: Add manual intervention check to each prevent flag:
- Allow retry if user has NOT manually intervened after last attempt (helper_ts.manual <= helper_ts.action)
- Block retry if user manually changed position after automation attempt (helper_ts.manual > helper_ts.action)

The logic is simplified to a single condition using OR:
- Original condition (different day/time) OR no manual intervention

Changes:
- prevent_opening_multiple_times (line 4706): Added: or helper_ts.manual <= helper_ts.open

- prevent_closing_multiple_times (line 4830): Added: or helper_ts.manual <= helper_ts.closed

- prevent_shading_multiple_times (line 5011): Added: or helper_ts.manual <= helper_ts.shaded

Example scenario:
08:00 - CCA opens cover, helper updated (helper_ts.open = 08:00) 12:00 - User manually closes (helper_ts.manual = 12:00) 14:00 - CCA attempts to open again
        Blocked: helper_ts.manual (12:00) > helper_ts.open (08:00)
        → User decision respected

vs.

08:00 - Opening blocked by force condition, helper updated 10:00 - CCA attempts to open again
        Allowed: helper_ts.manual < helper_ts.open
        → Retry allowed after blocked attempt