### PR TITLE
Only allow opening of a cover if both time and environment is ready for it

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4862,14 +4862,15 @@ actions:
                   - "{{ resident_flags.allow_opening }}"
                   - "{{ states(resident_sensor) in ['true', 'on'] }}"
           - or: # Opening scenarios - works for BOTH time and calendar mode
-              - "{{ is_time_control_disabled }}"
+              - and:
+                  - "{{ is_time_control_disabled }}"
+                  - "{{ environment_allows_opening }}" # This already checks if sun elevation or brightness conditions are enabled
               - and: # Ultimate opening ONLY for time triggers (no environment checks)
                   - "{{ is_time_up_late }}"
                   - "{{ not trigger.id.startswith('t_force_disabled') }}"
               - and: # All other triggers: WITH environment checks
-                  - "{{ is_opening_phase or is_daytime_phase }}"
-                  - "{{ not is_evening_phase }}"
-                  - "{{ environment_allows_opening }}"
+                  - "{{ is_opening_phase or is_closing_phase }}"
+                  - "{{ environment_allows_opening }}" # This already checks if sun elevation or brightness conditions are enabled
         sequence:
           - delay:
               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"


### PR DESCRIPTION
Example:

```
time_down_early: 16:00
time_down_late: 20:00
resident_sensor: enabled
sun_elevation opening and closing enabled
```

The starting point is that the cover is closed due to the resident sensor or a forced closed sensor. It will become dark after 20:00, so the earliest time the cover should remain closed is 20:00. If your forced closed sensor or resident sensor turns off at 17:00 then I would say it makes sense that the cover is allowed to open. In the old situation the cover would remain closed, this is not correct.

I have tested this for a week or two and so far has worked for my setup.