### PR TITLE
Update header navigation across all CCA tools

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -1231,6 +1231,9 @@
             <p class="subtitle">Analyze CCA automation traces to understand what happened</p>
             <div style="display: flex; gap: 0.5rem; justify-content: center; margin-top: 1rem;">
                 <span class="version-badge">v1.0 - For CCA Blueprint v2025.12.22+</span>
+                <a href="../validator/" class="version-badge"
+                    style="text-decoration: none; border-color: var(--accent-green); color: var(--accent-green);">📦
+                    CCA Configuration Validator</a>
                 <a href="../trace-compare/" class="version-badge"
                     style="text-decoration: none; border-color: var(--accent-purple); color: var(--accent-purple);">📈
                     CCA Trace Compare</a>

--- a/docs/trace-compare/index.html
+++ b/docs/trace-compare/index.html
@@ -914,6 +914,9 @@
             <p class="subtitle">Compare multiple CCA traces to analyze progression</p>
             <div style="display: flex; gap: 0.5rem; justify-content: center; margin-top: 1rem;">
                 <span class="version-badge">v1.1 - For CCA Blueprint v2025.12.22+</span>
+                <a href="../validator/" class="version-badge"
+                    style="text-decoration: none; border-color: var(--accent-green); color: var(--accent-green);">📦
+                    CCA Configuration Validator</a>
                 <a href="../trace-analyzer/" class="version-badge"
                     style="text-decoration: none; border-color: var(--accent-cyan); color: var(--accent-cyan);">🔍 CCA
                     Trace

--- a/docs/validator/index.html
+++ b/docs/validator/index.html
@@ -15,7 +15,8 @@
             <h1>🔍 CCA Configuration Validator</h1>
             <p>Validate your Cover Control Automation configuration</p>
             <div class="header-links">
-                <a href="https://hvorragend.github.io/ha-blueprints/trace-analyzer/" target="_blank">🔍 Trace Analyzer</a>
+                <a href="https://hvorragend.github.io/ha-blueprints/trace-analyzer/" target="_blank">🔍 CCA Trace Analyzer</a>
+                <a href="https://hvorragend.github.io/ha-blueprints/trace-compare/" target="_blank">📈 CCA Trace Compare</a>
                 <a href="https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/FAQ.md" target="_blank">❓ FAQ</a>
                 <a href="https://github.com/hvorragend/ha-blueprints" target="_blank">📦 GitHub Repository</a>
             </div>


### PR DESCRIPTION
- Validator: Changed "Trace Analyzer" to "CCA Trace Analyzer"
- Validator: Added "CCA Trace Compare" link to header
- Trace Analyzer: Added "CCA Configuration Validator" link to header
- Trace Compare: Added "CCA Configuration Validator" link to header

All three tools now have cross-links to the other two tools in their headers for improved navigation.