### PR TITLE
Prevent moving the cover if the cover is already in the target position (or position tolerance window)

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4071,6 +4071,8 @@ actions:
         sequence:
           - condition: template
             value_template: "{{ not prevent_flags.default_cover_actions }}"
+          - condition: template
+            value_template: "{{ target_position != current_position }}"
           - repeat:
               for_each: "{{ blind_entities | list }}"
               sequence:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4072,7 +4072,7 @@ actions:
           - condition: template
             value_template: "{{ not prevent_flags.default_cover_actions }}"
           - condition: template
-            value_template: "{{ target_position != current_position }}"
+            value_template: "{{ not (target_position >= current_position - position_tolerance and target_position <= current_position + position_tolerance) }}"
           - repeat:
               for_each: "{{ blind_entities | list }}"
               sequence:


### PR DESCRIPTION
I have some Switchbot U rails 3 on my curtains and use the ventilation mode. When they are in ventilation mode when lying on my bed I noticed that they often very slightly (< 1%) move. I have not spent time figuring out what the exact trigger is when this happens, but it is quite annoying to have your covers move when they are already in the required position. 

My approach was to skip the cover move action when the cover is already in the position window that is tolerated. Optionally this could have been a feature that users could opt in on, but I personally thought that would be an overkill.

Have been testing this for few weeks on all my covers and haven't had any issues with it. It also solved my issue that I'm no longer annoyed by my switchbots by making a clicking sound when lying in bed.