### PR TITLE
refactor(force): rename can_move_* to force_allows_* for clarity

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3049,11 +3049,11 @@ variables:
   # COMPUTED FLAGS - Simplified Movement Permissions
   # ═══════════════════════════════════════════════════════════════════════════
 
-  # Can the cover move in each direction?
-  can_move_open: "{{ state_force in ['none', 'open'] }}"
-  can_move_close: "{{ state_force in ['none', 'close'] }}"
-  can_move_shade: "{{ state_force in ['none', 'shade'] }}"
-  can_move_ventilate: "{{ state_force in ['none', 'vpart', 'vfull'] }}"
+  # Does force allow movement in each direction?
+  force_allows_open: "{{ state_force in ['none', 'open'] }}"
+  force_allows_close: "{{ state_force in ['none', 'close'] }}"
+  force_allows_shade: "{{ state_force in ['none', 'shade'] }}"
+  force_allows_ventilate: "{{ state_force in ['none', 'vpart', 'vfull'] }}"
 
   # Is any force active? (Runtime check via entity states - not helper!)
   # This avoids race conditions when force entities are just toggled
@@ -4543,7 +4543,7 @@ actions:
           - condition: !input auto_up_condition
           - or: # Use centralized force check
               - "{{ is_force_recovery_enabled }}"
-              - "{{ can_move_open }}" 
+              - "{{ force_allows_open }}" 
           - or: # Check state or position
               - "{{ state_current != 'open' }}"
               - "{{ not in_open_position }}"
@@ -4586,7 +4586,7 @@ actions:
                           shade_start: 0
                           shade_end: 0
                   - *helper_update
-                  - if: "{{ can_move_shade }}"
+                  - if: "{{ force_allows_shade }}"
                     then:
                       - delay:
                           seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -4621,7 +4621,7 @@ actions:
                           shade_start: 0
                           shade_end: 0
                   - *helper_update
-                  - if: "{{ can_move_open }}"
+                  - if: "{{ force_allows_open }}"
                     then:
                       - delay:
                           seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -4649,7 +4649,7 @@ actions:
           - condition: !input auto_down_condition
           - or: # Use centralized force check
               - "{{ is_force_recovery_enabled }}"
-              - "{{ can_move_close }}" 
+              - "{{ force_allows_close }}" 
           - or: # Check state or position
               - "{{ state_current != 'close' }}"
               - "{{ not in_close_position }}"
@@ -4721,7 +4721,7 @@ actions:
                           shade_start: 0
                           shade_end: 0
                   - *helper_update
-                  - if: "{{ can_move_ventilate }}"
+                  - if: "{{ force_allows_ventilate }}"
                     then:
                       - delay:
                           seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -4781,7 +4781,7 @@ actions:
                       shade_start: 0
                       shade_end: 0
               - *helper_update
-              - if: "{{ can_move_close }}"
+              - if: "{{ force_allows_close }}"
                 then:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -4809,7 +4809,7 @@ actions:
           - condition: !input auto_shading_start_condition
           - or: # Use centralized force check
               - "{{ is_force_recovery_enabled }}"
-              - "{{ can_move_shade }}"  
+              - "{{ force_allows_shade }}"  
           - or: # Check the helper status or the target status
               - "{{ not state_is_shaded }}"
               - "{{ not (state_current == 'vpart' or state_current == 'vfull') }}"
@@ -4916,7 +4916,7 @@ actions:
                               shade_start: 0
                               shade_end: 0
                       - *helper_update
-                      - if: "{{ can_move_shade }}"
+                      - if: "{{ force_allows_shade }}"
                         then:
                           - delay:
                               seconds: "{{ range(drive_delay_fix | int(0), drive_delay_fix | int(0) + drive_delay_random | int(0) +1) | random }}"
@@ -5015,7 +5015,7 @@ actions:
               - "{{ not state_pending_start }}"
           - "{{ is_cover_tilt_enabled_and_possible }}"
           - condition: !input auto_shading_tilt_condition
-          - "{{ can_move_shade }}"
+          - "{{ force_allows_shade }}"
           - "{{ not (state_current == 'vpart' or state_current == 'vfull') }}"
           - "{{ not (state_manual and override_flags.shading) }}" # Override check
         sequence:
@@ -5340,7 +5340,7 @@ actions:
                   - "{{ not in_open_position }}"
                   - or: # Force functions allow ventilation start
                       - "{{ is_force_recovery_enabled }}"
-                      - "{{ can_move_ventilate }}"
+                      - "{{ force_allows_ventilate }}"
                   - condition: !input auto_ventilate_condition
                 sequence:
                   - variables:
@@ -5355,7 +5355,7 @@ actions:
                           shade_start: 0
                           shade_end: 0
                   - *helper_update
-                  - if: "{{ can_move_open }}"
+                  - if: "{{ force_allows_open }}"
                     then:
                       - delay:
                           seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -5373,7 +5373,7 @@ actions:
                   - "{{ not contact_opened_now }}"
                   - or: # Force functions allow ventilation start
                       - "{{ is_force_recovery_enabled }}"
-                      - "{{ can_move_ventilate }}"
+                      - "{{ force_allows_ventilate }}"
                   - condition: !input auto_ventilate_condition
                   # Position check: Only move if cover is below ventilation position (or option enabled)
                   - or:
@@ -5404,7 +5404,7 @@ actions:
                           shade_start: 0
                           shade_end: 0
                   - *helper_update
-                  - if: "{{ can_move_ventilate }}"
+                  - if: "{{ force_allows_ventilate }}"
                     then:
                       - delay:
                           seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -5579,7 +5579,7 @@ actions:
                           - "{{ resident_flags.opening_trigger }}"
                           - "{{ is_up_enabled }}"
                           - "{{ state_current != 'open' or not in_open_position }}"
-                          - "{{ can_move_open }}"
+                          - "{{ force_allows_open }}"
                         sequence:
                           - delay:
                               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -5686,7 +5686,7 @@ actions:
                           - "{{ state_target == 'close' }}"
                           - "{{ is_down_enabled }}"
                           - "{{ state_current != 'close' or not in_close_position }}"
-                          - "{{ can_move_close }}"
+                          - "{{ force_allows_close }}"
                         sequence:
                           - delay:
                               seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
@@ -5720,7 +5720,7 @@ actions:
                   - "{{ is_down_enabled }}"
                   - "{{ resident_flags.closing_trigger }}"
                   - "{{ state_current != 'close' or not in_close_position }}"
-                  - "{{ can_move_close }}"
+                  - "{{ force_allows_close }}"
                 sequence:
                   - delay:
                       seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"


### PR DESCRIPTION
Rename force permission variables to make their purpose clearer:
- can_move_open → force_allows_open
- can_move_close → force_allows_close
- can_move_shade → force_allows_shade
- can_move_ventilate → force_allows_ventilate

https://claude.ai/code/session_01PtGTDWC49DZypaVpRq3vay