### PR TITLE
Document change in opening conditions

### DIFF
--- a/blueprints/automation/TIME_CONTROL_VISUALIZATION.md
+++ b/blueprints/automation/TIME_CONTROL_VISUALIZATION.md
@@ -156,14 +156,14 @@ Closes when: Sun < -5° below horizon
 ├─────────────────────────────────────────────────────────┤
 │ After time_up_early AND      │                          │
 │ (Brightness > threshold      │ ✅ Cover opens           │
-│  OR                          │                          │
+│  AND                         │                          │
 │  Sun > threshold)            │                          │
 ├─────────────────────────────────────────────────────────┤
 │ After time_up_late           │ ✅ Cover opens           │
 │ (REGARDLESS of sensors)      │    GUARANTEED            │
 └─────────────────────────────────────────────────────────┘
 
-⚠️  OR Logic: Only ONE sensor needs to exceed threshold!
+⚠️  AND Logic: ALL enabled sensors must exceed threshold!
 ```
 
 ### Closing (Evening)


### PR DESCRIPTION
The opening logic changed from (brightness OR sun elevation) to (brightness AND sun elevation).
What was the reasoning behind it? I'm not sure but I thought I'd update the documentation here as well

https://github.com/hvorragend/ha-blueprints/blob/d295a96d1afc9a3082e26bb96f2b92f91ef201fa/blueprints/automation/cover_control_automation.yaml#L4249