### PR TITLE
fix: correct forecast_weather_invalid logic to prevent spurious shading end

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4218,11 +4218,10 @@ actions:
             is_shading_enabled and
             shading_end_condition_enabled.forecast_weather and
             shading_weather_conditions != [] and
-            (
-              forecast_weather_condition_raw is none or
-              forecast_weather_condition_raw in invalid_states or
-              forecast_weather_condition_raw not in shading_weather_conditions
-            )
+            shading_forecast_sensor != [] and
+            forecast_weather_condition_raw is not none and
+            forecast_weather_condition_raw not in invalid_states and
+            forecast_weather_condition_raw not in shading_weather_conditions
           }}
 
       # SHADING END - Combined AND/OR Logic


### PR DESCRIPTION
forecast_weather_invalid was triggering incorrectly when no weather entity was configured (shading_forecast_sensor == []). In that case, forecast_weather_condition_raw returns None, and the previous check `forecast_weather_condition_raw is none` evaluated to TRUE, causing the condition to fire as "invalid" — ending shading on any trigger.

All other _invalid conditions guard against this pattern by explicitly checking that their sensor/entity is configured and the state is valid before comparing. Align forecast_weather_invalid with that pattern:
- Add `shading_forecast_sensor != []` (entity must be configured)
- Change from `is none or in invalid_states` to `is not none and not in invalid_states`
- This ensures the check only fires when valid weather data is actually available

The counterpart forecast_weather_valid correctly handles the missing-entity case via the forecast_source.use_sensor bypass. This fix restores symmetry: when weather data is unavailable, the condition is neutral for both START and END.
