### PR TITLE
fix: Remove incorrect man: 0 resets in non-movement blocks

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4795,7 +4795,6 @@ actions:
                       update_values:
                         shd: 0
                         win: "opn"
-                        man: 0
                         ts:
                           win: "now"
                           shs: 0
@@ -4970,7 +4969,6 @@ actions:
                           update_values:
                             # Set shade pending timestamp
                             shd: 0
-                            man: 0
                             ts:
                               shd: "now"
                               shs: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
@@ -5000,7 +4998,6 @@ actions:
                             # Shading blocked by lockout, record window state, store shading intent
                             shd: 1
                             win: "opn"
-                            man: 0
                             ts:
                               shd: "now"
                               win: "now"
@@ -5063,7 +5060,6 @@ actions:
                           update_values:
                             # Store shading intent for future (cover is closed)
                             shd: 1
-                            man: 0
                             ts:
                               shd: "now"
                               shs: 0
@@ -5088,7 +5084,6 @@ actions:
                           update_values:
                             # Continue waiting with new pending time
                             shd: 0
-                            man: 0
                             ts:
                               shd: "now"
                               shs: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
@@ -5108,7 +5103,6 @@ actions:
                           update_values:
                             # Abort shading start, clear pending
                             shd: 0
-                            man: 0
                             ts:
                               shd: "now"
                               shs: 0
@@ -5194,7 +5188,6 @@ actions:
                           update_values:
                             # Set shading end pending timestamp
                             shd: 1
-                            man: 0
                             ts:
                               shd: "now"
                               shs: 0
@@ -5252,7 +5245,6 @@ actions:
                             # Shading end blocked by lockout, window is open
                             shd: 0
                             win: "opn"
-                            man: 0
                             ts:
                               win: "now"
                               shd: "now"
@@ -5357,7 +5349,6 @@ actions:
                                   update_values:
                                     # Just clear shading state when forced
                                     shd: 0
-                                    man: 0
                                     ts:
                                       shd: "now"
                                       shs: 0
@@ -5380,7 +5371,6 @@ actions:
                           update_values:
                             # Continue waiting with new end pending time
                             shd: 1
-                            man: 0
                             ts:
                               shd: "now"
                               shs: 0
@@ -5400,7 +5390,6 @@ actions:
                           update_values:
                             # Abort shading end retry, keep shading active
                             shd: 1
-                            man: 0
                             ts:
                               shd: "now"
                               shs: 0


### PR DESCRIPTION
The man flag (manual status) should only be set to 0 when the automation actually moves the cover to a defined position, or when an explicit reset trigger fires. Previously, man: 0 was incorrectly set in 11 locations where no cover movement occurs (pending timers, lockout blocks, pure state changes), which could unintentionally clear manual override protection.

Removed man: 0 from:
- Closing skipped (Lockout protection)
- Shading Start Pending: Waiting
- Shading Start skipped: Lockout enabled
- Shading Start skipped: State saved (cover closed)
- Shading Start Pending: Continue waiting
- Shading Start aborted
- Shading End Pending: Waiting
- Shading End blocked by Lockout
- Shading End: Just clear state when force-blocked
- Shading End Pending: Continue waiting
- Shading End aborted

https://claude.ai/code/session_01UTWkTkckayqx6BPq5o6B1S