### PR TITLE
fix(cca): add missing guards in window-tilted ventilation branches

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5502,6 +5502,11 @@ actions:
                       - and:
                           - "{{ state_window == 'opn' }}"
                           - "{{ position_comparisons.current_above_ventilate }}"
+                      # Cover is above ventilate position but system is in privacy-close mode (resident present):
+                      # drive down to ventilate position instead of continuing to close fully
+                      - and:
+                          - "{{ position_comparisons.current_above_ventilate }}"
+                          - "{{ effective_state == 'cls' }}"
 
                 sequence:
                   - variables:
@@ -5536,6 +5541,7 @@ actions:
                 conditions:
                   - "{{ contact_tilted_now }}"
                   - "{{ not contact_opened_now }}"
+                  - "{{ in_ventilate_position }}" # Only update win state if cover is actually at ventilate position
                   - "{{ state_window != 'tlt' }}"
                 sequence:
                   - variables:


### PR DESCRIPTION
Fix 1: Add `in_ventilate_position` guard before `state_window != 'tlt'` in the "Cover already at ventilate position, update win" branch, so the win-state update only fires when the cover is actually at the ventilate position.

Fix 2: Add `current_above_ventilate + effective_state == 'cls'` entry to the or-conditions of "Window tilted - Partial ventilation", so that when the cover is above the ventilate position but the system is in privacy-close mode (resident present), it drives down to the ventilate position instead of continuing to close fully.

https://claude.ai/code/session_013cGZxBevSdZjM3vUTnWy97