### PR TITLE
Remove 'Cover Status Helper is required' notices

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1071,7 +1071,7 @@ blueprint:
       description: >-
         <br />
         <center><code>Settings if the feature ‘💨 - Enable ventilation mode’ has been activated above.</code></center><br />
-        <center><code>All these settings are optional / A Cover Status Helper is required!</code></center><br />
+        <center><code>All these settings are optional.</code></center><br />
       icon: mdi:door-closed-lock
       collapsed: true
       input:
@@ -1233,7 +1233,7 @@ blueprint:
       description: >-
         <br />
         <center><code>Settings if the feature '🥵 - Enable automatic sun protection / sunshade control' has been activated above.</code></center><br />
-        <center><code>All these settings are optional / A Cover Status Helper is required! / The attributes of default sun sensor (configured above) is used.</code></center><br />
+        <center><code>All these settings are optional / The attributes of default sun sensor (configured above) is used.</code></center><br />
       icon: mdi:shield-sun-outline
       collapsed: true
       input:
@@ -2007,7 +2007,6 @@ blueprint:
       name: "Manual Override"
       description: >-
         <br />
-        <center><code>A Cover Status Helper is required!</code></center><br />
       icon: mdi:debug-step-over
       collapsed: true
       input:
@@ -2035,7 +2034,6 @@ blueprint:
               - If option is activated: The action to open, close, etc. is not performed because a conscious decision was made to do otherwise due to a manual intervention.
 
 
-            A Cover Status Helper is required!
 
             </details>
 


### PR DESCRIPTION
The Cover Status Helper is now mandatory, so the hints in section descriptions and input documentation are no longer needed.