### PR TITLE
fix: allow window-open lockout to work regardless of resident ventila…

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5475,7 +5475,6 @@ actions:
           - "{{ trigger.id in ['t_contact_tilted_changed', 't_contact_opened_changed'] }}"
           - "{{ trigger.from_state.state not in invalid_states }}"
           - "{{ trigger.to_state.state not in invalid_states }}"
-          - "{{ resident_flags.allow_ventilate }}"
         sequence:
           # Wait for all sensor changes to settle
           - delay:
@@ -5552,6 +5551,7 @@ actions:
                   - "{{ contact_tilted_now }}"
                   - "{{ not contact_opened_now }}"
                   - "{{ force_allows_ventilate }}" # TODO
+                  - "{{ 'resident_allow_ventilation' in resident_config or not resident_now }}"
                   - condition: !input auto_ventilate_condition
                   # Position check: Only move if cover is below ventilation position (or option enabled)
                   - or:


### PR DESCRIPTION
…tion config

When a resident arrives and closes the blind, then a window is opened, the blind should return to open_position (lockout protection). Previously, the entire ventilation handler was gated by `resident_flags.allow_ventilate`, which blocked all ventilation processing — including physical lockout protection — when a resident was present without `resident_allow_ventilation` configured.

Changes:
- Remove `resident_flags.allow_ventilate` top-level condition from "Contact sensor state changed" branch so the handler always runs on window changes
- Add `resident_allow_ventilation` check directly to "Window tilted - Partial ventilation" sub-branch using live `resident_now` (post-delay sensor read) to correctly handle race conditions when resident and window change quickly

https://claude.ai/code/session_01FCx2cnEXuwxRHjaZ5KjTkn