### PR TITLE
feat: collapse Automation Options descriptions for mobile usability

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -48,10 +48,21 @@ blueprint:
       name: "Automation Options"
       icon: mdi:window-shutter-cog
       collapsed: true
+      description: >-
+        Configure what CCA controls and how it behaves. Most settings use safe defaults — expand the descriptions below only if you need details.
       input:
         auto_options:
           name: "👉 What should CCA control?"
           description: >-
+            Select which opening, closing, and special behaviors CCA should manage.
+
+            *Not sure? The defaults (Morning Opening, Evening Closing, Time Control) work for most setups.*
+
+
+            <details>
+            <summary><code><strong>📖 CLICK HERE:</strong> How these options work together</code></summary>
+
+
             **Basic Controls (When to move):**
 
             Enable morning opening and/or evening closing.
@@ -94,13 +105,14 @@ blueprint:
 
 
             <details>
-
-
             <summary><code><strong>⚙️ CLICK HERE:</strong> Notes on multiple triggering</code></summary>
 
 
             Even if multiple opening, closing, shading, etc. is activated, this only works if a trigger is available.
             However, the numeric state triggers only trigger under certain circumstances. See: [FAQ - Why are my numeric triggers not firing?](https://github.com/hvorragend/ha-blueprints/blob/main/blueprints/automation/FAQ.md#q-why-are-my-numeric-triggers-not-firing)
+
+
+            </details>
 
 
             </details>
@@ -136,12 +148,10 @@ blueprint:
         time_control:
           name: "⏲️ Time Control Type"
           description: >-
-            Select how time-based opening and closing is scheduled.
-            Only relevant when **Time Control** is enabled above.
+            Select how time-based opening and closing is scheduled. *(Only relevant when **Time Control** is enabled above.)*
 
             <details>
-            <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
-            <br />
+            <summary><code><strong>📖 CLICK HERE:</strong> Further descriptions</code></summary>
             <ins>Input fields for time control</ins><br />
             The times for opening and closing the cover are configured in the Time Control section below.
             Even if you only want to control the covers using brightness values or the sun elevation,
@@ -172,6 +182,10 @@ blueprint:
             How should Brightness and Sun Elevation conditions be combined when **both** are active?
 
 
+            <details>
+            <summary><code><strong>📖 CLICK HERE:</strong> OR vs. AND — which to choose?</code></summary>
+
+
             **⚡ OR** *(Default — recommended for most users)*
 
             The cover opens/closes as soon as **either** condition is met.
@@ -191,6 +205,8 @@ blueprint:
 
 
             *Has no effect when only one of the two conditions is enabled.*
+
+            </details>
           default: "or"
           selector:
             select:
@@ -209,6 +225,10 @@ blueprint:
             **Fine-tune automation behavior for your specific hardware and preferences.**
 
 
+            <details>
+            <summary><code><strong>📖 CLICK HERE:</strong> What each category controls</code></summary>
+
+
             This section lets you customize how CCA behaves in different scenarios:
 
             - **Position Management**: Control cover movements between states (e.g., avoid raising when closing for the evening)
@@ -221,7 +241,7 @@ blueprint:
 
 
             <details>
-            <summary><code><strong>CLICK HERE:</strong> Hardware-Specific Details</code></summary>
+            <summary><code><strong>🔧 CLICK HERE:</strong> Hardware-Specific Details</code></summary>
 
 
             <ins>Why use custom actions instead of default services?</ins><br />
@@ -236,6 +256,9 @@ blueprint:
             - Homematic: Use custom service [homematicip_local.set_cover_combined_position](https://github.com/SukramJ/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position)
 
             - Other devices: Implement via "Additional Actions" in the Service Calls section
+
+            </details>
+
 
             </details>
 


### PR DESCRIPTION
Move most descriptive text in the feature_section behind <details> blocks so users reach the input controls after reading only 1–2 lines per field.

Changes:
- Add section-level one-liner description to feature_section
- auto_options: 2 visible lines + new outer <details> wrapping all prose and existing nested <details> blocks; add default-reassurance hint
- time_control: tighten to 1 visible line; add 📖 emoji to summary; remove stray <br /> at top of expanded block
- brightness_sun_operator: 1 visible question; new <details> for OR/AND explanations and the trailing caveat
- individual_config: 1 visible bold line; new <details> wrapping intro + bullets + existing hardware block; upgrade hardware summary to 🔧

Always-visible prose in section drops from ~38 lines to ~5 lines.

https://claude.ai/code/session_01FvNaePHiCa9sd6uu3CLWc9