### PR TITLE
fix: prevent resident closing when cover already at ventilation position

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5910,7 +5910,6 @@ actions:
                           - "{{ contact_window_tilted != [] and states(contact_window_tilted) in ['true', 'on'] }}"
                           - "{{ 'resident_allow_ventilation' in resident_config }}"
                           - "{{ is_ventilation_enabled }}"
-                          - "{{ effective_state != 'vnt' or not in_ventilate_position }}"
                         sequence:
                           - variables:
                               target_position: !input ventilate_position
@@ -5922,7 +5921,7 @@ actions:
                                 ts:
                                   win: "now"
                                   res: "now"
-                          - if: "{{ force_allows_ventilate }}"
+                          - if: "{{ force_allows_ventilate and (effective_state != 'vnt' or not in_ventilate_position) }}"
                             then:
                               - delay:
                                   seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"


### PR DESCRIPTION
When resident_allow_ventilation was enabled and the cover was already at the ventilation position, condition 4 of the ventilation branch evaluated to False (already in correct state), causing the branch to be skipped. The subsequent closing branch then fired, incorrectly closing the cover.

Fix: Move the 'already-in-correct-position' guard from the ventilation branch conditions into the inner `if force_allows_ventilate` check. The ventilation branch now always matches when window is tilted + resident_allow_ventilation + is_ventilation_enabled, preventing fallthrough to the closing branch regardless of current cover position.

https://claude.ai/code/session_01Tw4gsQtQXgEk3JKGRX9HxQ