### PR TITLE
fix: defensive fallback for shading_forecast_type + robustness for us…

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2652,7 +2652,8 @@ trigger_variables:
   # Shading forecast configuration
   shading_forecast_sensor: !input shading_forecast_sensor
   shading_forecast_temp_sensor: !input shading_forecast_temp_sensor
-  shading_forecast_type: !input shading_forecast_type
+  shading_forecast_type_raw: !input shading_forecast_type
+  shading_forecast_type: "{{ shading_forecast_type_raw if shading_forecast_type_raw not in ['', none, []] else 'daily' }}"
   shading_forecast_temp: !input shading_forecast_temp
   shading_forecast_temp_hysteresis: !input shading_forecast_temp_hysteresis
   shading_weather_conditions: !input shading_weather_conditions
@@ -2927,7 +2928,7 @@ variables:
   # Priority: sensor > weather entity > attributes
   forecast_source:
     use_sensor: "{{ shading_forecast_temp_sensor != [] }}"
-    use_weather: "{{ shading_forecast_sensor != [] and shading_forecast_temp_sensor == [] }}"
+    use_weather: "{{ shading_forecast_sensor != [] and shading_forecast_temp_sensor in invalid_states }}"
     prevent_service: "{{ 'weather_attributes' in shading_forecast_type }}"
 
   # Shading condition enablement
@@ -4003,7 +4004,7 @@ actions:
         target:
           entity_id: !input shading_forecast_sensor
         data:
-          type: !input shading_forecast_type
+          type: "{{ shading_forecast_type }}"
         response_variable: weather_forecast
         continue_on_error: true
 


### PR DESCRIPTION
…e_weather check

Addresses issue #391.

- shading_forecast_type: HA can store null in automation config when a select input is never explicitly touched in the UI (default: daily is not persisted). Changed from plain !input to an intermediate raw variable + template fallback to 'daily', so the service call to weather.get_forecasts always receives a valid type value even when the input resolves to null/empty.

- Service call now uses the resolved variable instead of !input directly, ensuring the fallback is consistently applied.

- forecast_source.use_weather: changed shading_forecast_temp_sensor == [] to shading_forecast_temp_sensor in invalid_states for defensive consistency with the rest of the codebase (invalid_states already contains [] as a member).

https://claude.ai/code/session_016yf3SaXgYftsDT5qoUruYU