### PR TITLE
fix: clear stale shading-end pending when conditions recover (#395)

### DIFF
--- a/blueprints/automation/CHANGELOG.md
+++ b/blueprints/automation/CHANGELOG.md
@@ -76,6 +76,9 @@ The helper stores all relevant state information: the current base state, shadin
 
 ## 🔧 Bug Fixes
 
+### Cover stuck in shading position when conditions change rapidly ([#395](https://github.com/hvorragend/ha-blueprints/issues/395))
+On days with rapidly changing luminosity (e.g. alternating sun and clouds), the cover could remain stuck in the shading position for the rest of the day instead of opening when the sun moved past `shading_azimuth_end`. The internal shading-end pending state was never cleared if conditions recovered between the pending and execution phase, blocking all subsequent shading-end attempts until the midnight reset. The pending state is now cleared correctly so the next trigger can re-arm the shading-end flow.
+
 ### Redundant cover movements prevented ([#344](https://github.com/hvorragend/ha-blueprints/issues/344))
 The cover no longer moves when it is already at the target position or within the configured position tolerance range.
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5450,6 +5450,23 @@ actions:
                               she: 0
                       - *helper_update
                       - stop: "Shading End aborted: Timeout or invalid"
+            # Issue #395: Execution trigger fires but end conditions are no longer met
+            # (e.g. brightness recovered after a brief cloud). Without clearing 'she'
+            # the template trigger stays true forever (now() >= she always holds for a
+            # past timestamp), so it never re-fires and new pending triggers are blocked
+            # by helper_state_pending_end — cover gets stuck on the shading position.
+            else:
+              - if:
+                  - "{{ trigger.id | regex_match('^(t_shading_end_execution)') }}"
+                  - "{{ helper_state_pending_end }}"
+                then:
+                  - variables:
+                      update_values:
+                        shd: 1
+                        ts:
+                          she: 0
+                  - *helper_update
+                  - stop: "Shading End: cleared stale pending (conditions no longer met)"
 
       ############################################################
       # BRANCH (5): CONTACT SENSOR HANDLING


### PR DESCRIPTION
When shading_end_immediate_by_sun_position is enabled and conditions fluctuate rapidly (e.g. clouds passing), the t_shading_end_execution template trigger could fire while shading_end_conditions_met had become false again. The outer if-guard then skipped every choose branch, including the cleanup, leaving helper.shading.q (she) populated with a past timestamp.

Because the template trigger only fires on false→true transitions and now() >= she stays permanently true once she lies in the past, the trigger never re-fired. Subsequent t_shading_end_pending_* triggers were also blocked by helper_state_pending_end, so the cover stayed in the shading position until the midnight reset.

Add an else branch that clears she when t_shading_end_execution fires without satisfied conditions, allowing the pending mechanism to re-arm on the next valid trigger.