### PR TITLE
fix(shading): read weather condition from entity state, not 'conditio…

### DIFF
--- a/blueprints/automation/CHANGELOG.md
+++ b/blueprints/automation/CHANGELOG.md
@@ -76,6 +76,17 @@ The helper stores all relevant state information: the current base state, shadin
 
 ## 🔧 Bug Fixes
 
+### Shading never starts when using `weather_attributes` forecast mode ([#399](https://github.com/hvorragend/ha-blueprints/issues/399))
+In `shading_forecast_type: weather_attributes` mode, the current weather condition was read from the `condition` attribute of the weather entity. Most modern Home Assistant weather integrations expose the current condition as the entity **state**, not as an attribute, so this lookup returned `None` permanently. The resulting always-false `forecast_weather_valid` blocked the AND result and prevented shading from ever starting. The lookup now uses the entity state, which matches the Home Assistant weather entity contract.
+
+A diagnostic variable `diag_forecast_weather_attribute_mode` was added to the trace; it is populated only in `weather_attributes` mode and exposes the attribute value, the configured allow-list, and whether the current value is in that list.
+
+### Pending shading-start trigger no longer exits silently when conditions are not met
+When a `t_shading_start_pending_*` trigger fired but the combined start conditions evaluated false (e.g. due to a transient invalid sensor state), control fell into an inner `choose:` whose two options both required `t_shading_start_execution`. Without a `default:` branch, the run terminated silently and the trace ended on an irrelevant trigger-id regex check. A `default:` branch with an explicit `stop:` was added so the trace clearly reports the actual termination reason.
+
+### Brightness, temp1 and temp2 conditions trust their pending trigger
+The individual `*_valid` evaluations previously flipped to false if the source sensor was in `invalid_states` at the moment the action ran, even when the corresponding pending trigger had just fired (i.e. the value_template — which is identical — had evaluated true on that very sensor). This was a frequent cause of shading not starting when users had derived (template/min/max) sensors whose source briefly went unavailable. When the matching pending trigger is the active trigger, a transient `invalid_states` no longer overrides it.
+
 ### Cover stuck in shading position when conditions change rapidly ([#395](https://github.com/hvorragend/ha-blueprints/issues/395))
 On days with rapidly changing luminosity (e.g. alternating sun and clouds), the cover could remain stuck in the shading position for the rest of the day instead of opening when the sun moved past `shading_azimuth_end`. The internal shading-end pending state was never cleared if conditions recovered between the pending and execution phase, blocking all subsequent shading-end attempts until the midnight reset. The pending state is now cleared correctly so the next trigger can re-arm the shading-end flow.
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4063,11 +4063,23 @@ actions:
         {% if weather == [] or states(weather) in invalid_states %}
           {{ None }}
         {% elif 'weather_attributes' in shading_forecast_type %}
-          {{ state_attr(weather, 'condition') }}
+          {{ states(weather) }}
         {% elif weather_forecast is defined and weather in weather_forecast %}
           {{ weather_forecast[weather].forecast[0].condition | default(None) }}
         {% else %}
           {{ None }}
+        {% endif %}
+
+      diag_forecast_weather_attribute_mode: >-
+        {% if forecast_source.prevent_service %}
+          {{
+            {
+              'attribute_value': forecast_weather_condition_raw,
+              'in_configured_list': (forecast_weather_condition_raw in shading_weather_conditions)
+                                    if forecast_weather_condition_raw is not none else none,
+              'configured_list': shading_weather_conditions
+            }
+          }}
         {% endif %}
 
       # SHADING START - Individual Condition Evaluations
@@ -4099,6 +4111,10 @@ actions:
             not shading_start_condition_enabled.brightness or
             shading_brightness_sensor == [] or
             (
+              states(shading_brightness_sensor) in invalid_states and
+              trigger is defined and trigger.id == 't_shading_start_pending_2'
+            ) or
+            (
               states(shading_brightness_sensor) not in invalid_states and
               states(shading_brightness_sensor) | float(default=shading_sun_brightness_start) > (shading_sun_brightness_start + shading_sun_brightness_hysteresis)
             )
@@ -4109,6 +4125,10 @@ actions:
             not shading_start_condition_enabled.temp1 or
             shading_temperatur_sensor1 == [] or
             (
+              states(shading_temperatur_sensor1) in invalid_states and
+              trigger is defined and trigger.id == 't_shading_start_pending_3'
+            ) or
+            (
               states(shading_temperatur_sensor1) not in invalid_states and
               states(shading_temperatur_sensor1) | float(default=shading_min_temperatur1) > (shading_min_temperatur1 + shading_temperature_hysteresis1)
             )
@@ -4118,6 +4138,10 @@ actions:
             not is_shading_enabled or
             not shading_start_condition_enabled.temp2 or
             shading_temperatur_sensor2 == [] or
+            (
+              states(shading_temperatur_sensor2) in invalid_states and
+              trigger is defined and trigger.id == 't_shading_start_pending_4'
+            ) or
             (
               states(shading_temperatur_sensor2) not in invalid_states and
               states(shading_temperatur_sensor2) | float(default=shading_min_temperatur2) > (shading_min_temperatur2 + shading_temperature_hysteresis2)
@@ -5164,6 +5188,9 @@ actions:
                               she: 0
                       - *helper_update
                       - stop: "Shading Start aborted: Timeout or invalid"
+
+                default:
+                  - stop: "Shading start skipped: Pending trigger fired but combined start conditions evaluated false."
 
       ############################################################
       # BRANCH (3): SHADING Tilt


### PR DESCRIPTION
…n' attribute (#399)

Modern Home Assistant weather integrations expose the current condition as the entity state, not as a 'condition' attribute. Reading the attribute returned None for most users, permanently blocking shading via the forecast_weather_valid path in weather_attributes mode.

Also closes the silent exit when a t_shading_start_pending_* trigger lands on the inner else's choose with both options requiring the execution trigger, and trusts the matching pending trigger when the source sensor goes briefly invalid between trigger and action evaluation. Adds a trace-only diag_forecast_weather_attribute_mode variable for visibility in weather_attributes mode where there is no service-call step in the trace.

Refs: https://github.com/hvorragend/ha-blueprints/issues/399