### PR TITLE
Fix reset manual detection

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -6824,9 +6824,6 @@ actions:
               update_values:
                 # Reset manual override
                 man: 0
-                ts:
-                  shs: 0
-                  she: 0
           - *helper_update
           - choose: []
             default: !input auto_override_reset_action


### PR DESCRIPTION
Issue: https://github.com/hvorragend/ha-blueprints/issues/408

Shading start and end detection during the timeframe of manual change, should not be overwritten, so that retry loop for shading start and end detection could again recognize past triggers. 