### PR TITLE
fix(shading): use dedicated ts.shr anchor for shading-start retry dur…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ State is persisted as a JSON string in an `input_text` helper:
 
 ```json
 {"bas":"opn","shd":1,"win":"opn","frc":"non","res":1,"man":0,
- "ts":{"opn":0,"cls":0,"shd":0,"shs":0,"she":0,"win":0,"man":0,"res":0},
+ "ts":{"opn":0,"cls":0,"shd":0,"shs":0,"she":0,"shr":0,"man":0},
  "v":6,"t":0}
 ```
 
@@ -29,9 +29,10 @@ State is persisted as a JSON string in an `input_text` helper:
 | `ts.shd` | Unix timestamp | Last time shading state changed (0↔1) |
 | `ts.shs` | Unix timestamp | Shading pending start: when pending-start was armed |
 | `ts.she` | Unix timestamp | Shading pending end: when pending-end was armed |
-| `ts.win` | Unix timestamp | Last window state change |
+| `ts.shr` | Unix timestamp | Shading retry anchor: when current retry sequence began |
 | `ts.man` | Unix timestamp | Last manual override event |
-| `ts.res` | Unix timestamp | Last resident status change |
+
+> Note: `ts.win` and `ts.res` were removed during v6 beta. Existing helpers retain those keys until the next helper write, which silently drops them.
 
 ---
 
@@ -146,6 +147,12 @@ The `man` flag (manual override) may only be set to `0` when the automation actu
 **ts.shs / ts.she (shading pending timestamps):**
 - These must not be reset in win-only helper updates (when only `win` is updated without a drive)
 
+**ts.shr (shading retry anchor):**
+- Set to `"now"` exactly once when a retry sequence begins (in the "Shading detected. Save next execution time and pending status" branch)
+- Preserved across all retry-continuation branches (do not include `shr` in `update_values.ts` there — `helper_update` keeps the existing value)
+- Reset to `0` in every terminal branch of the start sequence: Drive, Lockout-skip, Save-for-future, both Abort branches
+- Read by the `shading_start_max_duration` check via `helper_ts_shade_retry` — gives a stable retry-window anchor independent of the Invariant-8 guard on `ts.shd`
+
 ### ⚠️ Invariant 9: `ts_now` must be evaluated at the point of use
 
 `ts_now` (`as_timestamp(now()) | round(0)`) must **never** be defined as a single global variable at the top of the automation action. It must be set locally — directly in the block where the current timestamp is needed.
@@ -249,6 +256,14 @@ if: "{{ force_allows_ventilate and (effective_state != 'lock' or not in_open_pos
 **Cause B:** `ts.shs/ts.she` are reset in win-only helper updates.
 
 **Fix:** Guard in `helper_update` — only apply `ts.shd` when `new_shd != current.shd`. Do not reset `ts.shs/ts.she` in win-only updates.
+
+### Bug Pattern I: Shading-start retry aborts on fresh day (Issue #416)
+
+**Symptom:** First retry attempt of the day aborts immediately when the start conditions are blocked by additional conditions or manual override; the `shading_start_max_duration` window is effectively zero on a fresh helper.
+
+**Cause:** The duration check used `helper_ts_shade` (= `ts.shd`) as anchor. Pending establishment does not transition `shd`, so the Invariant-8 guard preserves `ts.shd` at its previous value (yesterday's shading-end or `0`). `now() - ts.shd` is therefore much larger than `shading_start_max_duration` → check fails → retry aborts.
+
+**Fix:** Dedicated `ts.shr` field that records the retry-sequence start. Set in "Shading detected", preserved across continues, cleared in all terminal branches. Duration check now uses `helper_ts_shade_retry`.
 
 ### Bug Pattern G: `helper_state_window` instead of realtime sensor in `resident_arriving` handler
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@ State is persisted as a JSON string in an `input_text` helper:
 | `ts.shd` | Unix timestamp | Last time shading state changed (0↔1) |
 | `ts.shs` | Unix timestamp | Shading pending start: when pending-start was armed |
 | `ts.she` | Unix timestamp | Shading pending end: when pending-end was armed |
-| `ts.shr` | Unix timestamp | Shading retry anchor: when current retry sequence began |
+| `ts.shr` | Unix timestamp | Shading retry anchor: when current retry sequence (start OR end) began |
 | `ts.man` | Unix timestamp | Last manual override event |
 
 > Note: `ts.win` and `ts.res` were removed during v6 beta. Existing helpers retain those keys until the next helper write, which silently drops them.
@@ -148,10 +148,24 @@ The `man` flag (manual override) may only be set to `0` when the automation actu
 - These must not be reset in win-only helper updates (when only `win` is updated without a drive)
 
 **ts.shr (shading retry anchor):**
-- Set to `"now"` exactly once when a retry sequence begins (in the "Shading detected. Save next execution time and pending status" branch)
+- Single field shared by both shading-start and shading-end retry sequences (mutually exclusive in normal operation, guarded by Invariant 11)
+- Set to `"now"` exactly once when either retry sequence begins (in "Shading detected. Save next execution time and pending status" for start, "Shading end detected. Save next execution time and pending status" for end)
 - Preserved across all retry-continuation branches (do not include `shr` in `update_values.ts` there — `helper_update` keeps the existing value)
-- Reset to `0` in every terminal branch of the start sequence: Drive, Lockout-skip, Save-for-future, both Abort branches
-- Read by the `shading_start_max_duration` check via `helper_ts_shade_retry` — gives a stable retry-window anchor independent of the Invariant-8 guard on `ts.shd`
+- Reset to `0` in every terminal branch of either sequence:
+  - Start: Drive, Lockout-skip, Save-for-future, both Abort branches
+  - End: Tilt-only, Lockout, Ventilation, Move-cover (both then/else), Stop retry, stale-pending cleanup (#395)
+- Read by both `shading_start_max_duration` and `shading_end_max_duration` checks via `helper_ts_shade_retry` — gives a stable retry-window anchor independent of the Invariant-8 guard on `ts.shd`
+
+### ⚠️ Invariant 11: Mutual exclusivity of shading-start and shading-end pending
+
+Pending-start (`ts.shs > 0`) and pending-end (`ts.she > 0`) must never both be active simultaneously. With sane configuration (hysteresis > 0 between start and end thresholds), this state is unreachable. With misconfigured conditions it could otherwise produce ping-pong: start fires → end fires → start fires → …
+
+**Guard:** Both pending-establishment branches gate on the opposite pending state:
+
+- "Shading detected" (start) requires `not helper_state_pending_end`
+- "Shading end detected" requires `not helper_state_pending_start`
+
+This also keeps the shared `ts.shr` retry anchor unambiguous (Invariant 8).
 
 ### ⚠️ Invariant 9: `ts_now` must be evaluated at the point of use
 
@@ -263,7 +277,7 @@ if: "{{ force_allows_ventilate and (effective_state != 'lock' or not in_open_pos
 
 **Cause:** The duration check used `helper_ts_shade` (= `ts.shd`) as anchor. Pending establishment does not transition `shd`, so the Invariant-8 guard preserves `ts.shd` at its previous value (yesterday's shading-end or `0`). `now() - ts.shd` is therefore much larger than `shading_start_max_duration` → check fails → retry aborts.
 
-**Fix:** Dedicated `ts.shr` field that records the retry-sequence start. Set in "Shading detected", preserved across continues, cleared in all terminal branches. Duration check now uses `helper_ts_shade_retry`.
+**Fix:** Dedicated `ts.shr` field that records the retry-sequence start. Set in "Shading detected" (start) and "Shading end detected" (end), preserved across continues, cleared in all terminal branches of both sequences. Duration checks for both `shading_start_max_duration` and `shading_end_max_duration` now use `helper_ts_shade_retry`. The same field serves both directions because the sequences are mutually exclusive (Invariant 11).
 
 ### Bug Pattern G: `helper_state_window` instead of realtime sensor in `resident_arriving` handler
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2720,7 +2720,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.03-beta"
+  version: "2026.05.04-beta"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -2956,7 +2956,7 @@ variables:
   # Cover Status Helper – JSON parsing with v5 → v6 migration
   # ═══════════════════════════════════════════════════════════════════════════
   # v6 Compact Schema (stored in input_text, max 208 chars):
-  # {"bas":"opn","shd":0,"win":"cls","frc":"non","res":0,"man":0,"ts":{"opn":0,"cls":0,"shd":0,"shs":0,"she":0,"win":0,"man":0},"v":6,"t":0}
+  # {"bas":"opn","shd":0,"win":"cls","frc":"non","res":0,"man":0,"ts":{"opn":0,"cls":0,"shd":0,"shs":0,"she":0,"shr":0,"man":0},"v":6,"t":0}
   #
   # Field mapping (compact → internal):
   #   bas → base (opn/cls → open/close)
@@ -2967,7 +2967,8 @@ variables:
   #   man → manual (1/0)
   #   ts.opn → ts.open, ts.cls → ts.close, ts.shd → ts.shade
   #   ts.shs → ts.shade_start, ts.she → ts.shade_end
-  #   ts.win → ts.window, ts.man → ts.manual
+  #   ts.shr → ts.shade_retry (anchor for shading-start retry duration)
+  #   ts.man → ts.manual
   #
   # TODO: Potential v7 expansion fields (~46-106 chars remaining in input_text):
   #   lp  → last_position (+8 chars) – Position before last action (smart recovery)
@@ -3009,9 +3010,8 @@ variables:
             'shd': helper_raw.shading.t | default(0) if v5_current == 'shade' else 0,
             'shs': helper_raw.shading.p | default(0),
             'she': helper_raw.shading.q | default(0),
-            'win': helper_raw.vpart.t | default(helper_raw.vfull.t | default(0)),
-            'man': helper_raw.manual.t | default(0),
-            'res': 0
+            'shr': 0,
+            'man': helper_raw.manual.t | default(0)
           },
           'v': 6,
           't': ts_now
@@ -3033,9 +3033,8 @@ variables:
             'shd': raw_ts.shd | default(0) | int,
             'shs': raw_ts.shs | default(0) | int,
             'she': raw_ts.she | default(0) | int,
-            'win': raw_ts.win | default(0) | int,
-            'man': raw_ts.man | default(0) | int,
-            'res': raw_ts.res | default(0) | int
+            'shr': raw_ts.shr | default(0) | int,
+            'man': raw_ts.man | default(0) | int
           },
           'v': 6,
           't': helper_raw.t | default(ts_now) | int
@@ -3056,9 +3055,8 @@ variables:
             'shd': 0,
             'shs': 0,
             'she': 0,
-            'win': 0,
-            'man': 0,
-            'res': 0
+            'shr': 0,
+            'man': 0
           },
           'v': 6,
           't': ts_now
@@ -3140,6 +3138,7 @@ variables:
   helper_ts_open: "{{ helper_json.ts.opn | default(0) | int }}"
   helper_ts_close: "{{ helper_json.ts.cls | default(0) | int }}"
   helper_ts_shade: "{{ helper_json.ts.shd | default(0) | int }}"
+  helper_ts_shade_retry: "{{ helper_json.ts.shr | default(0) | int }}"
   helper_ts_man: "{{ helper_json.ts.man | default(0) | int }}"
 
   # SHADED STATUS - Is cover currently shaded (not pending)?
@@ -3878,7 +3877,7 @@ actions:
       # Uses v6 compact schema names directly (no internal name conversion)
       #
       # Fields: bas, shd (1/0), win, frc, res (1/0), man (1/0)
-      # Timestamps: ts.opn, ts.cls, ts.shd, ts.shs, ts.she, ts.win, ts.man
+      # Timestamps: ts.opn, ts.cls, ts.shd, ts.shs, ts.she, ts.shr, ts.man
       #
       # Template logic:
       #   1. Apply field updates (compact names directly)
@@ -3904,7 +3903,7 @@ actions:
               {% set current_ts = current.ts | default({}) %}
 
               {% set merged_ts = namespace(data={}) %}
-              {% for key in ['opn', 'cls', 'shd', 'shs', 'she', 'win', 'man', 'res'] %}
+              {% for key in ['opn', 'cls', 'shd', 'shs', 'she', 'shr', 'man'] %}
                 {% set merged_ts.data = dict(merged_ts.data, **{key: current_ts[key] | default(0) | int}) %}
               {% endfor %}
               {% if 'ts' in updates %}
@@ -3929,9 +3928,8 @@ actions:
                   'shd': merged_ts.data.shd | default(0) | int,
                   'shs': merged_ts.data.shs | default(0) | int,
                   'she': merged_ts.data.she | default(0) | int,
-                  'win': merged_ts.data.win | default(0) | int,
-                  'man': merged_ts.data.man | default(0) | int,
-                  'res': merged_ts.data.res | default(0) | int
+                  'shr': merged_ts.data.shr | default(0) | int,
+                  'man': merged_ts.data.man | default(0) | int
                 },
                 'v': 6,
                 't': ts_now | int
@@ -3965,9 +3963,8 @@ actions:
                 'shd': 0,
                 'shs': 0,
                 'she': 0,
-                'win': 0,
-                'man': 0,
-                'res': 0
+                'shr': 0,
+                'man': 0
               },
               'v': 6,
               't': ts_now | int
@@ -5065,6 +5062,7 @@ actions:
                               shd: "now"
                               shs: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
                               she: 0
+                              shr: "now" # Anchor for max-duration retry window
                       - *helper_update
                       - stop: "Shading Start Pending: Waiting"
 
@@ -5103,9 +5101,9 @@ actions:
                                         win: "opn"
                                         ts:
                                           shd: "now"
-                                          win: "now"
                                           shs: 0
                                           she: 0
+                                          shr: 0 # Clear retry anchor (sequence ended)
                                   - *helper_update
                                   - stop: "Shading Start skipped: Lockout enabled"
 
@@ -5135,6 +5133,7 @@ actions:
                                           shd: "now"
                                           shs: 0
                                           she: 0
+                                          shr: 0 # Clear retry anchor (sequence ended)
                                   - if: "{{ force_allows_shade }}"
                                     then:
                                       - delay:
@@ -5163,6 +5162,7 @@ actions:
                                           shd: "now"
                                           shs: 0
                                           she: 0
+                                          shr: 0 # Clear retry anchor (sequence ended)
                                   - *helper_update
                                   - stop: "Shading Start skipped: State saved"
 
@@ -5172,7 +5172,7 @@ actions:
                                 conditions:
                                   - "{{ shading_start_max_duration > 0 }}"
                                   - "{{ is_shading_allowed_window }}" # Continue only within time window
-                                  - "{{ (as_timestamp(now()) - helper_ts_shade) <= shading_start_max_duration }}"
+                                  - "{{ (as_timestamp(now()) - helper_ts_shade_retry) <= shading_start_max_duration }}"
                                 sequence:
                                   - variables:
                                       update_values:
@@ -5196,6 +5196,7 @@ actions:
                                           shd: "now"
                                           shs: 0
                                           she: 0
+                                          shr: 0 # Clear retry anchor (sequence ended)
                                   - *helper_update
                                   - stop: "Shading Start aborted: Timeout or invalid (blocked)"
 
@@ -5210,7 +5211,7 @@ actions:
                       - "{{ helper_state_pending_start }}"
                       - "{{ shading_start_max_duration > 0 }}"
                       - "{{ is_shading_allowed_window }}" # Continue only within time window
-                      - "{{ (as_timestamp(now()) - helper_ts_shade) <= shading_start_max_duration }}"
+                      - "{{ (as_timestamp(now()) - helper_ts_shade_retry) <= shading_start_max_duration }}"
                     sequence:
                       - variables:
                           update_values:
@@ -5239,6 +5240,7 @@ actions:
                               shd: "now"
                               shs: 0
                               she: 0
+                              shr: 0 # Clear retry anchor (sequence ended)
                       - *helper_update
                       - stop: "Shading Start aborted: Timeout or invalid"
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2720,7 +2720,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.04-beta"
+  version: "2026.05.04.1-beta"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5053,6 +5053,7 @@ actions:
                     conditions:
                       - "{{ trigger.id | regex_match('^(t_shading_start_pending)') }}"
                       - "{{ not helper_state_pending_start }}" # Not if a pending is already active
+                      - "{{ not helper_state_pending_end }}" # Mutual-exclusivity guard against misconfigured conditions
                     sequence:
                       - variables:
                           update_values:
@@ -5312,6 +5313,7 @@ actions:
                     conditions:
                       - "{{ trigger.id | regex_match('^(t_shading_end_pending)') }}"
                       - "{{ not helper_state_pending_end }}"
+                      - "{{ not helper_state_pending_start }}" # Mutual-exclusivity guard against misconfigured conditions
                     sequence:
                       - variables:
                           local_waitingtime_end: >
@@ -5327,6 +5329,7 @@ actions:
                               shd: "now"
                               shs: 0
                               she: "{{ (as_timestamp(now()) + local_waitingtime_end | int) | int }}"
+                              shr: "now" # Anchor for max-duration retry window
                       - *helper_update
                       - stop: "Shading End Pending: Waiting"
 
@@ -5350,6 +5353,7 @@ actions:
                               shd: "now"
                               shs: 0
                               she: 0
+                              shr: 0 # Clear retry anchor (sequence ended)
                       - if:
                           - "{{ not is_forced }}"
                         then:
@@ -5381,10 +5385,10 @@ actions:
                             shd: 0
                             win: "opn"
                             ts:
-                              win: "now"
                               shd: "now"
                               shs: 0
                               she: 0
+                              shr: 0 # Clear retry anchor (sequence ended)
                       - *helper_update
                       - stop: "Shading End skipped: Lockout enabled"
 
@@ -5416,10 +5420,10 @@ actions:
                             win: "tlt"
                             man: "{{ 0 if force_allows_ventilate else helper_json.man | default(0) | int }}"
                             ts:
-                              win: "now"
                               shd: "now"
                               shs: 0
                               she: 0
+                              shr: 0 # Clear retry anchor (sequence ended)
                       - if: "{{ force_allows_ventilate }}"
                         then:
                           - delay: # TODO: I can no longer recognize the original trigger here. That might be a bad idea here.
@@ -5463,6 +5467,7 @@ actions:
                                   shd: "now"
                                   shs: 0
                                   she: 0
+                                  shr: 0 # Clear retry anchor (sequence ended)
                           - if: "{{ force_allows_open }}"
                             then:
                               - delay: # TODO: I can no longer recognize the original trigger here. That might be a bad idea here.
@@ -5488,6 +5493,7 @@ actions:
                                       shd: "now"
                                       shs: 0
                                       she: 0
+                                      shr: 0 # Clear retry anchor (sequence ended)
                               - *helper_update
                       - stop: "Shading End (Opening after shading) executed"
 
@@ -5500,7 +5506,7 @@ actions:
                       - "{{ helper_state_pending_end }}"
                       - "{{ shading_end_max_duration > 0 }}"
                       - "{{ is_shading_allowed_window }}" # Continue only within time window
-                      - "{{ (as_timestamp(now()) - helper_ts_shade) <= shading_end_max_duration }}"
+                      - "{{ (as_timestamp(now()) - helper_ts_shade_retry) <= shading_end_max_duration }}"
                     sequence:
                       - variables:
                           update_values:
@@ -5529,6 +5535,7 @@ actions:
                               shd: "now"
                               shs: 0
                               she: 0
+                              shr: 0 # Clear retry anchor (sequence ended)
                       - *helper_update
                       - stop: "Shading End aborted: Timeout or invalid"
             # Issue #395: Execution trigger fires but end conditions are no longer met
@@ -5546,6 +5553,7 @@ actions:
                         shd: 1
                         ts:
                           she: 0
+                          shr: 0 # Clear retry anchor (sequence ended)
                   - *helper_update
                   - stop: "Shading End: cleared stale pending (conditions no longer met)"
 

--- a/docs/card-examples/cover-status-card-tile.yaml
+++ b/docs/card-examples/cover-status-card-tile.yaml
@@ -86,8 +86,8 @@ cards:
             {%- if s.ts.shs | default(0) > 0 %}🎬 Starts at {{ s.ts.shs | timestamp_custom('%H:%M', true) }}
             {%- elif s.ts.she | default(0) > 0 %}🔚 Ends at {{ s.ts.she | timestamp_custom('%H:%M', true) }}
             {%- elif s.shd == 1 %}🕒 Active since {{ s.ts.shd | default(0) | timestamp_custom('%H:%M', true) }}
-            {%- elif s.win == 'tlt' %}🕒 Ventilating since {{ s.ts.win | default(0) | timestamp_custom('%H:%M', true) }}
-            {%- elif s.win == 'opn' %}🛡️ Locked since {{ s.ts.win | default(0) | timestamp_custom('%H:%M', true) }}
+            {%- elif s.win == 'tlt' %}🕒 Ventilating
+            {%- elif s.win == 'opn' %}🛡️ Locked
             {%- elif s.bas == 'cls' %}🌙 Closed since {{ s.ts.cls | default(0) | timestamp_custom('%H:%M', true) }}
             {%- elif s.bas == 'opn' %}🌅 Open since {{ s.ts.opn | default(0) | timestamp_custom('%H:%M', true) }}
             {%- else %}ℹ️ Status OK

--- a/docs/card-examples/cover-status-flex-table.yaml
+++ b/docs/card-examples/cover-status-flex-table.yaml
@@ -144,19 +144,6 @@ columns:
                  d.toLocaleTimeString('de-DE', {hour:'2-digit', minute:'2-digit'});
         } catch(e) { return '—'; }
       })()
-  - name: 💨 ts.win
-    data: state
-    modify: |-
-      (() => {
-        try {
-          const j = JSON.parse(x);
-          const ts = j.ts?.win;
-          if (!ts) return '—';
-          const d = new Date(ts * 1000);
-          return d.toLocaleDateString('de-DE', {day:'2-digit', month:'2-digit'}) + ' ' +
-                 d.toLocaleTimeString('de-DE', {hour:'2-digit', minute:'2-digit'});
-        } catch(e) { return '—'; }
-      })()
   - name: ⏳ ts.shs
     data: state
     modify: |-

--- a/docs/card-examples/cover-status-flex-table.yaml
+++ b/docs/card-examples/cover-status-flex-table.yaml
@@ -170,6 +170,19 @@ columns:
                  d.toLocaleTimeString('de-DE', {hour:'2-digit', minute:'2-digit'});
         } catch(e) { return '—'; }
       })()
+  - name: 🔁 ts.shr
+    data: state
+    modify: |-
+      (() => {
+        try {
+          const j = JSON.parse(x);
+          const ts = j.ts?.shr;
+          if (!ts) return '—';
+          const d = new Date(ts * 1000);
+          return d.toLocaleDateString('de-DE', {day:'2-digit', month:'2-digit'}) + ' ' +
+                 d.toLocaleTimeString('de-DE', {hour:'2-digit', minute:'2-digit'});
+        } catch(e) { return '—'; }
+      })()
   - name: Updated
     data: state
     modify: |-

--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -3064,8 +3064,8 @@
                 if (helperJson.ts && typeof helperJson.ts === 'object') {
                     const ts = helperJson.ts;
                     const tsLabels = {
-                        open: 'Last Open', close: 'Last Close', shade: 'Last Shade Active', shade_start: 'Shade Start Pending', shade_end: 'Shade End Pending', window: 'Last Window Change', manual: 'Last Manual Override', resident: 'Last Resident Change',
-                        opn: 'Last Open', cls: 'Last Close', shd: 'Last Shade', shs: 'Shade Start Pending', she: 'Shade End Pending', win: 'Last Window', man: 'Last Manual', res: 'Last Resident'
+                        open: 'Last Open', close: 'Last Close', shade: 'Last Shade Active', shade_start: 'Shade Start Pending', shade_end: 'Shade End Pending', shade_retry: 'Shade Retry Anchor', manual: 'Last Manual Override',
+                        opn: 'Last Open', cls: 'Last Close', shd: 'Last Shade', shs: 'Shade Start Pending', she: 'Shade End Pending', shr: 'Shade Retry Anchor', man: 'Last Manual'
                     };
                     const tsEntries = Object.entries(ts).filter(([, v]) => v && v > 0);
                     if (tsEntries.length > 0) {


### PR DESCRIPTION
…ation (#416)

Pending establishment does not transition shd, so the Invariant-8 guard in helper_update preserved ts.shd at its previous value (yesterday's shading-end or 0). The retry duration check (now - ts.shd <= shading_start_max_duration) therefore evaluated against a stale anchor and aborted retry on the very first attempt of a fresh day, defeating both the natural-conditions retry path and the auto_shading_start_condition / manual-override retry path added in #408.

Add a dedicated ts.shr field that records when the current retry sequence began. Set it in "Shading detected", preserve it across continue branches, clear it in every terminal branch (Drive, Lockout, Save-for-future, both Abort variants). Both shading-start duration checks now use the new helper_ts_shade_retry alias.

To stay within the 254-byte input_text limit, the dead ts.win and ts.res timestamp fields (written everywhere but never read) are removed during the v6 beta phase. helper_json, helper_update, and the empty-helper init no longer emit them; existing beta helpers retain the keys until the next write, which silently drops them. Net byte count: 208/254 (was 225/254).

Beta version bump 2026.05.03 -> 2026.05.04.