### PR TITLE
fix(trace-analyzer): show recently added runtime variables

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -3461,15 +3461,20 @@
                     'current_sun_azimuth', 'current_sun_elevation',
                     'sun_elevation_up', 'sun_elevation_down',
                     'sun_elevation_up_current', 'sun_elevation_down_current',
-                    'brightness_up', 'brightness_down', 'brightness_hysteresis'
+                    'sun_elevation_mode',
+                    'brightness_up', 'brightness_down', 'brightness_hysteresis',
+                    'brightness_sun_operator', 'use_and_operator'
                 ],
                 'Shading Configuration': [
                     'shading_azimuth_start', 'shading_azimuth_end',
                     'shading_elevation_min', 'shading_elevation_max',
-                    'shading_sun_brightness_start', 'shading_sun_brightness_end',
-                    'shading_min_temperatur1', 'shading_min_temperatur2',
-                    'shading_forecast_temp',
-                    'shading_waitingtime_start', 'shading_waitingtime_end'
+                    'shading_sun_brightness_start', 'shading_sun_brightness_end', 'shading_sun_brightness_hysteresis',
+                    'shading_min_temperatur1', 'shading_temperature_hysteresis1',
+                    'shading_min_temperatur2', 'shading_temperature_hysteresis2',
+                    'shading_forecast_temp', 'shading_forecast_temp_hysteresis',
+                    'shading_waitingtime_start', 'shading_waitingtime_end',
+                    'shading_start_max_duration', 'shading_end_max_duration',
+                    'shading_end_immediate_by_sun_position', 'is_shading_end_immediate_by_sun_position'
                 ],
                 'Shading Conditions': [
                     'shading_conditions_start_and', 'shading_conditions_start_or',
@@ -3481,11 +3486,14 @@
                     'shading_start_conditions_met', 'shading_end_conditions_met'
                 ],
                 'Helper Status': [
-                    'helper_status', 'helper_json', 'helper_ts'
+                    'helper_status', 'helper_json', 'helper_ts',
+                    'helper_state_pending_start', 'helper_state_pending_end', 'helper_state_is_shaded',
+                    'helper_ts_shade', 'helper_ts_shade_retry'
                 ],
                 'Blocking & Force': [
                     'is_cover_movement_blocked',
-                    'auto_up_force', 'auto_down_force', 'auto_ventilate_force', 'auto_shading_start_force'
+                    'auto_up_force', 'auto_down_force', 'auto_ventilate_force', 'auto_shading_start_force',
+                    'force_pause', 'is_paused'
                 ],
                 'Override & Manual': [
                     'override_flags', 'ignore_after_manual_config',
@@ -3507,7 +3515,8 @@
                     'contact_delay_trigger', 'contact_delay_status'
                 ],
                 'Forecast': [
-                    'forecast_source', 'shading_forecast_sensor', 'shading_forecast_type'
+                    'forecast_source', 'shading_forecast_sensor', 'shading_forecast_type',
+                    'shading_forecast_temp_sensor'
                 ],
                 'Tilt Settings': [
                     'open_tilt_position', 'close_tilt_position', 'ventilate_tilt_position',

--- a/docs/validator/validator.js
+++ b/docs/validator/validator.js
@@ -20,10 +20,7 @@ class CCAValidator {
             'blind', 'cover_type', 'auto_options', 'individual_config',
 
             // Helper
-            'cover_status_options', 'cover_status_helper', 'drive_time',
-
-            // Background State Tracking (since 2025.12.27)
-            'enable_background_state_tracking',
+            'cover_status_helper', 'drive_time',
 
             // Positions
             'position_source', 'custom_position_sensor',
@@ -183,7 +180,6 @@ class CCAValidator {
             this.validateDynamicSunElevation();
             this.validateCalendarConfiguration();
             this.validatePositionSource();
-            this.validateHelperConfiguration();
             this.validateTiltFeatures();
             this.validateTimingValues();
             this.validateForceEntities();
@@ -295,14 +291,16 @@ class CCAValidator {
             }
         }
 
-        if (this.config.enable_background_state_tracking === false || this.config.enable_background_state_tracking === undefined) {
-            this.addInfo('ℹ️ Background state tracking is disabled (default). Enable enable_background_state_tracking for automatic return to target state after force functions.');
-        } else if (this.config.enable_background_state_tracking === true) {
-            if (!this.config.cover_status_helper || this.config.cover_status_helper.length === 0) {
-                this.addWarning('🦮 Background state tracking is enabled but no cover_status_helper configured. This feature requires a helper.');
-            } else {
-                this.addInfo('✅ Background state tracking enabled — cover returns to target state after force functions are disabled.');
-            }
+        const recover = this.config.auto_recover_after_force;
+        const recoverEnabled = typeof recover === 'string'
+            ? recover === 'auto_recover_enabled'
+            : Array.isArray(recover) && recover.includes('auto_recover_enabled');
+        if (!recoverEnabled) {
+            this.addInfo('ℹ️ Force recovery is disabled (default). Set auto_recover_after_force to "auto_recover_enabled" so the cover returns to its target state after a force function is disabled.');
+        } else if (!this.config.cover_status_helper || this.config.cover_status_helper.length === 0) {
+            this.addWarning('🦮 Force recovery (auto_recover_after_force) is enabled but no cover_status_helper configured. This feature requires a helper.');
+        } else {
+            this.addInfo('✅ Force recovery enabled — cover returns to target state after force functions are disabled.');
         }
     }
 
@@ -616,20 +614,6 @@ class CCAValidator {
         const c = this.config;
         if (c.position_source === 'custom_sensor' && (!c.custom_position_sensor || c.custom_position_sensor.length === 0)) {
             this.addError('Custom position sensor selected but not configured');
-        }
-    }
-
-    validateHelperConfiguration() {
-        const c = this.config;
-        const autoOptions = c.auto_options || [];
-        const needsHelper = autoOptions.includes('auto_shading_enabled') || autoOptions.includes('auto_ventilate_enabled');
-
-        if (needsHelper && c.cover_status_options !== 'cover_helper_enabled') {
-            this.addWarning('🦮 Shading or Ventilation requires a cover status helper. Set cover_status_options to "cover_helper_enabled" and configure cover_status_helper.');
-        }
-
-        if (c.cover_status_options === 'cover_helper_enabled' && (!c.cover_status_helper || c.cover_status_helper.length === 0)) {
-            this.addError('❌ Helper enabled (cover_status_options) but cover_status_helper entity not configured.');
         }
     }
 
@@ -1039,7 +1023,6 @@ auto_options:
   - auto_sun_enabled
 
 # Helper required for shading
-cover_status_options: cover_helper_enabled
 cover_status_helper: input_text.example_cover_status
 
 # Sun sensor for shading


### PR DESCRIPTION
The renderVariables groups missed several variables that exist in the blueprint but were not displayed when present in a trace:

- Sun & Brightness: sun_elevation_mode, brightness_sun_operator, use_and_operator
- Shading Configuration: hysteresis fields (sun_brightness, temp1/2, forecast_temp), shading_start_max_duration, shading_end_max_duration, shading_end_immediate_by_sun_position + is_shading_end_immediate_by_sun_position
- Helper Status: helper_state_pending_start/end, helper_state_is_shaded, helper_ts_shade, helper_ts_shade_retry
- Blocking & Force: force_pause, is_paused
- Forecast: shading_forecast_temp_sensor