### PR TITLE
fix: shading regex falsely matches ts.shd timestamp (#467)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -361,6 +361,14 @@ ts:
 
 **Root fix:** `effective_state` was changed to derive `win` from **live contact sensors** instead of the stale `h.win` helper field. When sensors are configured, the live sensor value takes priority; when no sensors are configured, it falls back to `h.win`. This means `effective_state` now correctly returns `'opn'` (not `'lock'`) when the window transitions from open → tilted and `bas == 'opn'`. The tilted-drive branch guards with `{{ effective_state != 'opn' }}`, and the no-drive branch catches `{{ effective_state == 'opn' }}`.
 
+### Bug Pattern K: `regex_search('"shd"\s*:\s*1')` matches `ts.shd` timestamp (Issue #467)
+
+**Symptom:** All `t_shading_start_pending_*` triggers are blocked by condition/3 even though `shd == 0` (shading inactive). The automation stops despite valid shading conditions.
+
+**Cause:** The regex `"shd"\s*:\s*1` is intended to check if the top-level `shd` field is `1`, but the helper JSON contains a nested `ts.shd` timestamp (e.g. `"shd":1779701945`) whose value starts with `1`. The regex matches this nested timestamp, making the condition think shading is already active.
+
+**Fix:** Change all 6 occurrences of the regex to `"shd"\s*:\s*1\s*[,}]` — requiring a comma or closing brace after the `1` ensures it matches only the top-level `"shd":1,` and not a multi-digit timestamp value.
+
 ---
 
 ## Language & Style Conventions

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3676,7 +3676,7 @@ triggers:
     value_template: >-
       {{
         states(cover_status_helper) not in invalid_states and
-        states(cover_status_helper) | regex_search('"shd"\s*:\s*1') and
+        states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_1
       }}
     enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
@@ -3686,7 +3686,7 @@ triggers:
     value_template: >-
       {{
         states(cover_status_helper) not in invalid_states and
-        states(cover_status_helper) | regex_search('"shd"\s*:\s*1') and
+        states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_2 and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_1
       }}
@@ -3697,7 +3697,7 @@ triggers:
     value_template: >-
       {{
         states(cover_status_helper) not in invalid_states and
-        states(cover_status_helper) | regex_search('"shd"\s*:\s*1') and
+        states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_3 and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_2
       }}
@@ -3708,7 +3708,7 @@ triggers:
     value_template: >-
       {{
         states(cover_status_helper) not in invalid_states and
-        states(cover_status_helper) | regex_search('"shd"\s*:\s*1') and
+        states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_3
       }}
     enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
@@ -3863,9 +3863,9 @@ conditions:
   - condition: template
     value_template: >-
       {% if trigger.id is match('^t_shading_start_pending_[1-6]$') %}
-        {{ not (states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1')) }}
+        {{ not (states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]')) }}
       {% elif trigger.id is match('^t_shading_end_pending_[1-6]$') %}
-        {{ states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1') }}
+        {{ states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') }}
       {% else %}
         true
       {% endif %}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - 🐛 **Fix:** Contact handler incorrectly lowered cover to ventilation position when base state was open (`bas=opn`) and window transitioned from fully open to tilted ([#460](https://github.com/hvorragend/ha-blueprints/issues/460))
 - 🔧 **Improvement:** `effective_state` now reads the window state from **live contact sensors** instead of the stale helper field — eliminates an entire class of stale-state bugs where `effective_state` returned `lock` instead of the correct cascade result during contact handler execution
+- 🐛 **Fix:** Shading condition regex `"shd"\s*:\s*1` falsely matched the `ts.shd` timestamp (e.g. `"shd":1779701945`) inside the nested `ts` object, blocking all `t_shading_start_pending_*` triggers even when shading was inactive ([#467](https://github.com/hvorragend/ha-blueprints/issues/467))
 
 ---
 


### PR DESCRIPTION
The regex `"shd"\s*:\s*1` in condition/3 and the shading tilt triggers was intended to check whether shading is active (top-level `"shd":1`), but it also matched the nested `ts.shd` Unix timestamp (e.g. `"shd":1779701945`) whose value starts with `1`. This caused all `t_shading_start_pending_*` triggers to be blocked even when shading was inactive (`shd:0`).

Fix: anchor the regex with `[,}]` after the `1` so it only matches `"shd":1,` or `"shd":1}`, not multi-digit timestamp values.

https://claude.ai/code/session_01BQwkS5dP6Dvs7W82ZqTcam