### PR TITLE
fix: shading start pending survives pre-window execution (#470)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -369,6 +369,22 @@ ts:
 
 **Fix:** Change all 6 occurrences of the regex to `"shd"\s*:\s*1\s*[,}]` — requiring a comma or closing brace after the `1` ensures it matches only the top-level `"shd":1,` and not a multi-digit timestamp value.
 
+### Bug Pattern L: Shading start pending aborted before time window opens (Issue #470)
+
+**Symptom:** Shading start pending is armed before the opening time (e.g. 06:12 CEST, opening at 07:00 CEST). When the execution trigger fires (after the waiting time), shading is permanently aborted. Shading never starts for the rest of the day.
+
+**Cause:** The `if:` block at the top of the shading start sequence has two AND conditions:
+1. Shading conditions met (OR independent temp mode)
+2. `trigger.id` matches `t_shading_start_pending` OR `is_shading_allowed_window`
+
+Pending triggers bypass `is_shading_allowed_window` via the OR (condition 2). But execution triggers (`t_shading_start_execution`) do NOT bypass it — they require `is_shading_allowed_window` to be true. Before the opening time, `is_shading_allowed_window` is false, so the `if:` fails.
+
+In the `else` branch, the retry mechanism also requires `is_shading_allowed_window`, so retry is blocked too. The abort branch runs and permanently clears the pending. After the time window opens, no new `t_shading_start_pending_*` trigger fires (false→true transition already happened), so shading never starts.
+
+**Masked by Bug Pattern K:** Before the #467 regex fix, all shading start pending triggers were blocked at condition/3 level when `ts.shd` started with `1`. The time window bug was invisible because the triggers never got through.
+
+**Fix:** Add "waiting for time window" branches in both `else` blocks (outer: conditions not met; inner: blocked by condition/override) that re-arm the pending with a new `ts.due` when `is_shading_allowed_window` is false. These branches also reset `ts.arm` to "now" so that `shading_start_max_duration` only counts from when the time window actually opens.
+
 ---
 
 ## Language & Style Conventions

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.26
+    **Version**: 2026.05.27
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2793,7 +2793,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.26"
+  version: "2026.05.27"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5328,6 +5328,21 @@ actions:
 
                         else: # Blocked by additional condition or manual override - retry or abort
                           - choose:
+                              - alias: "Shading start blocked - waiting for time window"
+                                conditions:
+                                  - "{{ not is_shading_allowed_window }}"
+                                sequence:
+                                  - variables:
+                                      log_extra: "blocked, waiting for time window; next_retry_in={{ shading_waitingtime_start | int }}s"
+                                      update_values:
+                                        shd: 0
+                                        pnd: 'beg'
+                                        ts:
+                                          due: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
+                                          arm: "now"
+                                  - *helper_update
+                                  - stop: "Shading Start Pending: Waiting for time window (blocked)"
+
                               - alias: "Shading start blocked by additional condition or manual override - check if we should continue"
                                 conditions:
                                   - "{{ shading_start_max_duration > 0 }}"
@@ -5364,6 +5379,26 @@ actions:
 
             else: # Shading conditions were no longer met or not met again.
               - choose:
+                  #####################################################################
+                  # Shading start execution - waiting for time window to open
+                  #####################################################################
+                  - alias: "Shading start execution - waiting for time window"
+                    conditions:
+                      - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}"
+                      - "{{ helper_state_pending_start }}"
+                      - "{{ not is_shading_allowed_window }}"
+                    sequence:
+                      - variables:
+                          log_extra: "waiting for time window; next_retry_in={{ shading_waitingtime_start | int }}s"
+                          update_values:
+                            shd: 0
+                            pnd: 'beg'
+                            ts:
+                              due: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
+                              arm: "now"
+                      - *helper_update
+                      - stop: "Shading Start Pending: Waiting for time window"
+
                   #####################################################################
                   # Shading start conditions not met - check if we should continue
                   #####################################################################

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.27
+
+- 🐛 **Fix:** Shading start pending armed before time window opens was permanently aborted at execution time because the retry mechanism required `is_shading_allowed_window` — the execution now re-arms the pending and waits for the time window to open instead of aborting ([#470](https://github.com/hvorragend/ha-blueprints/issues/470))
+
+---
+
 # CCA 2026.05.26
 
 - 🐛 **Fix:** Contact handler incorrectly lowered cover to ventilation position when base state was open (`bas=opn`) and window transitioned from fully open to tilted ([#460](https://github.com/hvorragend/ha-blueprints/issues/460))


### PR DESCRIPTION
When shading conditions were met before the time window opened (e.g.
06:12 CEST with opening at 07:00), the pending was armed (bypassing
the window check), but the execution trigger aborted permanently
because both the execution path and the retry path required
is_shading_allowed_window to be true. After the window opened, no new
trigger fired (false→true transition already consumed), so shading
never started for the rest of the day.

Add "waiting for time window" branches in both else blocks of the
shading start logic. When is_shading_allowed_window is false, the
pending is re-armed instead of aborted. ts.arm is reset so
shading_start_max_duration only counts from when the window opens.

https://claude.ai/code/session_01A8yuzyVyWzFj9HWkjawh7e