### PR TITLE
feat: add option to disable drive delay on ventilation start

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1172,6 +1172,13 @@ blueprint:
             <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
 
+              - <ins>Disables the drive delay when ventilation starts (window opens/tilts):</ins>
+                <br />
+                By default, the "Fixed Drive Delay" and "Random Drive Delay" are applied to all cover movements — including ventilation start.
+                If you use a large fixed delay to stagger many covers (e.g. for Somfy RF queue limits), this can feel sluggish when only one or two covers need to react to a window opening.
+                <br />
+                Enable this option to skip the drive delay when a window opens or tilts. The delay still applies to all other movements (open, close, shading).
+                <br /><br />
               - <ins>Enables a calculated delay after the window is closed:</ins>
                 <br />
                 Normally, when the window contact is closed, there is no delay in the upcoming drives. If you do want this, you can activate it here.
@@ -1204,6 +1211,8 @@ blueprint:
           selector:
             select:
               options:
+                - label: "💨 Disables the drive delay when ventilation starts (window opens/tilts)"
+                  value: "ventilation_start_no_delay"
                 - label: "💨 Enables a calculated delay after the window is closed"
                   value: "ventilation_delay_enabled"
                 - label: "💨 Lower cover to ventilation position when window tilts and cover is above"
@@ -3331,6 +3340,7 @@ variables:
   contact_delay_trigger: !input contact_delay_trigger
   contact_delay_status: !input contact_delay_status
   ventilation_flags:
+    start_no_delay: "{{ 'ventilation_start_no_delay' in auto_ventilate_options }}"
     delay_enabled: "{{ 'ventilation_delay_enabled' in auto_ventilate_options }}"
     if_lower_enabled: "{{ 'ventilation_if_lower_enabled' in auto_ventilate_options }}"
     after_shading_end: "{{ 'ventilation_after_shading_end' in auto_ventilate_options }}"
@@ -5073,8 +5083,11 @@ actions:
                           arm: 0
                   - if: "{{ force_allows_ventilate }}"
                     then:
-                      - delay:
-                          seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                      - if:
+                          - "{{ not ventilation_flags.start_no_delay }}"
+                        then:
+                          - delay:
+                              seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
                       - choose: []
                         default: !input auto_ventilate_action_before
                       - *cover_move_action
@@ -5814,8 +5827,11 @@ actions:
                           arm: 0
                   - if: "{{ force_allows_open }}"
                     then:
-                      - delay:
-                          seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                      - if:
+                          - "{{ not ventilation_flags.start_no_delay }}"
+                        then:
+                          - delay:
+                              seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
                       - choose: []
                         default: !input auto_up_action_before
                       - *cover_move_action
@@ -5890,8 +5906,11 @@ actions:
                           arm: 0
                   - if: "{{ force_allows_ventilate }}"
                     then:
-                      - delay:
-                          seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
+                      - if:
+                          - "{{ not ventilation_flags.start_no_delay }}"
+                        then:
+                          - delay:
+                              seconds: "{{ range(drive_delay_fix|int(0), drive_delay_fix|int(0) + drive_delay_random|int(0) +1) | random }}"
                       - choose: []
                         default: !input auto_ventilate_action_before
                       - *cover_move_action

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # CCA 2026.05.27
 
+- ✨ **Feature:** New ventilation option to disable the drive delay when ventilation starts (window opens/tilts) — useful for setups with many covers where a large fixed delay is needed for staggering, but single-cover ventilation reactions should be instant
 - 🐛 **Fix:** Shading start pending armed before time window opens was permanently aborted at execution time because the retry mechanism required `is_shading_allowed_window` — the execution now re-arms the pending and waits for the time window to open instead of aborting ([#470](https://github.com/hvorragend/ha-blueprints/issues/470))
 
 ---


### PR DESCRIPTION
Users with many covers (e.g. 15 Somfy) need a large fixed drive delay to stagger morning/evening movements, but this makes single-cover ventilation reactions feel sluggish. The new "ventilation_start_no_delay" option in Ventilation Configuration skips the drive delay when a window opens or tilts, while keeping it for all other movements.

https://claude.ai/code/session_01J6PLWgChgrQSGCgvkDt5Kv