### PR TITLE
Fix: Shading start pending aborts when armed before time window

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -369,21 +369,13 @@ ts:
 
 **Fix:** Change all 6 occurrences of the regex to `"shd"\s*:\s*1\s*[,}]` — requiring a comma or closing brace after the `1` ensures it matches only the top-level `"shd":1,` and not a multi-digit timestamp value.
 
-### Bug Pattern L: Shading start pending aborted before time window opens (Issue #470)
+### Bug Pattern L: Shading pending arms before time window → execution aborts immediately
 
-**Symptom:** Shading start pending is armed before the opening time (e.g. 06:12 CEST, opening at 07:00 CEST). When the execution trigger fires (after the waiting time), shading is permanently aborted. Shading never starts for the rest of the day.
+**Symptom:** Shading conditions are met shortly before `time_up_early_today` (e.g. 06:55 with window at 07:00). Pending arms successfully, but execution aborts with `"Shading Start aborted: Timeout or invalid"` despite having thousands of seconds of `shading_start_max_duration` remaining.
 
-**Cause:** The `if:` block at the top of the shading start sequence has two AND conditions:
-1. Shading conditions met (OR independent temp mode)
-2. `trigger.id` matches `t_shading_start_pending` OR `is_shading_allowed_window`
+**Cause:** The outer if (line ~5196) allows pending triggers to bypass `is_shading_allowed_window` (via `trigger.id` match on `t_shading_start_pending`), but requires it for execution triggers. When `ts.due` (= `now + waitingtime`) resolves to a time before the window opens, the execution trigger fires too early, fails the outer if, and the retry also requires `is_shading_allowed_window` → abort.
 
-Pending triggers bypass `is_shading_allowed_window` via the OR (condition 2). But execution triggers (`t_shading_start_execution`) do NOT bypass it — they require `is_shading_allowed_window` to be true. Before the opening time, `is_shading_allowed_window` is false, so the `if:` fails.
-
-In the `else` branch, the retry mechanism also requires `is_shading_allowed_window`, so retry is blocked too. The abort branch runs and permanently clears the pending. After the time window opens, no new `t_shading_start_pending_*` trigger fires (false→true transition already happened), so shading never starts.
-
-**Masked by Bug Pattern K:** Before the #467 regex fix, all shading start pending triggers were blocked at condition/3 level when `ts.shd` started with `1`. The time window bug was invisible because the triggers never got through.
-
-**Fix:** Add "waiting for time window" branches in both `else` blocks (outer: conditions not met; inner: blocked by condition/override) that re-arm the pending with a new `ts.due` when `is_shading_allowed_window` is false. These branches also reset `ts.arm` to "now" so that `shading_start_max_duration` only counts from when the time window actually opens.
+**Fix:** In the pending arming branch, compute `ts.due` as `max(now + waitingtime, window_start_time)`. When the window is already open, this equals `now + waitingtime` (unchanged). When arming before the window, execution is deferred to the window start. No retry logic changes needed — the execution fires within the window and the normal flow handles it.
 
 ---
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5420,11 +5420,10 @@ actions:
                       - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}"
                       - "{{ helper_state_pending_start }}"
                       - "{{ shading_start_max_duration > 0 }}"
-                      - "{{ is_shading_allowed_window }}" # Continue only within time window
                       - "{{ (as_timestamp(now()) - helper_ts_pending_arm) <= shading_start_max_duration }}"
                     sequence:
                       - variables:
-                          log_extra: "shading_start_conditions_met=false; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_start_max_duration | int }}s; next_retry_in={{ shading_waitingtime_start | int }}s"
+                          log_extra: "conditions_met={{ shading_start_conditions_met }}; in_window={{ is_shading_allowed_window }}; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_start_max_duration | int }}s; next_retry_in={{ shading_waitingtime_start | int }}s"
                           update_values:
                             # Continue waiting with new pending time
                             shd: 0
@@ -5436,7 +5435,7 @@ actions:
                       - stop: "Shading Start Pending: Continue waiting"
 
                   ######################################################################
-                  # Shading start / Stop retry (timeout OR outside time window OR disabled)
+                  # Shading start / Stop retry (timeout OR max_duration disabled)
                   ######################################################################
                   - alias: "Shading start / Stop retry"
                     conditions:
@@ -5717,11 +5716,10 @@ actions:
                       - "{{ trigger.id | regex_match('^(t_shading_end_execution)') }}"
                       - "{{ helper_state_pending_end }}"
                       - "{{ shading_end_max_duration > 0 }}"
-                      - "{{ is_shading_allowed_window }}" # Continue only within time window
                       - "{{ (as_timestamp(now()) - helper_ts_pending_arm) <= shading_end_max_duration }}"
                     sequence:
                       - variables:
-                          log_extra: "shading_end_conditions_met=false (after exec); elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_end_max_duration | int }}s; next_retry_in={{ shading_waitingtime_end | int }}s"
+                          log_extra: "conditions_met={{ shading_end_conditions_met }}; in_window={{ is_shading_allowed_window }}; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_end_max_duration | int }}s; next_retry_in={{ shading_waitingtime_end | int }}s"
                           update_values:
                             # Continue waiting with new end pending time
                             shd: 1
@@ -5733,7 +5731,7 @@ actions:
                       - stop: "Shading End Pending: Continue waiting"
 
                   ######################################################################
-                  # Shading end / Stop retry (timeout OR outside time window OR disabled)
+                  # Shading end / Stop retry (timeout OR max_duration disabled)
                   ######################################################################
                   - alias: "Shading end / Stop retry"
                     conditions:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5420,6 +5420,10 @@ actions:
                       - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}"
                       - "{{ helper_state_pending_start }}"
                       - "{{ shading_start_max_duration > 0 }}"
+                      - >-
+                        {{ is_shading_allowed_window or
+                           (is_time_field_enabled and now() < today_at(time_up_early_today)) or
+                           (is_calendar_enabled and calendar_open_start is not none and now_ts < calendar_open_start) }}
                       - "{{ (as_timestamp(now()) - helper_ts_pending_arm) <= shading_start_max_duration }}"
                     sequence:
                       - variables:
@@ -5716,10 +5720,11 @@ actions:
                       - "{{ trigger.id | regex_match('^(t_shading_end_execution)') }}"
                       - "{{ helper_state_pending_end }}"
                       - "{{ shading_end_max_duration > 0 }}"
+                      - "{{ is_shading_allowed_window }}"
                       - "{{ (as_timestamp(now()) - helper_ts_pending_arm) <= shading_end_max_duration }}"
                     sequence:
                       - variables:
-                          log_extra: "conditions_met={{ shading_end_conditions_met }}; in_window={{ is_shading_allowed_window }}; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_end_max_duration | int }}s; next_retry_in={{ shading_waitingtime_end | int }}s"
+                          log_extra: "shading_end_conditions_met=false (after exec); elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_end_max_duration | int }}s; next_retry_in={{ shading_waitingtime_end | int }}s"
                           update_values:
                             # Continue waiting with new end pending time
                             shd: 1
@@ -5731,7 +5736,7 @@ actions:
                       - stop: "Shading End Pending: Continue waiting"
 
                   ######################################################################
-                  # Shading end / Stop retry (timeout OR max_duration disabled)
+                  # Shading end / Stop retry (timeout OR outside time window OR disabled)
                   ######################################################################
                   - alias: "Shading end / Stop retry"
                     conditions:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5232,9 +5232,9 @@ actions:
                             {% if is_time_control_disabled or is_shading_allowed_window %}
                               {{ wait_due }}
                             {% elif is_time_field_enabled %}
-                              {{ [wait_due, as_timestamp(today_at(time_up_early_today)) | int] | max }}
+                              {{ [wait_due, as_timestamp(today_at(time_up_early_today)) | int + 1] | max }}
                             {% elif is_calendar_enabled and calendar_open_start is not none %}
-                              {{ [wait_due, calendar_open_start | int] | max }}
+                              {{ [wait_due, calendar_open_start | int + 1] | max }}
                             {% else %}
                               {{ wait_due }}
                             {% endif %}

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -5227,14 +5227,25 @@ actions:
                       - "{{ not helper_state_pending_end }}" # Mutual-exclusivity guard against misconfigured conditions
                     sequence:
                       - variables:
-                          log_extra: "shading start pending armed; wait={{ shading_waitingtime_start | int }}s; max_duration={{ shading_start_max_duration | int }}s"
+                          shading_start_due: >-
+                            {% set wait_due = (as_timestamp(now()) + shading_waitingtime_start | int) | int %}
+                            {% if is_time_control_disabled or is_shading_allowed_window %}
+                              {{ wait_due }}
+                            {% elif is_time_field_enabled %}
+                              {{ [wait_due, as_timestamp(today_at(time_up_early_today)) | int] | max }}
+                            {% elif is_calendar_enabled and calendar_open_start is not none %}
+                              {{ [wait_due, calendar_open_start | int] | max }}
+                            {% else %}
+                              {{ wait_due }}
+                            {% endif %}
+                          log_extra: "shading start pending armed; wait={{ shading_waitingtime_start | int }}s; due_in={{ (shading_start_due | int - as_timestamp(now()) | int) }}s; max_duration={{ shading_start_max_duration | int }}s"
                           update_values:
                             # Set shade pending timestamp
                             shd: 0
                             pnd: 'beg'
                             ts:
                               shd: "now"
-                              due: "{{ (as_timestamp(now()) + shading_waitingtime_start | int) | int }}"
+                              due: "{{ shading_start_due | int }}"
                               arm: "now" # Anchor for max-duration retry window
                       - *helper_update
                       - stop: "Shading Start Pending: Waiting"
@@ -5420,14 +5431,11 @@ actions:
                       - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}"
                       - "{{ helper_state_pending_start }}"
                       - "{{ shading_start_max_duration > 0 }}"
-                      - >-
-                        {{ is_shading_allowed_window or
-                           (is_time_field_enabled and now() < today_at(time_up_early_today)) or
-                           (is_calendar_enabled and calendar_open_start is not none and now_ts < calendar_open_start) }}
+                      - "{{ is_shading_allowed_window }}"
                       - "{{ (as_timestamp(now()) - helper_ts_pending_arm) <= shading_start_max_duration }}"
                     sequence:
                       - variables:
-                          log_extra: "conditions_met={{ shading_start_conditions_met }}; in_window={{ is_shading_allowed_window }}; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_start_max_duration | int }}s; next_retry_in={{ shading_waitingtime_start | int }}s"
+                          log_extra: "shading_start_conditions_met=false; elapsed={{ (as_timestamp(now()) - helper_ts_pending_arm) | int }}s/{{ shading_start_max_duration | int }}s; next_retry_in={{ shading_waitingtime_start | int }}s"
                           update_values:
                             # Continue waiting with new pending time
                             shd: 0
@@ -5439,7 +5447,7 @@ actions:
                       - stop: "Shading Start Pending: Continue waiting"
 
                   ######################################################################
-                  # Shading start / Stop retry (timeout OR max_duration disabled)
+                  # Shading start / Stop retry (timeout OR outside time window OR disabled)
                   ######################################################################
                   - alias: "Shading start / Stop retry"
                     conditions:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 # CCA 2026.05.27
 
 - ✨ **Feature:** New ventilation option to disable the drive delay when ventilation starts (window opens/tilts) — useful for setups with many covers where a large fixed delay is needed for staggering, but single-cover ventilation reactions should be instant
-- 🐛 **Fix:** Shading start pending armed before time window opens was permanently aborted at execution time because the retry mechanism required `is_shading_allowed_window` — the execution now re-arms the pending and waits for the time window to open instead of aborting ([#470](https://github.com/hvorragend/ha-blueprints/issues/470))
+- 🐛 **Fix:** Shading start pending armed before time window opens no longer aborts immediately — `ts.due` is now set to `max(now + waitingtime, window_start)`, ensuring execution fires after the window opens instead of aborting with only seconds elapsed of a multi-hour `max_duration` budget ([#475](https://github.com/hvorragend/ha-blueprints/issues/475))
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #475

- When shading conditions are met before `time_up_early` (e.g. 06:55 with window at 07:00), `ts.due` is now set to `max(now + waitingtime, window_start + 1)` so the execution trigger fires after the window opens
- Previously, `ts.due = now + waitingtime` resolved to a time before the window, causing the execution to abort immediately
- The +1s buffer prevents edge cases from HA template evaluation timing variance

## Root Cause

The outer if allows pending triggers to bypass `is_shading_allowed_window`, but requires it for execution triggers. When `ts.due` fell before the window, the execution fired too early → outer if failed → retry also required `is_shading_allowed_window` → abort.

## Fix approach

Single change at the pending arming branch: defer `ts.due` to window start when arming before the window. No changes to the retry/abort logic needed — the execution fires within the window and the normal flow handles it.

| Scenario | ts.due (before) | ts.due (after) |
|----------|----------------|----------------|
| 06:55, window 07:00, wait=60s | 06:56 → **Abort** | 07:00:01 → OK |
| 08:30, window 07:00 (already open) | 08:31 → OK | 08:31 → OK (unchanged) |
| No time window (disabled) | now + wait → OK | now + wait → OK (unchanged) |

## Test plan

- [x] All 118 unit tests pass
- [ ] Manual test: shading conditions met 5 min before `time_up_early` → verify cover drives to shading position after window opens
- [ ] Verify normal shading (conditions met within window) is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdjPXzZq3p74x3ZkqLtKCQ)_