### PR TITLE
Add shading_end trigger condition to calendar event handler

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4155,6 +4155,7 @@ actions:
           - "{{ trigger.id | regex_match('^t_open') }}"
           - "{{ trigger.id | regex_match('^t_close') }}"
           - "{{ trigger.id | regex_match('^t_shading_start') }}"
+          - "{{ trigger.id | regex_match('^t_shading_end') }}"
           - "{{ trigger.id | regex_match('^t_calendar_event') }}"
     then:
       - action: calendar.get_events


### PR DESCRIPTION
## Summary
Added support for the `t_shading_end` trigger ID pattern in the calendar event handler's condition check, enabling the automation to process calendar events when shading end timers fire.

## Changes
- Added `"{{ trigger.id | regex_match('^t_shading_end') }}"` condition to the calendar event handler's trigger ID validation logic
- This allows the `calendar.get_events` action to execute when a shading end pending timer triggers, consistent with the existing `t_shading_start` pattern

## Implementation Details
The change follows the existing pattern used for other trigger types (`t_open`, `t_close`, `t_shading_start`, `t_calendar_event`). The `t_shading_end` trigger is now properly recognized alongside `t_shading_start`, ensuring symmetrical handling of both shading lifecycle events within the calendar integration flow.

https://claude.ai/code/session_01PFch8QDWB14qEeRSGbtdWW