### PR TITLE
docs: clarify Time Control role and interaction with sensor triggers …

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -67,39 +67,47 @@ blueprint:
 
             **Basic Controls (When to move):**
 
-            Enable morning opening and/or evening closing.
+            - **Morning Opening / Evening Closing** — Enable automatic opening and/or closing.
 
 
             **Fine-Tuning (When to trigger):**
 
-            Control whether time, brightness, and sun elevation influence opening and closing.
-            Set the condition logic (AND/OR) when both brightness and sun elevation are active.
+            - **⏲️ Time Control** — Defines the Early/Late time windows that constrain *all* other triggers.
+            Keep this ON even when using Brightness or Sun Elevation — the time fields set the boundaries.
+            Early = earliest the cover may move; Late = guaranteed move (safety net).
+
+            - **🔅 Brightness** / **☀️ Sun Elevation** — Additional triggers that fire *within* the time window.
+            Set the condition logic (AND/OR) when both are active.
             Configure thresholds and sensors in the dedicated sections below.
 
 
             **Advanced Features (How to react):**
 
-            Add ventilation mode and/or sun protection for situational behavior.
+            - **💨 Ventilation** — React to open/tilted windows, prevent lockout.
+
+            - **🥵 Sun Protection** — Partially close when sun shines directly on the window (midday heat).
 
 
-            **Sun Elevation vs. Sun Protection are two different things!**
+            **☀️ Sun Elevation vs. 🥵 Sun Protection are two different things!**
 
-            - **Sun Elevation** (☀️) = Opens/closes based on sunrise/sunset — configure thresholds in *Sun Elevation Settings* below
+            - **Sun Elevation** = *When* to open/close (sunrise/sunset trigger) — configure in *Sun Elevation Settings*
 
-            - **Sun Protection** (🥵) = Partially closes the cover during midday when the sun shines directly on the window
+            - **Sun Protection** = *Shading* during midday when the sun shines directly on the window
 
 
-            **Example of a summer day**
+            **Example: Sun Elevation + Time Control (most common setup)**
 
-            - **6:00** — Sun Elevation triggers opening (sun rose above your threshold)
+            - **6:00** — Early time reached → Sun Elevation trigger is now allowed
 
-            - **7:00** — Time-based opening would have happened (but cover is already open)
+            - **6:30** — Sun rises above threshold → cover opens
 
-            - **12:00** — Sun Protection activates (sun now shines directly on window → partial close)
+            - **8:00** — Late time → cover would open now regardless (but it's already open)
 
-            - **18:00** — Sun Protection deactivates (sun moved away → cover opens again)
+            - **20:00** — Early closing time reached → Sun Elevation trigger is now allowed
 
-            - **21:00** — Sun Elevation triggers closing (sun dropped below your threshold)
+            - **21:00** — Sun drops below threshold → cover closes
+
+            - **22:00** — Late closing time → cover would close regardless (safety net)
 
 
             **Notes on multiple triggering**
@@ -119,19 +127,19 @@ blueprint:
           selector:
             select:
               options:
-                - label: "🔼 Morning Opening — Automatically open based on configured time"
+                - label: "🔼 Morning Opening — Automatically open the cover each morning"
                   value: "auto_up_enabled"
-                - label: "🔻 Evening Closing — Automatically close based on configured time"
+                - label: "🔻 Evening Closing — Automatically close the cover each evening"
                   value: "auto_down_enabled"
-                - label: "⏲️ Time Control — Enable time-based opening & closing triggers"
+                - label: "⏲️ Time Control — Use time windows (Early/Late) to constrain when triggers fire"
                   value: "time_control_enabled"
-                - label: "🔅 Brightness Control — Open/close earlier based on ambient brightness"
+                - label: "🔅 Brightness Control — Trigger opening/closing based on ambient brightness sensor"
                   value: "auto_brightness_enabled"
-                - label: "☀️ Sun Elevation Control — Open/close based on sun position (sunrise/sunset)"
+                - label: "☀️ Sun Elevation Control — Trigger opening/closing based on sun position (sunrise/sunset)"
                   value: "auto_sun_enabled"
                 - label: "💨 Ventilation Mode — React to open/tilted windows, prevent lockout"
                   value: "auto_ventilate_enabled"
-                - label: "🥵 Sun Protection / Shading — Partially close when sun shines on window"
+                - label: "🥵 Sun Protection / Shading — Partially close when sun shines directly on window"
                   value: "auto_shading_enabled"
               multiple: true
               sort: false
@@ -148,8 +156,11 @@ blueprint:
             <br />
             <ins>Input fields for time control</ins><br /><br />
             The times for opening and closing the cover are configured in the Time Control section below.
-            Even if you only want to control the covers using brightness values or the sun elevation,
-            it is important to specify times — they are used to define the "morning" (up) and "evening" (down) windows.
+            These time fields define the <strong>Early</strong> and <strong>Late</strong> boundaries — even when
+            using Brightness or Sun Elevation as the actual trigger. Early = earliest allowed trigger time;
+            Late = guaranteed fallback. See the
+            <a href="https://hvorragend.github.io/ha-blueprints/TIME_CONTROL_VISUALIZATION">Time Control Guide</a>
+            for a visual explanation.
             <br /><br />
             <ins>Calendar Control</ins><br />
             You can use a Home Assistant calendar to define when covers should be open or closed.


### PR DESCRIPTION
…(#480)

Improve option labels and descriptions to explain that Time Control defines the Early/Late time windows constraining all other triggers, not just time-based opening/closing. Add per-option explanations and a concrete example showing Sun Elevation + Time Control together.

https://claude.ai/code/session_018gJZ62PYUWJsP7PfFJJQiL