### PR TITLE
fix(card): show manual override activation time correctly

### DIFF
--- a/examples/cover-status-card-tile.yaml
+++ b/examples/cover-status-card-tile.yaml
@@ -77,7 +77,7 @@ cards:
           {%- set frc = s.frc | default('non') %}
           {%- if frc == 'shd' %}🕒 Active since {{ s.ts.shd | default(0) | timestamp_custom('%H:%M', true) }}
           {%- elif frc != 'non' %}📍 Position: {{ pos }}%
-          {%- elif s.man == 1 %}🖐️ Hold until {{ s.ts.man | default(0) | timestamp_custom('%H:%M', true) }}
+          {%- elif s.man == 1 %}🖐️ Active since {{ s.ts.man | default(0) | timestamp_custom('%H:%M', true) }}
           {%- elif pos_raw is not none and
                    ((s.bas == 'cls' and pos > 5) or
                    (s.bas == 'opn' and s.shd == 0 and s.win == 'cls' and pos < 95)) %}


### PR DESCRIPTION
ts.man stores when the override was activated, not when it resets. "Hold until" was therefore always showing the wrong time. Changed to "Active since" which accurately reflects the stored timestamp.

https://claude.ai/code/session_0181BiNgqeGPH8U7rGNZcnxE