### PR TITLE
fix: split combined sun-position shading end trigger into azimuth and elevation (#483)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -377,6 +377,18 @@ ts:
 
 **Fix:** In the pending arming branch, compute `ts.due` as `max(now + waitingtime, window_start_time)`. When the window is already open, this equals `now + waitingtime` (unchanged). When arming before the window, execution is deferred to the window start. No retry logic changes needed — the execution fires within the window and the normal flow handles it.
 
+### Bug Pattern M: Combined sun-position trigger swallows independent elevation/azimuth end (Issue #483)
+
+**Symptom:** Shading never ends even though the sun elevation drops below the configured end threshold. The trigger fires earlier (when azimuth goes out of range) but the end conditions are not met. When elevation later drops below threshold, no trigger fires.
+
+**Cause:** `t_shading_end_pending_5` combined azimuth and elevation checks in a single template trigger using OR logic. HA template triggers fire on FALSE→TRUE transitions only. When azimuth goes out of range first, the template becomes TRUE and the trigger fires. But `shading_end_conditions_met` is FALSE (user only configured elevation as end condition). When elevation later drops below threshold, the template is already TRUE (from azimuth) → no re-fire → shading end never triggers.
+
+**Fix:** Split `t_shading_end_pending_5` into two independent triggers:
+- `t_shading_end_pending_5`: azimuth only (outside configured range)
+- `t_shading_end_pending_7`: elevation only (outside configured range)
+
+Each condition gets its own independent FALSE→TRUE transition. Update condition regex `[1-6]` → `[1-7]` and `is_shading_end_immediate_by_sun_position` check to match both trigger IDs.
+
 ---
 
 ## Language & Style Conventions

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3763,12 +3763,19 @@ triggers:
     value_template: >-
       {{
         (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_start) < shading_azimuth_start) or
-        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end) or
+        (state_attr(default_sun_sensor, 'azimuth') | float(default=shading_azimuth_end) > shading_azimuth_end)
+      }}
+    enabled: "{{ is_shading_enabled and default_sun_sensor != [] }}"
+    id: "t_shading_end_pending_5"
+
+  - trigger: template
+    value_template: >-
+      {{
         (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_max) > shading_elevation_max) or
         (state_attr(default_sun_sensor, 'elevation') | float(default=shading_elevation_min) < shading_elevation_min)
       }}
     enabled: "{{ is_shading_enabled and default_sun_sensor != [] }}"
-    id: "t_shading_end_pending_5"
+    id: "t_shading_end_pending_7"
 
   - trigger: template
     value_template: "{{ states(shading_forecast_temp_sensor) not in invalid_states and states(shading_forecast_temp_sensor) | float(default=shading_forecast_temp) < (shading_forecast_temp - shading_forecast_temp_hysteresis) }}"
@@ -3885,7 +3892,7 @@ conditions:
     value_template: >-
       {% if trigger.id is match('^t_shading_start_pending_[1-6]$') %}
         {{ not (states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]')) }}
-      {% elif trigger.id is match('^t_shading_end_pending_[1-6]$') %}
+      {% elif trigger.id is match('^t_shading_end_pending_[1-7]$') %}
         {{ states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') }}
       {% else %}
         true
@@ -5553,7 +5560,7 @@ actions:
                       - variables:
                           local_waitingtime_end: >
                             {% set local_waitingtime_end = shading_waitingtime_end | int %}
-                            {% if (is_shading_end_immediate_by_sun_position | default(false)) | bool and trigger.id == 't_shading_end_pending_5' %}
+                            {% if (is_shading_end_immediate_by_sun_position | default(false)) | bool and trigger.id in ['t_shading_end_pending_5', 't_shading_end_pending_7'] %}
                             {% set local_waitingtime_end = 20 %}
                             {% endif %}
                             {{ local_waitingtime_end }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ✨ **Feature:** New ventilation option to disable the drive delay when ventilation starts (window opens/tilts) — useful for setups with many covers where a large fixed delay is needed for staggering, but single-cover ventilation reactions should be instant
 - 🐛 **Fix:** Shading start pending armed before time window opens no longer aborts immediately — `ts.due` is now set to `max(now + waitingtime, window_start)`, ensuring execution fires after the window opens instead of aborting with only seconds elapsed of a multi-hour `max_duration` budget ([#475](https://github.com/hvorragend/ha-blueprints/issues/475))
 - 🐛 **Fix:** Shading End never executed when using Calendar time control — `t_shading_end` triggers were missing from the `calendar.get_events` performance filter, causing `is_shading_allowed_window` to always evaluate to `false` ([#477](https://github.com/hvorragend/ha-blueprints/issues/477))
+- 🐛 **Fix:** Shading end never triggered when only elevation (or only azimuth) was configured as end condition — the combined sun-position trigger `t_shading_end_pending_5` used OR logic for azimuth and elevation in a single template, so when azimuth left the range first (without meeting end conditions), the trigger stayed TRUE and never re-fired when elevation later dropped below threshold ([#483](https://github.com/hvorragend/ha-blueprints/issues/483))
 
 ---
 


### PR DESCRIPTION
t_shading_end_pending_5 combined azimuth and elevation in a single OR
template trigger. When azimuth left the configured range first, the
template stayed TRUE. If only elevation was configured as a shading end
condition, the trigger never re-fired when elevation later dropped below
threshold — shading was stuck forever.

Split into t_shading_end_pending_5 (azimuth) and t_shading_end_pending_7
(elevation) so each fires independently.

https://claude.ai/code/session_01JHm5s5m5Vw5uJQBiH6wykH