### PR TITLE
Fix contact handler destroying active shading pending phase (#484)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -161,7 +161,8 @@ The `man` flag (manual override) may only be set to `0` when the automation actu
   - Start: Drive, Lockout-skip, Save-for-future, both Abort branches
   - End: Tilt-only, Lockout, Ventilation, Move-cover (both then/else), Stop retry, stale-pending cleanup (#395)
   - Midnight reset (BRANCH 11, "Reset shading status")
-  - Incidental clears in non-shading branches (force, manual, contact handlers) — also clear all three for hygiene.
+  - Incidental clears in non-shading branches (force, manual) — also clear all three for hygiene.
+- **Contact handler branches must NOT reset `pnd`/`ts.due`/`ts.arm`.** Window open/close events are orthogonal to shading pending state. Omit these keys from `update_values` so `helper_update` preserves the existing values (#484).
 
 ### ⚠️ Invariant 11: Mutual exclusivity of shading-start and shading-end pending
 
@@ -388,6 +389,18 @@ ts:
 - `t_shading_end_pending_7`: elevation only (outside configured range)
 
 Each condition gets its own independent FALSE→TRUE transition. Update condition regex `[1-6]` → `[1-7]` and `is_shading_end_immediate_by_sun_position` check to match both trigger IDs.
+
+### Bug Pattern N: Contact handler destroys active shading pending phase (Issue #484)
+
+**Symptom:** Briefly opening and closing a door/window during a shading-start (or shading-end) pending phase prevents shading from ever executing. The pending timer (`ts.due`) is reset to `0`, and the sun-position trigger doesn't re-fire because the azimuth condition hasn't changed (no FALSE→TRUE transition).
+
+**Cause A:** All "Window closed" sub-branches (`Return to shading`, `Return to open`, `Return to close`) and the "Window opened - Full ventilation (lockout)" branch unconditionally set `pnd: 'non'`, `ts.due: 0`, `ts.arm: 0` in their `update_values`.
+
+**Cause B:** The "was ventilating before" OR condition includes `in_open_position`, which matches whenever the cover happens to be at open position — even when CCA was never in ventilation mode (`win == 'cls'` the entire time). This causes spurious "Window closed" branch matches.
+
+**Fix A:** Remove `pnd`/`ts.due`/`ts.arm` from `update_values` in all contact handler branches. The `helper_update` anchor preserves existing values when keys are omitted.
+
+**Fix B:** Remove `in_open_position` from the "was ventilating before" OR condition in all three "Window closed" branches. The dedicated "No drive, sync" branches already ensure `helper_state_window` is correctly updated when the window opens/tilts.
 
 ---
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.27
+    **Version**: 2026.05.27 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2813,7 +2813,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.27"
+  version: "2026.05.27 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5851,10 +5851,6 @@ actions:
                         # Window is fully open (lockout)
                         win: "opn"
                         man: "{{ 0 if force_allows_open else helper_json.man | default(0) | int }}"
-                        pnd: 'non'
-                        ts:
-                          due: 0
-                          arm: 0
                   - if: "{{ force_allows_open }}"
                     then:
                       - if:
@@ -5986,7 +5982,6 @@ actions:
                   - or: # Was ventilating before
                       - "{{ helper_state_window in ['tlt', 'opn'] }}"
                       - "{{ in_ventilate_position }}"
-                      - "{{ in_open_position }}"
                   - "{{ not (helper_state_manual and override_flags.ventilation) }}" # Skip if manual override for ventilation is active
                   - "{{ not resident_now or 'resident_allow_shading' in resident_config }}" # Resident privacy overrides shading unless explicitly allowed
                   - condition: !input auto_ventilate_end_condition
@@ -5999,10 +5994,6 @@ actions:
                         shd: 1
                         win: "cls"
                         man: "{{ 0 if force_allows_shade else helper_json.man | default(0) | int }}"
-                        pnd: 'non'
-                        ts:
-                          due: 0
-                          arm: 0
                   - if: "{{ force_allows_shade }}"
                     then:
                       - if: # Optional delay if enabled
@@ -6030,7 +6021,6 @@ actions:
                   - or: # Was ventilating before
                       - "{{ helper_state_window in ['tlt', 'opn'] }}"
                       - "{{ in_ventilate_position }}"
-                      - "{{ in_open_position }}"
                   - "{{ not (helper_state_manual and override_flags.ventilation) }}" # Skip if manual override for ventilation is active
                   - condition: !input auto_ventilate_end_condition
                 sequence:
@@ -6041,10 +6031,6 @@ actions:
                         # Window closed, return to open base state
                         win: "cls"
                         man: "{{ 0 if not prevent_flags.opening_after_ventilation_end and force_allows_open else helper_json.man | default(0) | int }}"
-                        pnd: 'non'
-                        ts:
-                          due: 0
-                          arm: 0
                   - if: "{{ not prevent_flags.opening_after_ventilation_end and force_allows_open }}"
                     then:
                       - if: # Optional delay if enabled
@@ -6073,9 +6059,8 @@ actions:
                   - or: # Was ventilating before
                       - "{{ helper_state_window in ['tlt', 'opn'] }}"
                       - "{{ in_ventilate_position }}"
-                      - "{{ in_open_position }}"
                   - "{{ not (helper_state_manual and override_flags.ventilation) }}" # Skip if manual override for ventilation is active
-                  - condition: !input auto_ventilate_end_condition 
+                  - condition: !input auto_ventilate_end_condition
                 sequence:
                   - variables:
                       target_position: !input close_position
@@ -6084,10 +6069,6 @@ actions:
                         # Window closed, return to close base state
                         win: "cls"
                         man: "{{ 0 if force_allows_close else helper_json.man | default(0) | int }}"
-                        pnd: 'non'
-                        ts:
-                          due: 0
-                          arm: 0
                   - if: "{{ force_allows_close }}"
                     then:
                       - if: # Optional delay if enabled

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.27 V2
+
+- 🐛 **Fix:** Contact sensor "window closed" branches no longer destroy active shading pending phase (`pnd`, `ts.due`, `ts.arm`) — briefly opening and closing a door/window during shading-start or shading-end pending no longer prevents shading from executing ([#484](https://github.com/hvorragend/ha-blueprints/issues/484))
+- 🐛 **Fix:** "Window closed" branches no longer fire spuriously when cover is at open position but was never in ventilation mode — removed overly broad `in_open_position` fallback from the "was ventilating before" OR condition ([#484](https://github.com/hvorragend/ha-blueprints/issues/484))
+
+---
+
 # CCA 2026.05.27
 
 - ✨ **Feature:** New ventilation option to disable the drive delay when ventilation starts (window opens/tilts) — useful for setups with many covers where a large fixed delay is needed for staggering, but single-cover ventilation reactions should be instant


### PR DESCRIPTION
Two bugs caused shading to never start when a door/window was briefly
opened during the shading-start (or -end) pending phase:

1. All "Window closed" and "Window opened (lockout)" branches
   unconditionally reset pnd/ts.due/ts.arm, destroying any active
   pending timer. Removed these keys from update_values so
   helper_update preserves the existing pending state.

2. The "was ventilating before" OR condition included in_open_position,
   which matched whenever the cover happened to be at open position —
   even when CCA was never in ventilation mode (win stayed cls).
   Removed in_open_position from all three "Window closed" branches.

Version bump to 2026.05.27 V2.

https://claude.ai/code/session_01GpTx3XTgjUj4StFZhJUHzs