### PR TITLE
fix: correct shading END condition labels for forecast temp/weather

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -1514,9 +1514,9 @@ blueprint:
                   value: "cond_temp1"
                 - label: "2️⃣ Temperature Sensor 2 (below threshold)"
                   value: "cond_temp2"
-                - label: "📊 Forecast Temperature (above threshold)"
+                - label: "📊 Forecast Temperature (below threshold)"
                   value: "cond_forecast_temp"
-                - label: "🌦️ Forecast Weather Conditions (matching configured conditions)"
+                - label: "🌦️ Forecast Weather Conditions (no longer matching configured conditions)"
                   value: "cond_forecast_weather"
 
         shading_conditions_end_or:
@@ -1581,9 +1581,9 @@ blueprint:
                   value: "cond_temp1"
                 - label: "2️⃣ Temperature Sensor 2 (below threshold)"
                   value: "cond_temp2"
-                - label: "📊 Forecast Temperature (above threshold)"
+                - label: "📊 Forecast Temperature (below threshold)"
                   value: "cond_forecast_temp"
-                - label: "🌦️ Forecast Weather Conditions (matching configured conditions)"
+                - label: "🌦️ Forecast Weather Conditions (no longer matching configured conditions)"
                   value: "cond_forecast_weather"
 
         shading_azimuth_start:


### PR DESCRIPTION
The END selectors invert every label (azimuth/elevation "outside", brightness/temp "below"), but the forecast temperature label still read "above threshold" and the forecast weather label still read "matching configured conditions" — both describing START behavior. The END logic already checks below threshold / no-longer-matching; only the labels were misleading. Label-only change, no behavior impact.

https://claude.ai/code/session_012yjuWMtHANjTS3q2t2mViW