### PR TITLE
fix: window-closed contact handler must follow effective_state, not bare presence

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -402,6 +402,20 @@ Each condition gets its own independent FALSE→TRUE transition. Update conditio
 
 **Fix B:** Remove `in_open_position` from the "was ventilating before" OR condition in all three "Window closed" branches. The dedicated "No drive, sync" branches already ensure `helper_state_window` is correctly updated when the window opens/tilts.
 
+### Bug Pattern O: Contact "window closed" handler closes on bare resident presence
+
+**Symptom:** With `bas == 'opn'`, no shading, no force, and a resident present, closing the window lowers the cover from open to close — even though `effective_state == 'opn'` and the user never configured privacy-closing.
+
+**Cause:** The "Window closed" return branches used raw `resident_now` as a privacy proxy. "Return to open" required `helper_state_base == 'opn' and not resident_now`, and "Return to close" fired on `helper_state_base == 'cls' or resident_now`. Any resident presence therefore forced a close, diverging from `effective_state`, whose `privacy_active` requires `'resident_closing_enabled' in resident_config` (and whose `allow_open` gate closes only when `resident_allow_opening` is unset).
+
+**Fix:** Introduce `resident_blocks_open` in the post-delay contact-handler variables:
+```jinja2
+resident_now and (resident_flags.closing_trigger or 'resident_allow_opening' not in resident_config)
+```
+Use `not resident_blocks_open` in "Return to open" and `resident_blocks_open` in "Return to close". This mirrors `effective_state`'s privacy + allow_open gates exactly, so the contact handler agrees with the cascade.
+
+**Rule:** Contact "window closed" return branches must resolve open-vs-close from the same gates as `effective_state` (privacy + allow_open), never from bare presence.
+
 ---
 
 ## Language & Style Conventions

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.27 V2
+    **Version**: 2026.05.28
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2813,7 +2813,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.27 V2"
+  version: "2026.05.28"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5831,6 +5831,10 @@ actions:
               # Live resident check — like contact sensors above, must be read after delay
               # to detect race conditions when both window and resident change quickly
               resident_now: "{{ resident_sensor != [] and states(resident_sensor) in ['on', 'true'] }}"
+              # Present resident suppresses the open base state only when privacy-closing
+              # is enabled or opening is not permitted (mirrors effective_state's privacy
+              # and allow_open gates). Mere presence does NOT close the cover.
+              resident_blocks_open: "{{ resident_now and (resident_flags.closing_trigger or 'resident_allow_opening' not in resident_config) }}"
 
           - choose:
               ###################################
@@ -6016,7 +6020,7 @@ actions:
               - alias: "Window closed - Return to open position"
                 conditions:
                   - "{{ not contact_opened_now and not contact_tilted_now }}"
-                  - "{{ helper_state_base == 'opn' and not resident_now }}"  # Use live sensor, not stale helper
+                  - "{{ helper_state_base == 'opn' and not resident_blocks_open }}"
                   - "{{ not helper_state_is_shaded and not helper_state_shade }}"
                   - or: # Was ventilating before
                       - "{{ helper_state_window in ['tlt', 'opn'] }}"
@@ -6055,7 +6059,7 @@ actions:
                   - "{{ not contact_opened_now and not contact_tilted_now }}"
                   - or:
                       - "{{ helper_state_base == 'cls' }}"
-                      - "{{ resident_now }}"  # Use live sensor, not stale helper
+                      - "{{ resident_blocks_open }}"
                   - or: # Was ventilating before
                       - "{{ helper_state_window in ['tlt', 'opn'] }}"
                       - "{{ in_ventilate_position }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.28
+
+- 🐛 **Fix:** Cover no longer closes when the window is closed while a resident is present but privacy-closing is not configured. The contact "window closed" handler treated any resident presence as a privacy-close trigger ("Return to open" required the resident to be absent; "Return to close" fired on mere presence). It now mirrors `effective_state`: privacy-close applies only when `resident_closing_enabled` is configured, or when opening is not permitted (`resident_allow_opening` unset). With `bas=opn` and no shading, the cover correctly returns to the open position after the window closes.
+
+---
+
 # CCA 2026.05.27 V2
 
 - 🐛 **Fix:** Contact sensor "window closed" branches no longer destroy active shading pending phase (`pnd`, `ts.due`, `ts.arm`) — briefly opening and closing a door/window during shading-start or shading-end pending no longer prevents shading from executing ([#484](https://github.com/hvorragend/ha-blueprints/issues/484))

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -2067,6 +2067,17 @@ class TestWindowClosedReturnRespectsPrivacy:
         branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
         assert branch == "close"
 
+    def test_base_close_resident_present_returns_close(self):
+        """Base=cls with a present resident (no privacy config) → still close via the base=cls arm."""
+        env = make_jinja_env()
+        cfg = ["resident_allow_opening"]  # present, but neither privacy nor a reason to stay open
+        v = _make_window_closed_vars(resident_now=True, resident_config=cfg, helper_state_base="cls")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "close"
+        assert branch == self._expected_from_cascade(
+            resident_now=True, resident_config=cfg, base="cls"
+        )
+
     def test_shading_active_returns_shading(self):
         """Shading active and allowed → return to shading (branch precedence intact)."""
         env = make_jinja_env()

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -1883,3 +1883,226 @@ class TestForcePauseDisabledHasBackgroundOpen:
             "with bas=opn + tilted window the effective_state is now 'opn' and "
             "needs an explicit drive branch."
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: contact "window closed" return respects privacy gate, not bare presence
+# ─────────────────────────────────────────────────────────────────────────────
+
+# The privacy/allow_open suppression of the open base state, as used by the
+# "Return to open" / "Return to close" branches. Mirrors effective_state's
+# `privacy_active` and `allow_open` gates.
+_RESIDENT_BLOCKS_OPEN_EXPR = (
+    "resident_now and (resident_flags.closing_trigger"
+    " or 'resident_allow_opening' not in resident_config)"
+)
+
+# Fixed branches (gate on the privacy/allow_open condition).
+WINDOW_CLOSED_RETURN_BRANCHES = [
+    {
+        "name": "shading",
+        "conditions": [
+            "{{ not contact_opened_now and not contact_tilted_now }}",
+            "{{ helper_state_is_shaded or helper_state_shade }}",
+            "{{ helper_state_window in ['tlt', 'opn'] or in_ventilate_position }}",
+            "{{ not (helper_state_manual and override_flags.ventilation) }}",
+            "{{ not resident_now or 'resident_allow_shading' in resident_config }}",
+        ],
+    },
+    {
+        "name": "open",
+        "conditions": [
+            "{{ not contact_opened_now and not contact_tilted_now }}",
+            "{{ helper_state_base == 'opn' and not (" + _RESIDENT_BLOCKS_OPEN_EXPR + ") }}",
+            "{{ not helper_state_is_shaded and not helper_state_shade }}",
+            "{{ helper_state_window in ['tlt', 'opn'] or in_ventilate_position }}",
+            "{{ not (helper_state_manual and override_flags.ventilation) }}",
+        ],
+    },
+    {
+        "name": "close",
+        "conditions": [
+            "{{ not contact_opened_now and not contact_tilted_now }}",
+            "{{ helper_state_base == 'cls' or (" + _RESIDENT_BLOCKS_OPEN_EXPR + ") }}",
+            "{{ helper_state_window in ['tlt', 'opn'] or in_ventilate_position }}",
+            "{{ not (helper_state_manual and override_flags.ventilation) }}",
+        ],
+    },
+]
+
+# Buggy variant: bare resident_now treated as a privacy-close trigger.
+WINDOW_CLOSED_RETURN_BRANCHES_BUGGY = [
+    WINDOW_CLOSED_RETURN_BRANCHES[0],
+    {
+        "name": "open",
+        "conditions": [
+            "{{ not contact_opened_now and not contact_tilted_now }}",
+            "{{ helper_state_base == 'opn' and not resident_now }}",
+            "{{ not helper_state_is_shaded and not helper_state_shade }}",
+            "{{ helper_state_window in ['tlt', 'opn'] or in_ventilate_position }}",
+            "{{ not (helper_state_manual and override_flags.ventilation) }}",
+        ],
+    },
+    {
+        "name": "close",
+        "conditions": [
+            "{{ not contact_opened_now and not contact_tilted_now }}",
+            "{{ helper_state_base == 'cls' or resident_now }}",
+            "{{ helper_state_window in ['tlt', 'opn'] or in_ventilate_position }}",
+            "{{ not (helper_state_manual and override_flags.ventilation) }}",
+        ],
+    },
+]
+
+
+def _make_window_closed_vars(
+    *,
+    resident_now: bool = False,
+    resident_config: list | None = None,
+    helper_state_base: str = "opn",
+    helper_state_shade: bool = False,
+    helper_state_is_shaded: bool = False,
+    helper_state_window: str = "opn",
+    in_ventilate_position: bool = False,
+    helper_state_manual: bool = False,
+    override_ventilation: bool = False,
+) -> dict:
+    resident_config = resident_config or []
+    return {
+        "contact_opened_now": False,
+        "contact_tilted_now": False,
+        "resident_now": resident_now,
+        "resident_config": resident_config,
+        # closing_trigger mirrors the blueprint: 'resident_closing_enabled' in resident_config
+        "resident_flags": {"closing_trigger": "resident_closing_enabled" in resident_config},
+        "helper_state_base": helper_state_base,
+        "helper_state_shade": helper_state_shade,
+        "helper_state_is_shaded": helper_state_is_shaded,
+        "helper_state_window": helper_state_window,
+        "in_ventilate_position": in_ventilate_position,
+        "helper_state_manual": helper_state_manual,
+        "override_flags": {"ventilation": override_ventilation},
+    }
+
+
+class TestWindowClosedReturnRespectsPrivacy:
+    """
+    Forum trace (cover closes after window is closed at ~10:00):
+
+    After the window closes, the contact handler must return the cover to the
+    state the priority cascade dictates (effective_state) — NOT close it merely
+    because a resident is present. Privacy-close applies only when
+    `resident_closing_enabled` is configured, or when opening is not permitted.
+
+    Root cause: 'Return to open' required `not resident_now` and 'Return to
+    close' fired on bare `resident_now`. Fixed via `resident_blocks_open`.
+    """
+
+    def _expected_from_cascade(self, *, resident_now, resident_config, base, shade=False) -> str:
+        es = _eval_effective_state(
+            helper_json={"frc": "non", "win": "cls", "bas": base, "shd": 1 if shade else 0},
+            state_resident=resident_now,
+            resident_config=resident_config,
+            sensor_opened=False,
+            sensor_tilted=False,
+            has_opened_sensor=True,
+        )
+        return {"opn": "open", "cls": "close", "shd": "shading"}[es]
+
+    def test_present_no_privacy_allow_open_returns_open(self):
+        """Reported bug: resident present, base=opn, allow_opening set, no privacy → OPEN."""
+        env = make_jinja_env()
+        cfg = ["resident_allow_shading", "resident_allow_opening", "resident_allow_ventilation"]
+        v = _make_window_closed_vars(resident_now=True, resident_config=cfg, helper_state_base="opn")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "open", f"Expected 'open' but got '{branch}'"
+        assert branch == self._expected_from_cascade(
+            resident_now=True, resident_config=cfg, base="opn"
+        ), "Contact handler must agree with effective_state cascade."
+
+    def test_buggy_version_wrongly_closes(self):
+        """Locks in the regression: the old bare-resident_now logic closed here."""
+        env = make_jinja_env()
+        cfg = ["resident_allow_shading", "resident_allow_opening", "resident_allow_ventilation"]
+        v = _make_window_closed_vars(resident_now=True, resident_config=cfg, helper_state_base="opn")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES_BUGGY, v)
+        assert branch == "close", (
+            "Buggy variant is expected to (wrongly) close — this documents the bug "
+            "the fix resolves."
+        )
+
+    def test_present_privacy_returns_close(self):
+        """Resident present WITH resident_closing_enabled → privacy-close still works."""
+        env = make_jinja_env()
+        cfg = ["resident_closing_enabled", "resident_allow_opening"]
+        v = _make_window_closed_vars(resident_now=True, resident_config=cfg, helper_state_base="opn")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "close"
+        assert branch == self._expected_from_cascade(
+            resident_now=True, resident_config=cfg, base="opn"
+        )
+
+    def test_present_no_allow_open_returns_close(self):
+        """Resident present, opening not permitted (no allow_opening) → CLOSE (allow_open gate)."""
+        env = make_jinja_env()
+        cfg = ["resident_allow_ventilation"]  # neither allow_opening nor closing_enabled
+        v = _make_window_closed_vars(resident_now=True, resident_config=cfg, helper_state_base="opn")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "close"
+        assert branch == self._expected_from_cascade(
+            resident_now=True, resident_config=cfg, base="opn"
+        )
+
+    def test_absent_base_open_returns_open(self):
+        """No resident → return to open base state."""
+        env = make_jinja_env()
+        v = _make_window_closed_vars(resident_now=False, resident_config=[], helper_state_base="opn")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "open"
+
+    def test_base_close_returns_close(self):
+        """Base=cls → return to close regardless of presence."""
+        env = make_jinja_env()
+        v = _make_window_closed_vars(resident_now=False, resident_config=[], helper_state_base="cls")
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "close"
+
+    def test_shading_active_returns_shading(self):
+        """Shading active and allowed → return to shading (branch precedence intact)."""
+        env = make_jinja_env()
+        cfg = ["resident_allow_shading"]
+        v = _make_window_closed_vars(
+            resident_now=True, resident_config=cfg, helper_state_base="opn", helper_state_shade=True
+        )
+        branch = first_matching_branch(env, WINDOW_CLOSED_RETURN_BRANCHES, v)
+        assert branch == "shading"
+
+    def test_blueprint_branches_use_resident_blocks_open(self):
+        """Static wiring: the actual YAML branches gate on resident_blocks_open."""
+        blueprint = _load_blueprint_yaml(BLUEPRINT_PATH)
+
+        def find_branch(node, alias):
+            if isinstance(node, dict):
+                if node.get("alias") == alias:
+                    return node
+                for value in node.values():
+                    result = find_branch(value, alias)
+                    if result is not None:
+                        return result
+            elif isinstance(node, list):
+                for item in node:
+                    result = find_branch(item, alias)
+                    if result is not None:
+                        return result
+            return None
+
+        for alias in (
+            "Window closed - Return to open position",
+            "Window closed - Return to close position",
+        ):
+            branch = find_branch(blueprint, alias)
+            assert branch is not None, f"Missing branch: {alias}"
+            conds = str(branch.get("conditions", []))
+            assert "resident_blocks_open" in conds, (
+                f"'{alias}' must gate on resident_blocks_open, not bare resident_now."
+            )


### PR DESCRIPTION
## Summary

- The contact handler's "Window closed" return branches treated **any** resident presence as a privacy-close trigger: "Return to open" required `not resident_now`, and "Return to close" fired on bare `resident_now`. With `bas=opn`, no shading and a present resident, **closing the window closed the cover** — even though `effective_state == 'opn'`.
- This diverged from `effective_state`, whose `privacy_active` requires `resident_closing_enabled` to be configured (and whose `allow_open` gate only closes when `resident_allow_opening` is unset).
- Fix: introduce `resident_blocks_open` in the post-delay contact-handler variables, mirroring `effective_state`'s privacy + allow_open gates exactly, and gate both branches on it.

```jinja2
resident_blocks_open = resident_now and (resident_flags.closing_trigger
                       or 'resident_allow_opening' not in resident_config)
```

For a config with `resident_allow_opening` set and no `resident_closing_enabled`, this resolves to `false`, so the cover correctly returns to the open position after the window closes. Privacy-close (with `resident_closing_enabled`) and the `allow_open` gate keep working.

### Root cause confirmed by trace
A HA trace showed the window-opened sensor turning OFF (window closed), `res=1`, no shading, no force, `effective_state="opn"`, cover at 100% — yet the branch "Window closed - Return to close position" ran `cover.close_cover`.

### Changes
- `blueprints/automation/cover_control_automation.yaml`: add `resident_blocks_open`; gate "Return to open" / "Return to close" on it. Version → `2026.05.28`.
- `tests/test_blueprint_logic.py`: new `TestWindowClosedReturnRespectsPrivacy` (9 tests) cross-checking the contact handler against `effective_state`, incl. a buggy-variant regression sentinel and a static YAML wiring check.
- `docs/CHANGELOG.md`: new `2026.05.28` entry.
- `.claude/CLAUDE.md`: document Bug Pattern O.

## Test plan

- [x] `pytest tests/ -v` — 127 passed
- [x] Blueprint YAML parses (incl. `!input`/anchors)
- [x] Fix verified against the exact trace scenario (cover stays open)
- [x] Independent review (Sonnet): confirmed cascade-equivalent, no regressions, no dead branch combinations

https://claude.ai/code/session_01XHdau2DUdjSMMLYRrqC4MM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHdau2DUdjSMMLYRrqC4MM)_