### PR TITLE
fix: opening handler kills shading-start pending when armed before time window

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -250,6 +250,16 @@ The resident sensor handler (`resident_leaving` / `resident_arriving`) does **no
 
 This is intentional. Do not "harmonize" by adding the override gate to the resident handler.
 
+### Opening handler preserves shading-start pending; closing handler discards it
+
+When the opening trigger fires while a shading-start pending is active (`pnd == 'beg'`), the opening handler **preserves** `pnd`, `ts.due`, and `ts.arm` and defers to the `t_shading_start_execution` trigger (which fires 1 second later at `ts.due = window_start + 1`).
+
+When the closing trigger fires while a shading-start pending is active, the closing branches **discard** `pnd`/`ts.due`/`ts.arm` by setting them to `non`/`0`/`0`.
+
+**Rationale:** At closing time, a shading-start intent from earlier in the day is no longer relevant — the cover is about to close regardless. Driving it to the shading position only to immediately close it would be wrong. At opening time, the intent is still valid (the sun is out, conditions are met) and the execution trigger should handle the drive.
+
+This asymmetry is intentional. Do not "harmonize" the closing handler to preserve pending — it must discard it.
+
 ### Midnight reset (BRANCH 11) sets `man: 0` without driving
 
 The "Reset shading status that is no longer required" branch writes `man: 0` even though it does not drive the cover. This is an intentional exception to Invariant 7.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.28 V2
+    **Version**: 2026.05.29
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2834,7 +2834,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.28 V2"
+  version: "2026.05.29"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -4978,8 +4978,7 @@ actions:
               - alias: "Shading detected. Move to shading position"
                 conditions:
                   - or:
-                      - "{{ helper_state_is_shaded }}" # TODO
-                      - "{{ helper_state_pending_start }}" # Pending-Timestamp
+                      - "{{ helper_state_is_shaded }}"
                       - "{{ helper_state_shade }}" # Check for target(!) marker
                   - "{{ not in_shading_position }}" # Even if this is hardly possible, there may be situations that require it. Purely as a precautionary measure in case the target state and actual state do not match.
                 sequence:
@@ -5008,6 +5007,21 @@ actions:
                         default: !input auto_shading_start_action
                   - *helper_update
                   - stop: "Opening skipped: Shading detected"
+
+              ###################################
+              # Shading start pending - defer to execution trigger
+              ###################################
+              - alias: "Opening skipped: Shading start pending"
+                conditions:
+                  - "{{ helper_state_pending_start }}"
+                sequence:
+                  - variables:
+                      update_values:
+                        bas: "opn"
+                        ts:
+                          opn: "now"
+                  - *helper_update
+                  - stop: "Opening skipped: Shading start pending"
 
             ###################################
             # Normal opening of the cover

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.29
+
+- 🐛 **Fix:** Shading never executed when pending-start (`pnd=beg`) armed before the opening time window and the opening trigger fired at window-start — the opening handler's "Shading detected" branch matched on `helper_state_pending_start`, cleared the pending state (`pnd=non`, `ts.due=0`) without driving the cover (because `effective_state != 'shd'` while `shd` was still `0`), causing the `t_shading_start_execution` trigger to be silently killed. The opening handler now defers to the execution trigger: a new "Opening skipped: Shading start pending" branch preserves `pnd`, `ts.due`, and `ts.arm`, updates only the base state (`bas=opn`, `ts.opn`), and lets the execution trigger fire 1 second later to handle the drive — including the correct retry/abort logic for manual overrides.
+
+---
+
 # CCA 2026.05.28 V2
 
 - ✨ **Feature:** New input *"Independent Temperature Threshold"* (`shading_independent_temp`) for the *"Independent Shading via Temperature Comparison"* mode — previously this mode shared the same threshold as the normal forecast condition, causing both paths to be blocked simultaneously when the threshold wasn't met. The dedicated threshold can be set lower (e.g. 23 °C) while keeping a stricter value in the AND conditions, without either path interfering with the other ([#491](https://github.com/hvorragend/ha-blueprints/issues/491))


### PR DESCRIPTION
When shading-start pending armed before the opening window (Bug Pattern L fix
defers ts.due to window_start+1), the opening trigger fires 1 second before
the execution trigger. The opening handler's "Shading detected" branch matched
on helper_state_pending_start=TRUE, set shd=1/pnd=non/ts.due=0 in update_values
but skipped the drive (effective_state != 'shd' because shd was still 0 in the
helper). The execution trigger was then silently killed because ts.due=0.

Fix: remove helper_state_pending_start from "Shading detected" conditions and
add a new "Opening skipped: Shading start pending" branch that only updates
bas=opn/ts.opn and preserves pnd/ts.due/ts.arm, allowing the execution trigger
to fire 1 second later with full retry/abort logic intact.

https://claude.ai/code/session_014fgdtrTEwxszfrp6pM8REr