### PR TITLE
fix: preserve ts.opn when late opening trigger fires with cover already open (#495)

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4955,20 +4955,20 @@ actions:
                   - "{{ not helper_state_is_shaded }}"
                   - "{{ not helper_state_pending_start }}"
                   - "{{ not helper_state_shade }}"
-                  - or:
-                      # Primary: base not yet reflecting current schedule
-                      # (e.g. Force Open is active while closing time has passed,
-                      # or Resident override holds cover open past opening time)
-                      - "{{ helper_state_base != 'opn' }}"
-                      # Secondary: ts.opn is from a previous day
-                      # (needed for prevent_multiple_times to work correctly)
-                      - "{{ now().day != helper_ts_open | timestamp_custom('%-d', true) | int }}"
                 sequence:
-                  - variables:
-                      update_values:
-                        bas: "opn"
-                        ts:
-                          opn: "now"
+                  - if: "{{ helper_state_base != 'opn' or now().day != helper_ts_open | timestamp_custom('%-d', true) | int }}"
+                    then:
+                      # Real base-state transition or new day: refresh ts.opn
+                      - variables:
+                          update_values:
+                            bas: "opn"
+                            ts:
+                              opn: "now"
+                    else:
+                      # Already open, same day: preserve ts.opn (Issue #495)
+                      - variables:
+                          update_values:
+                            bas: "opn"
                   - *helper_update
                   - stop: "Open time: Already in position, base state updated"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # CCA 2026.05.29
 
+- 🐛 **Fix:** `ts.opn` no longer overwritten by the late opening trigger when the cover was already opened earlier the same day. The "Already in open position" branch now catches all cases where the cover is at open position with `effective_state=opn` — including the case where `bas=opn` and `ts.opn` is already from today. `ts.opn` is only refreshed when there is a real base-state transition or when the timestamp is from a previous day; otherwise the existing value is preserved. Additionally, the late trigger no longer redundantly drives the cover or clears the manual override ([#495](https://github.com/hvorragend/ha-blueprints/issues/495))
 - 🐛 **Fix:** Shading never executed when pending-start (`pnd=beg`) armed before the opening time window and the opening trigger fired at window-start — the opening handler's "Shading detected" branch matched on `helper_state_pending_start`, cleared the pending state (`pnd=non`, `ts.due=0`) without driving the cover (because `effective_state != 'shd'` while `shd` was still `0`), causing the `t_shading_start_execution` trigger to be silently killed. The opening handler now defers to the execution trigger: a new "Opening skipped: Shading start pending" branch preserves `pnd`, `ts.due`, and `ts.arm`, updates only the base state (`bas=opn`, `ts.opn`), and lets the execution trigger fire 1 second later to handle the drive — including the correct retry/abort logic for manual overrides.
 
 ---


### PR DESCRIPTION
The "Already in open position" branch previously required base!=opn OR new day
to fire. When both conditions were false (cover opened at 07:00, late trigger at
08:00, same day), it fell through to "Normal opening", which redundantly drove
the cover, cleared man, and overwrote ts.opn with the late trigger time.

Remove the or-gate from branch conditions; move it inside the sequence as
if/then/else: ts.opn is refreshed only on a real base-state transition or
a new day — otherwise the existing timestamp is preserved.

https://claude.ai/code/session_016L215oyjjcQvK2QLBwh8cP