### PR TITLE
fix: treat cover below close position as closed for shading-end guard…

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.29 V3
+    **Version**: 2026.05.30
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2834,7 +2834,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.29 V3"
+  version: "2026.05.30"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5591,7 +5591,7 @@ actions:
               - "{{ in_shading_position }}" # Be careful if the tolerance value is too high!
           - or: # Optional: Continue if cover is not already closed
               - "{{ not prevent_flags.shading_end_if_closed }}"
-              - "{{ prevent_flags.shading_end_if_closed and not in_close_position}}"
+              - "{{ prevent_flags.shading_end_if_closed and not in_close_position and not position_comparisons.current_below_close }}"
           - "{{ resident_flags.allow_shade }}"
         sequence:
           - if:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.30
+
+- 🐛 **Fix:** *"Don't end shading if cover is already closed"* no longer ends shading (opening the cover) when the cover was manually closed **further** than the configured close position. The guard checked `in_close_position`, which is a tolerance window centered on the configured close position — a cover driven below that position (e.g. fully closed at 0 % while the close position is 15 %) was treated as "not closed", so shading ended and the cover opened. The condition now also treats a position below the close position (`current_below_close`, awning-aware) as closed ([#502](https://github.com/hvorragend/ha-blueprints/issues/502))
+
+---
+
 # CCA 2026.05.29 V3
 
 - 🐛 **Fix:** When a resident was present and shading conditions became true in the meantime (shading blocked by resident presence because `resident_allow_shading` was not configured), the cover opened normally after the resident left but shading never activated on that day — the sun-position template triggers only fire on FALSE→TRUE transitions and do not re-fire when conditions were already TRUE during residence. `resident_flags.allow_shade` is removed from the top-level "Check for shading start" conditions so the pending mechanism arms normally; the existing "Save shading state for the future" branch in the execution handler is extended with `OR not resident_flags.allow_shade`, so it saves `shd=1` alongside the already-handled `effective_state == 'cls'` case. The existing "Resident leaving: target SHADED" branch then drives to the shading position when the resident leaves.

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -2117,3 +2117,84 @@ class TestWindowClosedReturnRespectsPrivacy:
             assert "resident_blocks_open" in conds, (
                 f"'{alias}' must gate on resident_blocks_open, not bare resident_now."
             )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: "Don't end shading if cover is already closed" (Issue #502)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# The "or:" guard in the "Check for shading end" branch. Shading end is allowed
+# to continue when this evaluates True; it is blocked (cover stays closed) when
+# it evaluates False.
+SHADING_END_IF_CLOSED_GUARD = (
+    "(not prevent_flags.shading_end_if_closed) or "
+    "(prevent_flags.shading_end_if_closed and not in_close_position "
+    "and not position_comparisons.current_below_close)"
+)
+
+
+def _shading_end_guard_vars(*, enabled, in_close_position, current_below_close):
+    return {
+        "prevent_flags": {"shading_end_if_closed": enabled},
+        "in_close_position": in_close_position,
+        "position_comparisons": {"current_below_close": current_below_close},
+    }
+
+
+class TestShadingEndIfClosedGuard:
+    """
+    Regression for Issue #502: a cover manually closed *further* than the
+    configured close position (e.g. 0% while close_position=15%) must be
+    treated as closed, so shading end does not open it.
+    """
+
+    def test_below_close_position_blocks_shading_end(self):
+        """current_position below close_position → guard False → shading end blocked."""
+        env = make_jinja_env()
+        result = eval_condition(env, SHADING_END_IF_CLOSED_GUARD, _shading_end_guard_vars(
+            enabled=True,
+            in_close_position=False,   # 0% is outside the close-position tolerance window
+            current_below_close=True,  # but it IS below the close position → still "closed"
+        ))
+        assert result is False, (
+            "Cover closed further than close_position must count as closed; "
+            "shading end must not continue (Issue #502)."
+        )
+
+    def test_at_close_position_blocks_shading_end(self):
+        """Cover within close-position tolerance → guard False → shading end blocked."""
+        env = make_jinja_env()
+        result = eval_condition(env, SHADING_END_IF_CLOSED_GUARD, _shading_end_guard_vars(
+            enabled=True,
+            in_close_position=True,
+            current_below_close=False,
+        ))
+        assert result is False
+
+    def test_above_close_position_allows_shading_end(self):
+        """Cover above close_position → guard True → shading end continues normally."""
+        env = make_jinja_env()
+        result = eval_condition(env, SHADING_END_IF_CLOSED_GUARD, _shading_end_guard_vars(
+            enabled=True,
+            in_close_position=False,
+            current_below_close=False,
+        ))
+        assert result is True
+
+    def test_option_disabled_always_allows_shading_end(self):
+        """Option off → guard True regardless of position."""
+        env = make_jinja_env()
+        result = eval_condition(env, SHADING_END_IF_CLOSED_GUARD, _shading_end_guard_vars(
+            enabled=False,
+            in_close_position=False,
+            current_below_close=True,
+        ))
+        assert result is True
+
+    def test_blueprint_guard_checks_current_below_close(self):
+        """Static wiring: the shading-end guard in the YAML uses current_below_close."""
+        text = BLUEPRINT_PATH.read_text()
+        assert "prevent_flags.shading_end_if_closed and not in_close_position and not position_comparisons.current_below_close" in text, (
+            "Shading-end 'if closed' guard must also block when the cover is "
+            "below the close position (Issue #502)."
+        )


### PR DESCRIPTION
… (#502)

"Don't end shading if cover is already closed" used `in_close_position`, a tolerance window centered on the configured close position. A cover manually driven *further* closed than that position (e.g. 0% while the close position is 15%) fell outside the window and was treated as "not closed", so shading ended and the cover opened.

The guard now also treats `position_comparisons.current_below_close` (awning-aware) as closed, so a more-closed cover keeps shading active.

- Bump version to 2026.05.30 (description + runtime variable)
- Add CHANGELOG entry
- Add regression tests for the shading-end-if-closed guard