### PR TITLE
option for reset manual override *"reset in position"*

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2199,6 +2199,8 @@ blueprint:
                   value: "reset_fixed_time"
                 - label: "Reset after a timeout in minutes (see below)"
                   value: "reset_timeout"
+                - label: "Reset in position (see below)"
+                  value: "reset_in_position"
               multiple: false
               sort: false
               custom_value: false
@@ -2220,6 +2222,16 @@ blueprint:
               min: 0
               max: 1440
               unit_of_measurement: minutes
+        
+        reset_override_position:
+          name: "🗑️ Position for reset manual override"
+          description: "At which position (+- tolerance) should it be reset? Typically, these are 'open' or 'closed' positions. Note: This position must be maintained for the duration specified by the 'minutes until reset' setting."
+          default: 100
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
 
     delay_section:
       description: >-
@@ -2802,9 +2814,11 @@ trigger_variables:
   reset_override_config: !input reset_override_config
   reset_override_time: !input reset_override_time
   reset_override_timeout: !input reset_override_timeout
+  reset_override_position: !input reset_override_position
   is_reset_disabled: "{{ 'reset_disabled' in reset_override_config }}"
   is_reset_fixed_time: "{{ 'reset_fixed_time' in reset_override_config }}"
   is_reset_timeout: "{{ 'reset_timeout' in reset_override_config }}"
+  is_reset_position: "{{ 'reset_in_position' in reset_override_config }}"
 
   # Force entities
   auto_up_force: !input auto_up_force
@@ -3866,6 +3880,7 @@ triggers:
       minutes: 1
     enabled: "{{ is_cover_tilt_enabled }}"
 
+  # Resets
   - trigger: template
     value_template: "{{ now() >= today_at(reset_override_time) }}"
     enabled: "{{ is_reset_fixed_time }}"
@@ -3888,6 +3903,18 @@ triggers:
     id: "t_reset_timeout"
     for:
       seconds: 2
+
+  - trigger: template
+    value_template: >
+      {% set pos = state_attr(blind, 'current_position') | float(-100) %}
+      {% set target_pos = reset_override_position | float(0) %}
+      {% set tol = position_tolerance | float(5) %}
+      {% set min_pos = target_pos - tol %}
+      {% set max_pos = target_pos + tol %}
+      {{ pos >= min_pos and pos <= max_pos }}
+    enabled: "{{ is_reset_position }}"
+    id: "t_reset_position"
+    for: "{{ reset_override_timeout | int(4) * 60 }}"
 
 ################################################################################
 # GLOBAL CONDITIONS
@@ -7182,7 +7209,7 @@ actions:
         conditions:
           - "{{ trigger.id is defined }}"
           - "{{ not is_reset_disabled }}"
-          - "{{ trigger.id in ['t_reset_fixedtime', 't_reset_timeout'] }}"
+          - "{{ trigger.id in ['t_reset_fixedtime', 't_reset_timeout', 't_reset_position'] }}"
         sequence:
           - variables:
               update_values:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.05.30
+    **Version**: 2026.05.31
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2848,7 +2848,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.05.30"
+  version: "2026.05.31"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -3906,15 +3906,18 @@ triggers:
 
   - trigger: template
     value_template: >
+      {% set helper_state = states(cover_status_helper) %}
+      {% set helper = helper_state | from_json(default={}) if helper_state not in invalid_states and helper_state | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") else {} %}
       {% set pos = state_attr(blind, 'current_position') | float(-100) %}
       {% set target_pos = reset_override_position | float(0) %}
       {% set tol = position_tolerance | float(5) %}
       {% set min_pos = target_pos - tol %}
       {% set max_pos = target_pos + tol %}
-      {{ pos >= min_pos and pos <= max_pos }}
+      {{ helper.man | int == 1 and pos >= min_pos and pos <= max_pos }}
     enabled: "{{ is_reset_position }}"
     id: "t_reset_position"
-    for: "{{ reset_override_timeout | int(4) * 60 }}"
+    for:
+      minutes: "{{ reset_override_timeout | int(4) }}"
 
 ################################################################################
 # GLOBAL CONDITIONS
@@ -7565,3 +7568,4 @@ actions:
                 update={{ update_values | default({}) | to_json }} 
                 {% if log_extra is defined %} extra={{ log_extra }}{% endif %}
       - stop: "No operational branch matched (Opening, Closing, Shading, etc. conditions not met for current trigger)"
+      

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -3906,12 +3906,14 @@ triggers:
 
   - trigger: template
     value_template: >
+      {% set helper_state = states(cover_status_helper) %}
+      {% set helper = helper_state | from_json(default={}) if helper_state not in invalid_states and helper_state | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") else {} %}
       {% set pos = state_attr(blind, 'current_position') | float(-100) %}
       {% set target_pos = reset_override_position | float(0) %}
       {% set tol = position_tolerance | float(5) %}
       {% set min_pos = target_pos - tol %}
       {% set max_pos = target_pos + tol %}
-      {{ pos >= min_pos and pos <= max_pos }}
+      {{ helper.man | int == 1 and pos >= min_pos and pos <= max_pos }}
     enabled: "{{ is_reset_position }}"
     id: "t_reset_position"
     for: "{{ reset_override_timeout | int(4) * 60 }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.05.31
+
+- ✨ **Feature:** New option for reset manual override *"reset in position"*. This option will automatically clear the manual override state and restore automatic control once the cover reaches a specific target position (± configured tolerance) and remains there for the duration of the defined timeout. *Use Case:* Keep the blind in manual mode after lowering it by hand, and only let the automation take over again once the blind is fully reopened to 100%.
+
+---
+
 # CCA 2026.05.30
 
 - 🐛 **Fix:** *"Don't end shading if cover is already closed"* no longer ends shading (opening the cover) when the cover was manually closed **further** than the configured close position. The guard checked `in_close_position`, which is a tolerance window centered on the configured close position — a cover driven below that position (e.g. fully closed at 0 % while the close position is 15 %) was treated as "not closed", so shading ended and the cover opened. The condition now also treats a position below the close position (`current_below_close`, awning-aware) as closed ([#502](https://github.com/hvorragend/ha-blueprints/issues/502))


### PR DESCRIPTION
New option for reset manual override *"reset in position"*. 
This option will automatically clear the manual override state and restore automatic control once the cover reaches a specific target position (± configured tolerance) and remains there for the duration of the defined timeout. 

*Use Case:* Keep the blind in manual mode after lowering it by hand, and only let the automation take over again once the blind is fully reopened to 100%.