### PR TITLE
fix: dead-band manual position detection against hardware drift

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -470,6 +470,22 @@ No drive, no `man: 0` in the already-open case. `helper_update` preserves the ex
 
 ---
 
+### Bug Pattern Q: Hardware position drift triggers false manual override
+
+**Symptom:** Some minutes after the automation drives the cover (e.g. to the shading position 58 %), the cover reports a tiny position drift on its own (58 % → 59 %, stable ≥ the trigger's `for: 60s`). `t_manual_position` fires *outside* the drive-settle window, the "Manual: …" handler sets `man: 1`. With `ignore_shading_after_manual` active, the shading-end branches (gated by `not (helper_state_manual and override_flags.shading)`) are then blocked → the cover stays in the shading position even after the sun leaves the facade, until `reset_override_timeout` clears the override.
+
+**Cause:** The manual-detection gate in "Checking for manual position changes" only required `trigger.from_state ... != trigger.to_state ...` — **any** position change after the `now > helper_json.t + drive_time + 60` settle window counted as manual. There was no dead-band, so a ±1 % hardware/integration jitter (even one that keeps the cover *within* `position_tolerance` of where CCA put it, i.e. `in_shading_position` still `True`) was treated as a manual intervention. The trigger's own `for: 60s` confirms the drift is stable, so a transient filter does not help.
+
+**Fix:** Replace the `!=` detection with a dead-band against `position_tolerance` for all three position sources (`custom_sensor` → state value, `current_position_attr`, `position_attr`):
+```yaml
+- "{{ ((trigger.to_state.attributes.current_position | float(0)) - (trigger.from_state.attributes.current_position | float(0))) | abs > position_tolerance }}"
+```
+A change only counts as manual when its magnitude *exceeds* `position_tolerance`. With `position_tolerance = 0` the old behaviour (react to every change) is restored. The tilt-detection branch is intentionally left unchanged (no tilt tolerance exists).
+
+**Note — not solved by raising `position_tolerance` alone:** before this fix the detection ignored the tolerance entirely (`!=` only). The tolerance governed *which* branch was chosen (`in_shading_position`), not *whether* manual was detected. The dead-band ties the two together.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.02
+    **Version**: 2026.06.07
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2850,7 +2850,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.02"
+  version: "2026.06.07"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -7048,7 +7048,7 @@ actions:
                   - "{{ trigger.to_state.state not in invalid_states }}"
                   - "{{ is_number(trigger.from_state.state) }}"
                   - "{{ is_number(trigger.to_state.state) }}"
-                  - "{{ trigger.from_state.state != trigger.to_state.state }}"
+                  - "{{ ((trigger.to_state.state | float(0)) - (trigger.from_state.state | float(0))) | abs > position_tolerance }}"
 
               # Position change via current_position attribute
               - and:
@@ -7059,7 +7059,7 @@ actions:
                   - "{{ trigger.to_state.attributes.current_position not in invalid_states }}"
                   - "{{ is_number(trigger.from_state.attributes.current_position) }}"
                   - "{{ is_number(trigger.to_state.attributes.current_position) }}"
-                  - "{{ trigger.from_state.attributes.current_position != trigger.to_state.attributes.current_position }}"
+                  - "{{ ((trigger.to_state.attributes.current_position | float(0)) - (trigger.from_state.attributes.current_position | float(0))) | abs > position_tolerance }}"
 
               # Position change via position attribute
               - and:
@@ -7070,7 +7070,7 @@ actions:
                   - "{{ trigger.to_state.attributes.position not in invalid_states }}"
                   - "{{ is_number(trigger.from_state.attributes.position) }}"
                   - "{{ is_number(trigger.to_state.attributes.position) }}"
-                  - "{{ trigger.from_state.attributes.position != trigger.to_state.attributes.position }}"
+                  - "{{ ((trigger.to_state.attributes.position | float(0)) - (trigger.from_state.attributes.position | float(0))) | abs > position_tolerance }}"
 
               # Tilt change detection
               - and:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.07
+
+- 🐛 **Fix:** Manual override (`man:1`) was triggered by tiny hardware position drift. Some covers report their position with ±1 % jitter; if such a drift happened after the drive-settle window (e.g. the cover slipped from 58 % to 59 % a few minutes after shading), the manual-position detection treated it as a manual intervention and locked in the manual override. With `ignore_shading_after_manual` active, this then blocked the shading from ending — the cover stayed in the shading position even after the sun left the facade. The detection now applies a dead-band: a reported position change only counts as manual when it exceeds the configured *position tolerance*. Drift within the tolerance is ignored (set the tolerance to `0` to restore the previous behaviour of reacting to every change)
+
+---
+
 # CCA 2026.06.02
 
 - 🔧 **Improvement:** The reset timer of the *"reset in position"* option now uses the configured minutes directly, so the Home Assistant editor displays it correctly. Note: the *"Error in describing condition"* messages reported in [#512](https://github.com/hvorragend/ha-blueprints/issues/512) are a cosmetic Home Assistant frontend issue and do not affect how the automation runs

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -2198,3 +2198,94 @@ class TestShadingEndIfClosedGuard:
             "Shading-end 'if closed' guard must also block when the cover is "
             "below the close position (Issue #502)."
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: Manual detection dead-band — hardware position drift is not "manual"
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Dead-band expression taken verbatim from the blueprint (current_position_attr).
+MANUAL_DEADBAND_CURRENT_POS = (
+    "((trigger.to_state.attributes.current_position | float(0)) "
+    "- (trigger.from_state.attributes.current_position | float(0))) | abs "
+    "> position_tolerance"
+)
+
+
+def _deadband_env():
+    env = make_jinja_env()
+    # HA registers `abs` as a filter; plain Jinja2 does not.
+    env.filters["abs"] = abs
+    return env
+
+
+def _trigger_vars(from_pos, to_pos, tolerance):
+    return {
+        "trigger": {
+            "from_state": {"attributes": {"current_position": from_pos}},
+            "to_state": {"attributes": {"current_position": to_pos}},
+        },
+        "position_tolerance": tolerance,
+    }
+
+
+class TestManualDetectionDeadband:
+    """
+    Regression: covers that report their position with ±1% jitter must not
+    arm the manual override. A reported position change only counts as manual
+    when it exceeds the configured position_tolerance. Within the tolerance it
+    is treated as hardware drift and ignored.
+    """
+
+    def test_one_percent_drift_within_tolerance_is_not_manual(self):
+        """58 -> 59 with tolerance 1 must NOT be detected as a manual change."""
+        env = _deadband_env()
+        result = eval_condition(env, MANUAL_DEADBAND_CURRENT_POS, _trigger_vars(58, 59, 1))
+        assert result is False, (
+            "A 1% drift within position_tolerance must not trigger manual override."
+        )
+
+    def test_real_move_beyond_tolerance_is_manual(self):
+        """58 -> 70 with tolerance 1 IS a real manual move."""
+        env = _deadband_env()
+        result = eval_condition(env, MANUAL_DEADBAND_CURRENT_POS, _trigger_vars(58, 70, 1))
+        assert result is True
+
+    def test_drift_in_either_direction_is_ignored(self):
+        """The dead-band is symmetric: 59 -> 58 is also ignored."""
+        env = _deadband_env()
+        result = eval_condition(env, MANUAL_DEADBAND_CURRENT_POS, _trigger_vars(59, 58, 1))
+        assert result is False
+
+    def test_tolerance_zero_restores_react_to_every_change(self):
+        """tolerance 0 → any non-zero change counts as manual (legacy behaviour)."""
+        env = _deadband_env()
+        result = eval_condition(env, MANUAL_DEADBAND_CURRENT_POS, _trigger_vars(58, 59, 0))
+        assert result is True
+
+    def test_change_larger_than_tolerance_is_manual(self):
+        """tolerance 1, 58 -> 60 (delta 2 > 1) → manual."""
+        env = _deadband_env()
+        result = eval_condition(env, MANUAL_DEADBAND_CURRENT_POS, _trigger_vars(58, 60, 1))
+        assert result is True
+
+    def test_blueprint_wires_deadband_for_all_position_sources(self):
+        """Static wiring: all three position sources use the position_tolerance dead-band."""
+        text = BLUEPRINT_PATH.read_text()
+        for attr in ("current_position", "position"):
+            expr = (
+                f"((trigger.to_state.attributes.{attr} | float(0)) "
+                f"- (trigger.from_state.attributes.{attr} | float(0))) | abs "
+                f"> position_tolerance"
+            )
+            assert expr in text, f"Dead-band missing for attribute '{attr}'"
+        # custom_sensor uses the state value, not an attribute
+        custom = (
+            "((trigger.to_state.state | float(0)) "
+            "- (trigger.from_state.state | float(0))) | abs > position_tolerance"
+        )
+        assert custom in text, "Dead-band missing for custom_sensor position source"
+        # The old unconditional '!=' detection must be gone.
+        assert "trigger.from_state.attributes.current_position != trigger.to_state.attributes.current_position" not in text, (
+            "Old unconditional '!=' manual detection must be replaced by the dead-band."
+        )


### PR DESCRIPTION
Tiny position drift (e.g. 58% -> 59%) reported by the cover after the drive-settle window was treated as a manual change and set man:1. With ignore_shading_after_manual active this blocked shading from ending, so the cover stayed in the shading position after the sun left the facade.

Manual detection now requires the position change to exceed position_tolerance for all three position sources. Drift within the tolerance is ignored; set tolerance to 0 to restore the old behaviour.