### PR TITLE
Anchor shading-start retry budget to time-window start (#524)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -471,6 +471,18 @@ A change only counts as manual when its magnitude *exceeds* `position_tolerance`
 
 ---
 
+### Bug Pattern S: `shading_start_max_duration` budget consumed by pre-window wait (Issue #524)
+
+**Symptom:** Shading-start conditions are met well *before* the opening time (e.g. independent-temperature mode at dawn). The pending arms, `ts.due` is correctly deferred to the window start (Bug Pattern L). Inside the window the start is gated off by an additional condition (`auto_shading_start_condition`) or unstable conditions, so the loop retries. But the retry loop aborts with `"Shading Start aborted: Timeout or invalid (blocked)"` much earlier than the configured `shading_start_max_duration` would suggest — e.g. only ~1 h of in-window retry on a 2 h budget.
+
+**Cause:** The "Shading detected" arming branch set `ts.arm: "now"` at the (pre-window) arming moment, and the max-duration checks compute `now - helper_ts_pending_arm`. When the pending arms an hour before the window opens, that hour is counted against the budget even though no real retry happens during it (the cover only waits for the window). When `ts.due` is deferred directly to the window start, the "waiting for time window" branches (which re-anchor `ts.arm` to `now` on each pre-window retry) never run, so `ts.arm` stays at the early arming time and the budget is silently shortened.
+
+**Fix:** In the "Shading detected" arming branch, anchor `ts.arm` to the start of the shading window when arming early. Compute a `shading_start_arm` variable mirroring `shading_start_due` but without the `+ waitingtime`/`+1`: `max(now, window_start)` where `window_start` is `today_at(time_up_early_today)` (time field) or `calendar_open_start` (calendar), and plain `now` when the window is already open or time control is disabled. The "waiting for time window" retry branches keep `arm: "now"` — they already push the anchor forward to ~window-open by re-arming every `waitingtime` seconds.
+
+**Note:** This is distinct from the underlying *configuration* cause that usually surfaces this symptom: an `auto_shading_start_condition` that stays `false` through the whole window (e.g. "outdoor temp > 14 °C" when it is 13.7 °C) will still abort after the (now correctly-sized) budget. The additional condition is a *gate*, not a trigger — if its entity is not also a shading trigger source, a value that only crosses the threshold later in the day will not re-arm the pending.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.07
+    **Version**: 2026.06.08
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2850,7 +2850,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.07"
+  version: "2026.06.08"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5353,7 +5353,18 @@ actions:
                             {% else %}
                               {{ wait_due }}
                             {% endif %}
-                          log_extra: "shading start pending armed; wait={{ shading_waitingtime_start | int }}s; due_in={{ (shading_start_due | int - as_timestamp(now()) | int) }}s; max_duration={{ shading_start_max_duration | int }}s"
+                          shading_start_arm: >-
+                            {% set ts = as_timestamp(now()) | int %}
+                            {% if is_time_control_disabled or is_shading_allowed_window %}
+                              {{ ts }}
+                            {% elif is_time_field_enabled %}
+                              {{ [ts, as_timestamp(today_at(time_up_early_today)) | int] | max }}
+                            {% elif is_calendar_enabled and calendar_open_start is not none %}
+                              {{ [ts, calendar_open_start | int] | max }}
+                            {% else %}
+                              {{ ts }}
+                            {% endif %}
+                          log_extra: "shading start pending armed; wait={{ shading_waitingtime_start | int }}s; due_in={{ (shading_start_due | int - as_timestamp(now()) | int) }}s; max_duration={{ shading_start_max_duration | int }}s; budget_from={{ shading_start_arm | int }}"
                           update_values:
                             # Set shade pending timestamp
                             shd: 0
@@ -5361,7 +5372,7 @@ actions:
                             ts:
                               shd: "now"
                               due: "{{ shading_start_due | int }}"
-                              arm: "now" # Anchor for max-duration retry window
+                              arm: "{{ shading_start_arm | int }}" # Anchor max-duration budget to window start when arming before the window
                       - *helper_update
                       - stop: "Shading Start Pending: Waiting"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.08
+
+- 🔧 **Improvement:** When a shading-start countdown was armed *before* the configured opening time (e.g. the shading conditions were already met at dawn), the maximum retry duration was counted from that early arming moment instead of from when the shading time window actually opens. As a result a large part of the configured "maximum duration for shading start retry loop" was consumed while merely waiting for the window to open, and the retry loop could abort with *"Shading Start aborted: Timeout or invalid"* shortly after the window opened — even though plenty of retry time was supposedly configured. The retry budget is now anchored to the start of the shading time window when arming early, so the configured duration applies *within* the window as intended ([#524](https://github.com/hvorragend/ha-blueprints/issues/524))
+
+---
+
 # CCA 2026.06.07
 
 - 🐛 **Fix:** When a resident left (presence `on → off`) or arrived while a window was tilted, the cover stayed in the ventilation position instead of opening fully. With the schedule set to "open" (`bas=opn`) and no shading/privacy active, ventilation is only a *floor* — the cover should open completely because no ventilation is needed at that point. The "Resident leaving: target VENTILATION (window tilted)" and "Resident arriving: window tilted → hold ventilation position" branches only checked the tilted sensor and drove to the ventilation position regardless of the effective target. They now also require `effective_state == 'vnt'`, so when the base state is open the branch is skipped and the cover opens fully; at night (`bas=cls`) ventilation remains the correct floor. This matches the priority cascade (BASE=OPN before VENT) already used by the contact handler ([#460](https://github.com/hvorragend/ha-blueprints/issues/460), [#513](https://github.com/hvorragend/ha-blueprints/issues/513))


### PR DESCRIPTION
When the shading-start pending arms before the opening time, ts.due is deferred to the window start (Bug Pattern L) but ts.arm was set to the early arming moment. Since the max-duration checks use now - ts.arm, the pre-window wait silently consumed part of shading_start_max_duration, so the retry loop could abort with "Shading Start aborted: Timeout or invalid" far earlier than the configured budget.

The arming branch now anchors ts.arm to max(now, window_start), mirroring the existing ts.due window-deferral logic, so the configured retry duration applies within the shading window as intended.