### PR TITLE
fix(cca): load weather forecast on every opening trigger (#514 follow-up)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -483,6 +483,18 @@ A change only counts as manual when its magnitude *exceeds* `position_tolerance`
 
 ---
 
+### Bug Pattern T: Weather forecast not loaded on non-`t_open_1` opening triggers breaks `shading_start_warranted` (Issue #514 follow-up)
+
+**Symptom:** A shading-start pending is armed before the opening time and the shading conditions are *still* met when the opening time fires. The cover should stay in shading (the opening handler defers to the shading execution per Bug Pattern R). Instead the cover opens normally — but only for users on **calendar-controlled opening** (`t_calendar_event_start`) or any non-`t_open_1` opening trigger (`t_open_2/4/5`). The trace shows the "Opening skipped: Shading start pending" branch was *not* selected, "Normal opening" ran, and the pending was cleared.
+
+**Cause:** The forecast-load gate (line ~4207) only ran `weather.get_forecasts` when the trigger matched `^(t_shading_start|t_open_1)`. Other opening triggers were excluded. With the forecast not loaded, `weather_forecast` is undefined, `forecast_temp_raw` and `forecast_weather_condition_raw` fall through to `None`, and `forecast_temp_valid`/`forecast_weather_valid` evaluate to `false` whenever the user has configured those conditions. `shading_start_warranted` therefore evaluates to `false`, the "Opening skipped: Shading start pending" branch (which gates on `shading_start_warranted` per the Bug Pattern R fix) is skipped, and execution falls through to "Normal opening". `independent_temp_valid` is affected too (depends on `forecast_temp_raw`), so the independent-temperature path also breaks under the same conditions.
+
+**Fix:** Widen the regex to `^(t_shading_start|t_open|t_calendar_event_start)` so the weather forecast is loaded on every opening-related trigger. This mirrors the top-level "Check for opening" branch gate (`^(t_open|t_calendar_event)`) plus the existing shading-start triggers, ensuring `shading_start_warranted` is evaluated against fresh forecast data whenever the opening handler may need it. The closing handler discards pending unconditionally and never reads `shading_start_warranted`, so it does not need the forecast.
+
+**Why only this user setup hit it:** The original `t_open_1` covered the most common time-based opening. Bug Pattern R (#514, CCA 2026.06.07) added the `shading_start_warranted` gate without revisiting the forecast-load gate — the moment the user's setup uses a calendar trigger or a late/brightness/sun-elevation opening trigger, the gate's premise (forecast already loaded) silently breaks.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.08
+    **Version**: 2026.06.08 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2850,7 +2850,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.08"
+  version: "2026.06.08 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -4204,7 +4204,7 @@ actions:
       - "{{ forecast_source.use_weather and not forecast_source.prevent_service }}"
       - "{{ states(shading_forecast_sensor) not in invalid_states }}"
       - "{{ trigger.id is defined }}"
-      - "{{ trigger.id | regex_match('^(t_shading_start|t_open_1)') }}" # Important: All triggers for shading start necessary!
+      - "{{ trigger.id | regex_match('^(t_shading_start|t_open|t_calendar_event_start)') }}" # All shading-start triggers AND every opening trigger (so the opening handler can evaluate shading_start_warranted while a pending is armed, #514 follow-up)
     then:
       - action: weather.get_forecasts
         target:

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.08 V2
+    **Version**: 2026.06.08
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2850,7 +2850,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.08 V2"
+  version: "2026.06.08"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.08 V2
+
+- 🐛 **Fix:** When a shading-start pending was armed before the opening time and the shading conditions were *still* met when the opening time fired, the cover opened normally instead of staying in shading — but only for setups using **calendar-controlled opening times** (or any opening trigger other than the early time trigger). The opening handler's "Opening skipped: Shading start pending" branch now correctly evaluates whether shading is still warranted, but on a calendar opening the weather forecast was never loaded, so the forecast-based conditions defaulted to *false*, "still warranted" evaluated to *false*, and the cover opened. The forecast is now loaded for every opening-related trigger (early/late time, brightness, sun elevation, calendar start), so the *"defer to shading execution while still warranted"* logic works regardless of which trigger fires the opening ([#514](https://github.com/hvorragend/ha-blueprints/issues/514))
+
+---
+
 # CCA 2026.06.08
 
 - 🔧 **Improvement:** When a shading-start countdown was armed *before* the configured opening time (e.g. the shading conditions were already met at dawn), the maximum retry duration was counted from that early arming moment instead of from when the shading time window actually opens. As a result a large part of the configured "maximum duration for shading start retry loop" was consumed while merely waiting for the window to open, and the retry loop could abort with *"Shading Start aborted: Timeout or invalid"* shortly after the window opened — even though plenty of retry time was supposedly configured. The retry budget is now anchored to the start of the shading time window when arming early, so the configured duration applies *within* the window as intended ([#524](https://github.com/hvorragend/ha-blueprints/issues/524))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,8 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
-# CCA 2026.06.08 V2
-
-- 🐛 **Fix:** When a shading-start pending was armed before the opening time and the shading conditions were *still* met when the opening time fired, the cover opened normally instead of staying in shading — but only for setups using **calendar-controlled opening times** (or any opening trigger other than the early time trigger). The opening handler's "Opening skipped: Shading start pending" branch now correctly evaluates whether shading is still warranted, but on a calendar opening the weather forecast was never loaded, so the forecast-based conditions defaulted to *false*, "still warranted" evaluated to *false*, and the cover opened. The forecast is now loaded for every opening-related trigger (early/late time, brightness, sun elevation, calendar start), so the *"defer to shading execution while still warranted"* logic works regardless of which trigger fires the opening ([#514](https://github.com/hvorragend/ha-blueprints/issues/514))
-
----
-
 # CCA 2026.06.08
 
+- 🐛 **Fix:** When a shading-start pending was armed before the opening time and the shading conditions were *still* met when the opening time fired, the cover opened normally instead of staying in shading — but only for setups using **calendar-controlled opening times** (or any opening trigger other than the early time trigger). The opening handler's "Opening skipped: Shading start pending" branch now correctly evaluates whether shading is still warranted, but on a calendar opening the weather forecast was never loaded, so the forecast-based conditions defaulted to *false*, "still warranted" evaluated to *false*, and the cover opened. The forecast is now loaded for every opening-related trigger (early/late time, brightness, sun elevation, calendar start), so the *"defer to shading execution while still warranted"* logic works regardless of which trigger fires the opening ([#514](https://github.com/hvorragend/ha-blueprints/issues/514))
 - 🔧 **Improvement:** When a shading-start countdown was armed *before* the configured opening time (e.g. the shading conditions were already met at dawn), the maximum retry duration was counted from that early arming moment instead of from when the shading time window actually opens. As a result a large part of the configured "maximum duration for shading start retry loop" was consumed while merely waiting for the window to open, and the retry loop could abort with *"Shading Start aborted: Timeout or invalid"* shortly after the window opened — even though plenty of retry time was supposedly configured. The retry budget is now anchored to the start of the shading time window when arming early, so the configured duration applies *within* the window as intended ([#524](https://github.com/hvorragend/ha-blueprints/issues/524))
 
 ---

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -2442,3 +2442,108 @@ class TestManualDetectionDeadband:
         assert "trigger.from_state.attributes.current_position != trigger.to_state.attributes.current_position" not in text, (
             "Old unconditional '!=' manual detection must be replaced by the dead-band."
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: Weather forecast must be loaded on every opening trigger (Bug Pattern T)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestWeatherForecastLoadGateCoversOpeningTriggers:
+    """
+    Regression for Bug Pattern T (issue #514 follow-up):
+
+    The Bug Pattern R fix (CCA 2026.06.07) added `shading_start_warranted` to
+    the "Opening skipped: Shading start pending" branch. That variable reads
+    `forecast_temp_raw` and `forecast_weather_condition_raw`, which require
+    `weather_forecast` to be populated by the `weather.get_forecasts` action.
+
+    The forecast-load gate originally only matched `^(t_shading_start|t_open_1)`
+    triggers. With Bug Pattern R in place, every opening trigger that may
+    reach the "Opening skipped" branch must also load the forecast — otherwise
+    the forecast-based conditions silently evaluate to false and the cover
+    opens despite shading still being warranted.
+
+    The top-level "Check for opening" branch is gated on
+    `^(t_open|t_calendar_event)` (calendar_event_end is filtered out by other
+    conditions). The forecast-load regex must therefore cover all `t_open*`
+    triggers AND `t_calendar_event_start`.
+    """
+
+    OPENING_TRIGGER_IDS_REQUIRING_FORECAST = [
+        "t_open_1",            # early time
+        "t_open_2",            # late time
+        "t_open_4",            # brightness
+        "t_open_5",            # sun elevation
+        "t_calendar_event_start",  # calendar
+    ]
+
+    def _load_forecast_load_block(self) -> dict:
+        """Locate the top-level if/then block that calls weather.get_forecasts."""
+        blueprint = _load_blueprint_yaml(BLUEPRINT_PATH)
+
+        def walk(node):
+            if isinstance(node, dict):
+                if "if" in node and "then" in node:
+                    then = node["then"]
+                    if isinstance(then, list):
+                        for step in then:
+                            if isinstance(step, dict) and step.get("action") == "weather.get_forecasts":
+                                return node
+                for v in node.values():
+                    result = walk(v)
+                    if result is not None:
+                        return result
+            elif isinstance(node, list):
+                for item in node:
+                    result = walk(item)
+                    if result is not None:
+                        return result
+            return None
+
+        block = walk(blueprint)
+        assert block is not None, "Could not find weather.get_forecasts if/then block"
+        return block
+
+    def test_regex_matches_all_opening_triggers(self):
+        """Every opening-related trigger ID must satisfy the forecast-load regex."""
+        import re
+
+        block = self._load_forecast_load_block()
+        conditions = block["if"]
+        flat = yaml.safe_dump(conditions)
+        # Extract the regex_match pattern from the trigger-gating condition.
+        # We look for `regex_match('^(...)')` to pull out the alternation list.
+        m = re.search(r"regex_match\(''?(\^\([^)]+\))''?\)", flat)
+        assert m is not None, (
+            "Forecast-load gate must use a regex_match on trigger.id with an "
+            f"anchored alternation. Conditions were:\n{flat}"
+        )
+        pattern = m.group(1)
+        compiled = re.compile(pattern)
+        for trigger_id in self.OPENING_TRIGGER_IDS_REQUIRING_FORECAST:
+            assert compiled.match(trigger_id), (
+                f"Forecast-load regex {pattern!r} does not match opening trigger "
+                f"{trigger_id!r}. Without loading the forecast, the opening "
+                f"handler cannot correctly evaluate shading_start_warranted "
+                f"and may open the cover even when shading is still warranted."
+            )
+
+    def test_regex_still_matches_shading_start_triggers(self):
+        """The forecast must continue to load on shading-start pending triggers."""
+        import re
+
+        block = self._load_forecast_load_block()
+        flat = yaml.safe_dump(block["if"])
+        m = re.search(r"regex_match\(''?(\^\([^)]+\))''?\)", flat)
+        assert m is not None
+        pattern = m.group(1)
+        compiled = re.compile(pattern)
+        for trigger_id in [
+            "t_shading_start_pending_1",
+            "t_shading_start_pending_7",
+            "t_shading_start_execution",
+        ]:
+            assert compiled.match(trigger_id), (
+                f"Forecast-load regex {pattern!r} must also match shading-start "
+                f"trigger {trigger_id!r}."
+            )


### PR DESCRIPTION
The Bug Pattern R fix (CCA 2026.06.07) added shading_start_warranted to
the "Opening skipped: Shading start pending" branch so a stale pending no
longer suppresses the opening. shading_start_warranted depends on
forecast_temp_raw / forecast_weather_condition_raw, which require the
weather.get_forecasts service to have been called earlier in the run.

The forecast-load gate was still narrow:
  trigger.id | regex_match('^(t_shading_start|t_open_1)')

So for users on calendar-controlled opening (t_calendar_event_start) or
any other opening trigger (t_open_2/4/5), the forecast was never loaded
when the opening fired. weather_forecast was undefined,
forecast_temp_raw and forecast_weather_condition_raw fell through to
None, and forecast_temp_valid / forecast_weather_valid evaluated to
false. shading_start_warranted therefore evaluated to false, the
"Opening skipped" branch was skipped, and the cover opened normally
even though shading was still warranted.

Widen the regex to cover every opening-related trigger:
  ^(t_shading_start|t_open|t_calendar_event_start)

The closing handler discards pending unconditionally and never reads
shading_start_warranted, so closing triggers do not need the forecast.

- Documented as Bug Pattern T in CLAUDE.md.
- Added regression tests asserting the gate matches t_open_1/2/4/5,
  t_calendar_event_start, and all shading-start triggers.
- Bumped version to 2026.06.08 V2 and added a changelog entry.