### PR TITLE
Feature: Allow to specify how many traces are stored.

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -2681,6 +2681,16 @@ blueprint:
           default: false
           selector:
             boolean: {}
+        trace_count:
+          name: "📜 Number of stored traces"
+          description: >-
+            Set how many traces Home Assistant shall keep for this automation.
+          default: 5
+          selector:
+            number:
+              min: 1
+              max: 100
+              step: 1
 
 ################################################################################
 # TRIGGER VARIABLES
@@ -7647,3 +7657,5 @@ actions:
                 update={{ update_values | default({}) | to_json }} 
                 {% if log_extra is defined %} extra={{ log_extra }}{% endif %}
       - stop: "No operational branch matched (Opening, Closing, Shading, etc. conditions not met for current trigger)"
+ trace:
+  stored_traces: !input trace_count


### PR DESCRIPTION
Add an integer input to the blueprint that allows the user to specify how many traces are stored. The default number of 5 matches the [current HA default](https://www.home-assistant.io/docs/automation/yaml/#number-of-debug-traces-stored). The input is added under the "Logging" section.