### PR TITLE
Fix YAML parse error: trace key indented under actions block

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.08
+    **Version**: 2026.06.14
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2872,7 +2872,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.08"
+  version: "2026.06.14"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -7657,5 +7657,6 @@ actions:
                 update={{ update_values | default({}) | to_json }} 
                 {% if log_extra is defined %} extra={{ log_extra }}{% endif %}
       - stop: "No operational branch matched (Opening, Closing, Shading, etc. conditions not met for current trigger)"
- trace:
+
+trace:
   stored_traces: !input trace_count

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.14
+
+- 🐛 **Fix:** The blueprint failed to import (YAML parsing error *"expected \<block end\>, but found ?"* at the `trace:` key) since the *"Number of stored traces"* setting was added. The `trace:` top-level key was indented by one space, which made it part of the preceding `actions:` block instead of a separate automation-level key. It is now correctly placed at the top level, so importing via the official button or the standard/raw URL works again ([#532](https://github.com/hvorragend/ha-blueprints/issues/532))
+
+---
+
 # CCA 2026.06.08
 
 - ✨ **Feature:** The *"Reset manual override"* setting now accepts **multiple** reset mechanisms at the same time. Previously the four options (*disabled*, *at fixed time*, *after timeout*, *in position*) were mutually exclusive; you can now combine e.g. *Reset in position* with *Reset after a timeout* as a safety net for when you forget to drive the cover back to the reset position. The first triggered reset wins. Existing single-value configurations continue to work unchanged. To disable all timed resets, leave the field empty ([#522](https://github.com/hvorragend/ha-blueprints/issues/522))


### PR DESCRIPTION
The trace: top-level key was indented by one space, making it part of
the preceding actions: block. HA's YAML loader failed to import the
blueprint with 'expected <block end>, but found trace:'. Move trace: to
column 0 so stored_traces is a proper automation-level setting.

Fixes #532

https://claude.ai/code/session_01NeqVEo4EWNJt8MKVxixTKd