### PR TITLE
Fix shading start when cover is below the shading position (#530)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -495,6 +495,22 @@ A change only counts as manual when its magnitude *exceeds* `position_tolerance`
 
 ---
 
+### Bug Pattern U: Shading start skipped when cover sits below the shading position (Issue #530)
+
+**Symptom:** Shading conditions are met *before* the opening time, so at opening time the cover is still fully closed (position `0`). The opening handler correctly defers to `t_shading_start_execution` (Bug Pattern R), but the execution then does nothing: no drive, no helper write, `shd` stays `0`, `pnd` stays `'beg'`. The cover hangs closed all morning and the slats never tilt into the shading angle. Trace shows the execution reaching the inner drive `choose` with **all** branches false (`Consider lockout` / `Start Shading` / `Save shading state for the future`), then falling off the end with no `stop`.
+
+**Cause:** The "Start Shading" branch position guard (line ~5437) only allowed driving *downward* to the shading position: `current_above_shading` (and, for tilt covers, `current_above_shading or current_position == shading_position`). With `shading_position` above `close_position` (e.g. `3` vs `0`), a fully-closed cover is **below** the shading position → `current_above_shading` is false and `current_position != shading_position` → the guard fails. "Consider lockout" needs an open window (false here) and "Save shading state for the future" needs `effective_state == 'cls'` — but after the opening trigger set `bas: 'opn'`, `effective_state == 'opn'` (shading not yet active, `shd == 0`). All three branches miss → dead zone.
+
+**Fix:** Add a third alternative to the "Start Shading" position-check OR: drive when the cover is **below** the shading position **and** the base state wants it open (so shading must cap an otherwise-open cover by *raising* it to the shading position):
+```yaml
+- and:
+    - "{{ position_comparisons.current_below_shading }}"
+    - "{{ effective_state == 'opn' }}"
+```
+The `effective_state == 'opn'` gate is essential: when `effective_state == 'cls'` (base closed, e.g. overnight) the cover must stay closed and "Save shading state for the future" stores the intent without driving — do **not** raise the cover at night. This mirrors the opening handler's "Shading detected. Move to shading position" branch, which already drives from any direction via `not in_shading_position`.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.08
+    **Version**: 2026.06.14
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2862,7 +2862,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.08"
+  version: "2026.06.14"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5441,6 +5441,10 @@ actions:
                                       - and:
                                           - "{{ is_cover_tilt_enabled_and_possible }}"
                                           - "{{ position_comparisons.current_above_shading or current_position == shading_position }}"
+                                      # Cover below the shading position (e.g. closed overnight) while the base state wants it open: raise to the shading cap
+                                      - and:
+                                          - "{{ position_comparisons.current_below_shading }}"
+                                          - "{{ effective_state == 'opn' }}"
                                   - "{{ is_shading_allowed_window }}" # Shading during daytime window
                                   - "{{ resident_flags.allow_shade }}"
                                 sequence:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.14
+
+- 🐛 **Fix:** When the shading conditions were already met *before* the opening time, the cover stayed closed all morning instead of moving into the shading position. At the opening time the handler correctly deferred to the shading execution, but the execution then refused to move the cover: its position check only drove the cover *down* to the shading position, while a cover that was still fully closed sits *below* the shading position (e.g. shading position 3 %, closed 0 %). As a result nothing happened — no movement, the shading state was never recorded, and the cover stayed stuck closed (and the slats never tilted into the shading angle). The shading-start branch now also raises a closed cover up to the shading position when the schedule wants it open ([#530](https://github.com/hvorragend/ha-blueprints/issues/530))
+
+---
+
 # CCA 2026.06.08
 
 - ✨ **Feature:** The *"Reset manual override"* setting now accepts **multiple** reset mechanisms at the same time. Previously the four options (*disabled*, *at fixed time*, *after timeout*, *in position*) were mutually exclusive; you can now combine e.g. *Reset in position* with *Reset after a timeout* as a safety net for when you forget to drive the cover back to the reset position. The first triggered reset wins. Existing single-value configurations continue to work unchanged. To disable all timed resets, leave the field empty ([#522](https://github.com/hvorragend/ha-blueprints/issues/522))

--- a/tests/test_documented_bug_patterns.py
+++ b/tests/test_documented_bug_patterns.py
@@ -376,3 +376,51 @@ class TestIssue495AlreadyOpenPreservesTsOpn:
         # else (already open, same day) → preserve ts.opn by omitting the key
         assert "ts" not in else_uv, "else must preserve ts.opn (omit it) (#495)"
         assert else_uv.get("bas") == "opn"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #530: shading starts while the cover sits BELOW the shading position
+#
+# When the shading conditions are met before the opening time, the cover is
+# still fully closed (position 0) at execution time. The shading-position cap is
+# above the closed position (e.g. shading_position=3, close_position=0), so the
+# old `current_above_shading` position guard was always False and the
+# "Start Shading" branch was skipped — leaving the cover stuck closed with
+# pnd='beg' forever. The branch must also drive when the cover is below the
+# shading position while the base state wants it open (effective_state == 'opn').
+# ─────────────────────────────────────────────────────────────────────────────
+
+START_SHADING_ALIAS = "Start Shading"
+
+
+class TestIssue530RaiseToShadingFromBelow:
+    """The Start Shading branch must raise a closed cover to the shading cap."""
+
+    @pytest.fixture(scope="class")
+    def branch(self):
+        return _find_branch_by_alias(_load_blueprint_yaml(), START_SHADING_ALIAS)
+
+    def test_branch_exists(self, branch):
+        assert branch is not None, f"branch not found: {START_SHADING_ALIAS!r}"
+
+    def test_position_check_has_below_shading_alternative(self, branch):
+        # The position-check OR must include an alternative that fires when the
+        # cover is below the shading position and the base state wants it open.
+        or_clauses = [
+            c["or"] for c in branch["conditions"] if isinstance(c, dict) and "or" in c
+        ]
+        assert or_clauses, "Start Shading must have an or-based position check"
+        flat = " ".join(str(clause) for clause in or_clauses)
+        assert "current_below_shading" in flat, (
+            "Start Shading must drive when cover is below the shading position (#530)"
+        )
+        assert "effective_state == 'opn'" in flat, (
+            "below-shading drive must be gated on base wanting open (#530)"
+        )
+
+    def test_branch_still_sets_shd_and_clears_pending(self, branch):
+        # Whatever direction the cover moves, the helper must record shd=1 and
+        # clear the pending so the cover never gets stuck in 'beg'.
+        uv = _branch_update_values(branch)
+        assert uv.get("shd") == 1, "Start Shading must set shd=1"
+        assert uv.get("pnd") == "non", "Start Shading must clear pnd"


### PR DESCRIPTION
When the shading conditions are met before the opening time, the cover is
still fully closed at execution time. With shading_position above
close_position (e.g. 3 vs 0) the closed cover sits below the shading
position, so the "Start Shading" position guard (current_above_shading)
never matched and the execution branch fell into a dead zone: no drive, no
helper write, shd stayed 0 and pnd stayed 'beg' — the cover hung closed all
morning and the slats never tilted into the shading angle.

Add a third alternative to the position-check OR so the branch also drives
when the cover is below the shading position while the base state wants it
open (effective_state == 'opn'), raising it to the shading cap. The
effective_state == 'opn' gate keeps the cover closed at night (base=cls),
where "Save shading state for the future" stores the intent instead.

- Bump version 2026.06.08 -> 2026.06.14 (description + variable)
- Changelog entry and Bug Pattern U in CLAUDE.md
- Regression test TestIssue530RaiseToShadingFromBelow

https://claude.ai/code/session_01QN8qUr8gj4m7Jw8g4samdA