### PR TITLE
fix: shade-once-per-day guard ignored without manual override

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,6 +149,7 @@ The `man` flag (manual override) may only be set to `0` when the automation actu
 **ts.shd (shading timestamp):**
 - `ts.shd` may only be set when `shd` actually changes (guard in `helper_update`: only when `new_shd != current.shd`)
 - In the SHADED branch of the `resident_leaving` handler: `shd` was already `1` (precondition) → do **not** set `ts.shd` to `now`, preserve the original activation timestamp
+- The midnight reset (BRANCH 11) **does** write `ts.shd: "now"` when it clears `shd` 1→0 — this is fine: the reset fires at **23:55 same day** (`now() >= today_at('23:55:00')`), so the stamp lands on the current day, never the next one. The once-per-day shading guard (full-date compare) therefore still allows shading the following day.
 
 **pnd / ts.due / ts.arm (pending phase + timestamps):**
 - The top-level `pnd` enum encodes which phase is pending: `'non'` (idle), `'beg'` (start armed), `'end'` (end armed). Only one value at a time is representable — Invariant 11 is enforced by the schema.
@@ -508,6 +509,32 @@ A change only counts as manual when its magnitude *exceeds* `position_tolerance`
     - "{{ effective_state == 'opn' }}"
 ```
 The `effective_state == 'opn'` gate is essential: when `effective_state == 'cls'` (base closed, e.g. overnight) the cover must stay closed and "Save shading state for the future" stores the intent without driving — do **not** raise the cover at night. This mirrors the opening handler's "Shading detected. Move to shading position" branch, which already drives from any direction via `not in_shading_position`.
+
+---
+
+### Bug Pattern V: "Shade only once per day" never blocks for users who don't touch the cover by hand
+
+**Symptom:** With `prevent_shading_multiple_times` enabled, the cover still shades multiple times a day. After the morning shading ends (sun leaves the facade, cover returns to open), the afternoon shading conditions re-trigger and the cover shades **again**. The repeated shading-end movements also make the cover appear to *open* multiple times (shade → open → shade → open).
+
+**Cause:** The once-per-day guard was
+
+```jinja2
+prevent_flags.shading_multiple_times and ((now().day != helper_ts_shade|timestamp_custom('%-d')|int) or helper_ts_man <= helper_ts_shade)
+```
+
+The second OR-clause `helper_ts_man <= helper_ts_shade` ("no manual change happened after the last shading") is **always true** when the user never moves the cover by hand, because `ts.man` defaults to `0` and `0 <= ts.shd` holds for any non-zero `ts.shd`. The day-check is therefore short-circuited and the guard never blocks a second shading. The clause was originally added for the opening/closing guards to handle `ts.opn`/`ts.cls` being polluted by non-driving base-state syncs (Issue #311) — but for shading it only disables the feature.
+
+**Fix:** Drop the manual clause for shading and make the guard purely calendar-based, comparing the **full date** (not just day-of-month, which collapsed across months and treated a fresh `ts.shd == 0` as "day 1"):
+
+```jinja2
+prevent_flags.shading_multiple_times and now().strftime('%Y-%m-%d') != helper_ts_shade | timestamp_custom('%Y-%m-%d')
+```
+
+The `t_shading_start_execution` bypass (third OR-clause) is kept so an already-armed pending can still execute. Manual override is still respected via the separate `not (helper_state_manual and override_flags.shading)` gate.
+
+**`ts.shd` is the only consumer of this guard, and it is not polluted like `ts.opn`/`ts.cls`** — it changes only on a real `shd` 0↔1 transition (Invariant 8). The opening/closing guards are intentionally **left unchanged** (they keep the manual clause) because their timestamps *are* polluted by non-driving syncs, so removing the clause there would reintroduce Issue #311. The user-reported "opening multiple times" symptom is a side-effect of the shading loop, not an independent opening bug.
+
+**Why the midnight reset (BRANCH 11) needs no special handling:** `t_shading_reset` fires at **23:55 the same day** (`now() >= today_at('23:55:00')`), so even though it clears `shd` 1→0 and writes `ts.shd: "now"`, the stamp lands on the *current* day — never the next one. The full-date guard compares `ts.shd`'s day against today, so the following day is still a different date → shading is allowed. The old CHANGELOG #365 failure (reset stamping the *new* day and blocking it) cannot occur with the 23:55 trigger; no `ts.shd` omission is required.
 
 ---
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.14
+    **Version**: 2026.06.16
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2872,7 +2872,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.14"
+  version: "2026.06.16"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5339,7 +5339,7 @@ actions:
               - "{{ is_cover_tilt_enabled_and_possible }}"
           - or: # Only once a day?
               - "{{ not prevent_flags.shading_multiple_times }}"
-              - "{{ prevent_flags.shading_multiple_times and ((now().day != helper_ts_shade|timestamp_custom('%-d')|int) or helper_ts_man <= helper_ts_shade) }}"
+              - "{{ prevent_flags.shading_multiple_times and now().strftime('%Y-%m-%d') != helper_ts_shade | timestamp_custom('%Y-%m-%d') }}"
               - "{{ trigger.id | regex_match('^(t_shading_start_execution)') }}" # Execution must not be stopped if there is a shading pending in the helper beforehand.
 
         sequence:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.16
+
+- 🐛 **Fix:** The *"shade the cover only once per day"* option was effectively inactive for everyone who does not manually move their covers by hand. The daily guard allowed shading again whenever no manual change had happened since the last shading — and since that is *always* the case when you never touch the cover by hand, the guard never blocked a second shading. Covers therefore re-entered the shading position again and again throughout the day (and the repeated shading-end movements made the cover look like it was *also* opening multiple times). The guard is now purely calendar-based: once the cover has shaded today, it will not shade again until the next day
+
+---
+
 # CCA 2026.06.14
 
 - 🐛 **Fix:** The blueprint failed to import (YAML parsing error *"expected \<block end\>, but found ?"* at the `trace:` key) since the *"Number of stored traces"* setting was added. The `trace:` top-level key was indented by one space, which made it part of the preceding `actions:` block instead of a separate automation-level key. It is now correctly placed at the top level, so importing via the official button or the standard/raw URL works again ([#532](https://github.com/hvorragend/ha-blueprints/issues/532))

--- a/tests/test_documented_bug_patterns.py
+++ b/tests/test_documented_bug_patterns.py
@@ -8,6 +8,8 @@ Covered here:
   - Pattern M (#483): sun-position end split into azimuth-only / elevation-only
   - Pattern N (#484): contact handler must not reset pnd/ts.due/ts.arm,
                       and "was ventilating before" must not gate on in_open_position
+  - Pattern V:        shade-once-per-day guard is calendar-based (no helper_ts_man
+                      short-circuit)
 
 Run with: pytest tests/ -v
 """
@@ -424,3 +426,53 @@ class TestIssue530RaiseToShadingFromBelow:
         uv = _branch_update_values(branch)
         assert uv.get("shd") == 1, "Start Shading must set shd=1"
         assert uv.get("pnd") == "non", "Start Shading must clear pnd"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pattern V: "shade only once per day" must block on a calendar-day basis,
+# not be short-circuited by the always-true `helper_ts_man <= helper_ts_shade`
+# clause.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPatternVShadeOncePerDay:
+    """The shading once-per-day guard must actually block a second shading."""
+
+    @pytest.fixture(scope="class")
+    def branch(self):
+        return _find_branch_by_alias(_load_blueprint_yaml(), "Check for shading start")
+
+    def _once_per_day_clauses(self, branch):
+        for cond in branch["conditions"]:
+            if isinstance(cond, dict) and "or" in cond:
+                flat = " ".join(str(c) for c in cond["or"])
+                if "prevent_flags.shading_multiple_times" in flat:
+                    return cond["or"], flat
+        raise AssertionError("once-per-day OR not found in shading-start branch")
+
+    def test_branch_exists(self, branch):
+        assert branch is not None, "Check for shading start branch must exist"
+
+    def test_no_manual_short_circuit_clause(self, branch):
+        # The `helper_ts_man <= helper_ts_shade` clause defaulted to True for
+        # users who never touch the cover, disabling the guard entirely.
+        _, flat = self._once_per_day_clauses(branch)
+        assert "helper_ts_man" not in flat, (
+            "shading once-per-day guard must not use helper_ts_man "
+            "(always-true short-circuit, Bug Pattern V)"
+        )
+
+    def test_guard_is_calendar_day_based(self, branch):
+        # Full-date comparison guards against month-rollover and a fresh
+        # ts.shd == 0 (which '%-d' rendered as day 1).
+        _, flat = self._once_per_day_clauses(branch)
+        assert "%Y-%m-%d" in flat, (
+            "shading once-per-day guard must compare full calendar dates"
+        )
+
+    def test_execution_bypass_preserved(self, branch):
+        # An already-armed pending must still be able to execute.
+        _, flat = self._once_per_day_clauses(branch)
+        assert "t_shading_start_execution" in flat, (
+            "execution trigger must bypass the once-per-day guard"
+        )


### PR DESCRIPTION
The shading once-per-day guard short-circuited on
`helper_ts_man <= helper_ts_shade`, which is always true when the user
never moves the cover by hand (ts.man defaults to 0). The guard never
blocked a second shading, so covers re-shaded all day; the repeated
shading-end movements also looked like the cover was opening multiple
times.

Make the shading guard purely calendar-day based (full-date compare,
fixing month-rollover and fresh ts.shd==0).

Opening/closing guards are intentionally left unchanged: their ts.opn/
ts.cls are polluted by non-driving base syncs, so the manual clause is
what keeps Issue #311 fixed there.

The t_shading_reset trigger fires at 23:55 the same day, so it stamps
ts.shd onto the current day, never the next one -- no special midnight
handling is needed for the calendar-day guard.