### PR TITLE
fix: shading tilt ignored resident allow_shade gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -538,6 +538,18 @@ The `t_shading_start_execution` bypass (third OR-clause) is kept so an already-a
 
 ---
 
+### Bug Pattern W: Shading-tilt adjustment ignores resident `allow_shade`
+
+**Symptom:** With `resident_allow_shading` **unset** ("Allow sun protection when resident is still present" disabled) and a resident present, the cover still tilts its slats into the shading position. The helper shows `shd=1` and `res=1` but the cover visibly enters shading mode despite the resident block.
+
+**Cause:** When the shading-start conditions are met while a resident is present, the execution handler's "Save shading state for the future" branch (gated by `not resident_flags.allow_shade`) stores the intent — `shd: 1`, `pnd: 'non'`, no drive. This makes `helper_state_is_shaded` true. A subsequent `t_shading_tilt_*` trigger then enters the "Check for shading tilt" branch, which gated on `is_shading_enabled`, `helper_state_is_shaded`, tilt-possible, `auto_shading_tilt_condition`, `force_allows_shade`, window-closed and manual-override — but **not** on `resident_flags.allow_shade`. So `*tilt_move_action` drove the slats into the shading angle while the resident was present.
+
+**Fix:** Add `- "{{ resident_flags.allow_shade }}"` to the "Check for shading tilt" branch conditions, matching every other shading-drive branch (start execution #5459, shading-end #5680, resident-leaving SHADED #6303, force-recovery SHADING #6947, and the inline equivalent in "Window closed - Return to shading" #6123).
+
+**Rule:** Every branch that physically moves the cover (position *or* tilt) into the shading position must gate on `resident_flags.allow_shade`. The shading-tilt adjustment is a shading movement, not an exception.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.16
+    **Version**: 2026.06.20
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2872,7 +2872,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.16"
+  version: "2026.06.20"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5639,6 +5639,7 @@ actions:
           - "{{ is_cover_tilt_enabled_and_possible }}"
           - condition: !input auto_shading_tilt_condition
           - "{{ force_allows_shade }}"
+          - "{{ resident_flags.allow_shade }}" # Do not tilt into shading while a resident is present and shading is not allowed
           - "{{ not (contact_window_opened != [] and states(contact_window_opened) in ['true', 'on']) and not (contact_window_tilted != [] and states(contact_window_tilted) in ['true', 'on']) }}"
           - "{{ not (helper_state_manual and override_flags.shading) }}" # Override check
         sequence:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.20
+
+- 🐛 **Fix:** With *"Allow sun protection when resident is still present"* disabled, the slats could still tilt into the shading angle while a resident was present. When the shading conditions were met during resident presence, the shading **intent** was correctly stored without driving the cover (`shade` on, status `resident`). But the separate *shading tilt* adjustment (which re-angles the slats as the sun rises) was missing the resident check, so a tilt-position trigger would still move the slats into the shading position — making the cover appear to enter shading mode despite the resident being present. The shading-tilt adjustment now respects the resident *"allow shading"* setting like every other shading movement
+
+---
+
 # CCA 2026.06.16
 
 - 🐛 **Fix:** The *"shade the cover only once per day"* option was effectively inactive for everyone who does not manually move their covers by hand. The daily guard allowed shading again whenever no manual change had happened since the last shading — and since that is *always* the case when you never touch the cover by hand, the guard never blocked a second shading. Covers therefore re-entered the shading position again and again throughout the day (and the repeated shading-end movements made the cover look like it was *also* opening multiple times). The guard is now purely calendar-based: once the cover has shaded today, it will not shade again until the next day

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -2547,3 +2547,55 @@ class TestWeatherForecastLoadGateCoversOpeningTriggers:
                 f"Forecast-load regex {pattern!r} must also match shading-start "
                 f"trigger {trigger_id!r}."
             )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: shading-tilt adjustment must respect resident allow_shade
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _flatten_condition_strings(conditions) -> list:
+    """Collect all template/condition strings from a (possibly nested) conditions list."""
+    out = []
+
+    def walk(node):
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(conditions)
+    return out
+
+
+class TestShadingTiltRespectsResident:
+    """
+    Regression: the 'Check for shading tilt' branch drove the slats into the
+    shading tilt position while a resident was present, even when
+    'Allow sun protection when resident is still present' was disabled.
+
+    Every other shading-drive branch gates on resident_flags.allow_shade
+    (or the inline equivalent). The shading-tilt branch was missing it, so a
+    t_shading_tilt_* trigger tilted the cover into shading mode despite the
+    resident block (shd=1 stored via 'Save shading state for the future',
+    res=1, but the cover still moved).
+    """
+
+    def _load_blueprint(self) -> dict:
+        return _load_blueprint_yaml(BLUEPRINT_PATH)
+
+    def test_shading_tilt_branch_gates_on_allow_shade(self):
+        blueprint = self._load_blueprint()
+        branch = _find_branch_by_alias(blueprint, "Check for shading tilt")
+        assert branch is not None, "Could not find 'Check for shading tilt' branch."
+        conditions = _flatten_condition_strings(branch.get("conditions", []))
+        assert any("resident_flags.allow_shade" in c for c in conditions), (
+            "The 'Check for shading tilt' branch must gate on "
+            "resident_flags.allow_shade so the slats are not tilted into the "
+            "shading position while a resident is present and shading is not "
+            "allowed. Conditions found: " + repr(conditions)
+        )


### PR DESCRIPTION
The 'Check for shading tilt' branch drove the slats into the shading
position even while a resident was present and shading was not allowed.
When shading conditions are met during resident presence, the start
execution stores the intent (shd=1, no drive) via 'Save shading state
for the future', which makes helper_state_is_shaded true. A subsequent
t_shading_tilt_* trigger then tilted the cover into shading mode because
the branch was missing the resident_flags.allow_shade gate that every
other shading-drive branch has.

Add the resident_flags.allow_shade condition, a regression test, and
document as Bug Pattern W.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GGAaBR13seMGbC2LQ7jWxM