### PR TITLE
feat: warn when weather forecast service returns empty data

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.20
+    **Version**: 2026.06.21
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2872,7 +2872,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.20"
+  version: "2026.06.21"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -4235,6 +4235,41 @@ actions:
           type: "{{ shading_forecast_type }}"
         response_variable: weather_forecast
         continue_on_error: true
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Warn when the forecast service returned no usable data
+  # ════════════════════════════════════════════════════════════════════════════
+  # The weather entity is available, the service was called, but the returned
+  # forecast list is empty/missing. Without this warning the forecast conditions
+  # silently evaluate to "not met" (forecast_temp_raw / forecast_weather_condition_raw
+  # stay None) and shading never starts. This is most commonly a temporary
+  # provider-side hiccup (e.g. Met.no rate-limiting) and otherwise invisible.
+  - if:
+      - "{{ is_shading_enabled }}"
+      - "{{ forecast_source.use_weather and not forecast_source.prevent_service }}"
+      - "{{ states(shading_forecast_sensor) not in invalid_states }}"
+      - "{{ trigger.id is defined }}"
+      - "{{ trigger.id | regex_match('^(t_shading_start|t_open|t_calendar_event_start)') }}"
+      - "{{ shading_start_condition_enabled.forecast_temp or shading_start_condition_enabled.forecast_weather or shading_end_condition_enabled.forecast_temp or shading_end_condition_enabled.forecast_weather }}"
+      - >-
+        {{
+          weather_forecast is not defined or
+          shading_forecast_sensor not in weather_forecast or
+          (weather_forecast[shading_forecast_sensor].forecast | default([]) | count == 0)
+        }}
+    then:
+      - action: system_log.write
+        data:
+          level: warning
+          logger: "blueprints.hvorragend.cca"
+          message: >-
+            Cover Control Automation ({{ friendly_name }}): weather.get_forecasts for
+            {{ shading_forecast_sensor }} (type '{{ shading_forecast_type }}') returned an empty
+            forecast - forecast-based shading conditions cannot be evaluated and will be treated as
+            not met. The weather entity is available but provides no forecast data (often a temporary
+            provider-side issue, e.g. Met.no rate-limiting). Verify by running weather.get_forecasts
+            for this entity in Developer Tools - Actions. If this persists, reload the weather
+            integration or use a different weather entity / a direct forecast temperature sensor.
 
   # ════════════════════════════════════════════════════════════════════════════
   # Load calendar events for today (00:00 to 23:59)

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4236,40 +4236,32 @@ actions:
         response_variable: weather_forecast
         continue_on_error: true
 
-  # ════════════════════════════════════════════════════════════════════════════
-  # Warn when the forecast service returned no usable data
-  # ════════════════════════════════════════════════════════════════════════════
-  # The weather entity is available, the service was called, but the returned
-  # forecast list is empty/missing. Without this warning the forecast conditions
-  # silently evaluate to "not met" (forecast_temp_raw / forecast_weather_condition_raw
-  # stay None) and shading never starts. This is most commonly a temporary
-  # provider-side hiccup (e.g. Met.no rate-limiting) and otherwise invisible.
-  - if:
-      - "{{ is_shading_enabled }}"
-      - "{{ forecast_source.use_weather and not forecast_source.prevent_service }}"
-      - "{{ states(shading_forecast_sensor) not in invalid_states }}"
-      - "{{ trigger.id is defined }}"
-      - "{{ trigger.id | regex_match('^(t_shading_start|t_open|t_calendar_event_start)') }}"
-      - "{{ shading_start_condition_enabled.forecast_temp or shading_start_condition_enabled.forecast_weather or shading_end_condition_enabled.forecast_temp or shading_end_condition_enabled.forecast_weather }}"
-      - >-
-        {{
-          weather_forecast is not defined or
-          shading_forecast_sensor not in weather_forecast or
-          (weather_forecast[shading_forecast_sensor].forecast | default([]) | count == 0)
-        }}
-    then:
-      - action: system_log.write
-        data:
-          level: warning
-          logger: "blueprints.hvorragend.cca"
-          message: >-
-            Cover Control Automation ({{ friendly_name }}): weather.get_forecasts for
-            {{ shading_forecast_sensor }} (type '{{ shading_forecast_type }}') returned an empty
-            forecast - forecast-based shading conditions cannot be evaluated and will be treated as
-            not met. The weather entity is available but provides no forecast data (often a temporary
-            provider-side issue, e.g. Met.no rate-limiting). Verify by running weather.get_forecasts
-            for this entity in Developer Tools - Actions. If this persists, reload the weather
-            integration or use a different weather entity / a direct forecast temperature sensor.
+      # Warn when the service returned no usable forecast data: the weather entity
+      # is available and the service was called, but the returned forecast list is
+      # empty/missing. Without this, forecast conditions silently evaluate to "not met"
+      # (forecast_temp_raw / forecast_weather_condition_raw stay None) and shading never
+      # starts. Most commonly a temporary provider-side hiccup (e.g. Met.no rate-limiting).
+      - if:
+          - "{{ shading_start_condition_enabled.forecast_temp or shading_start_condition_enabled.forecast_weather or shading_end_condition_enabled.forecast_temp or shading_end_condition_enabled.forecast_weather }}"
+          - >-
+            {{
+              weather_forecast is not defined or
+              shading_forecast_sensor not in weather_forecast or
+              (weather_forecast[shading_forecast_sensor].forecast | default([]) | count == 0)
+            }}
+        then:
+          - action: system_log.write
+            data:
+              level: warning
+              logger: "blueprints.hvorragend.cca"
+              message: >-
+                Cover Control Automation ({{ friendly_name }}): weather.get_forecasts for
+                {{ shading_forecast_sensor }} (type '{{ shading_forecast_type }}') returned an empty
+                forecast - forecast-based shading conditions cannot be evaluated and will be treated as
+                not met. The weather entity is available but provides no forecast data (often a temporary
+                provider-side issue, e.g. Met.no rate-limiting). Verify by running weather.get_forecasts
+                for this entity in Developer Tools - Actions. If this persists, reload the weather
+                integration or use a different weather entity / a direct forecast temperature sensor.
 
   # ════════════════════════════════════════════════════════════════════════════
   # Load calendar events for today (00:00 to 23:59)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.21
+
+- 🔧 **Improvement:** Forecast-based shading now warns you when the weather forecast comes back empty. If the weather entity is available but `weather.get_forecasts` returns no forecast data (most often a temporary provider-side hiccup such as Met.no rate-limiting), the forecast values (`forecast_temp_raw` / `forecast_weather_condition_raw`) silently stayed `null`, the forecast conditions evaluated to *"not met"*, and shading never started — with nothing in the log to explain why (you had to dig through the trace to find the `null` values). The blueprint now writes a clear warning to the Home Assistant log (logger `blueprints.hvorragend.cca`) pointing at the empty forecast and how to verify it (Developer Tools → Actions → `weather.get_forecasts`). No behavior change otherwise; this only makes the existing silent failure discoverable
+
+---
+
 # CCA 2026.06.20
 
 - 🐛 **Fix:** When a cover was already in the ventilation position because the window was tilted, a following closing trigger (e.g. the sun-based closing trigger that fires repeatedly throughout the evening) re-drove the cover to the ventilation position again instead of leaving it alone. The closing handler's *"window tilted → ventilation"* branch always drove the cover, while the analogous *"already in close position"* branch only updates the base state. The branch now only drives when the cover is not already in the ventilation position — matching the contact handler, which already behaved this way. Note: if your cover reports a resting position that differs from the configured ventilation position by more than the *position tolerance* (common with tilt/venetian covers, where the tilt movement changes the reported position), increase the *position tolerance* so the cover is recognized as "in ventilation position" ([#538](https://github.com/hvorragend/ha-blueprints/issues/538))


### PR DESCRIPTION
When the weather entity is available but weather.get_forecasts returns
an empty/missing forecast list (e.g. Met.no rate-limiting), the forecast
values stayed null, forecast conditions silently evaluated to "not met"
and shading never started - with nothing in the log. Add a warning so
this otherwise invisible failure is discoverable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018tDv3o1AcAAjbC5GM92Yjk