### PR TITLE
docs: clarify "End Sun Shading - Immediately When Out Of Range" optio…

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.21
+    **Version**: 2026.06.23
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2073,8 +2073,19 @@ blueprint:
         shading_end_immediate_by_sun_position:
           name: "🥵 End Sun Shading - Immediately When Out Of Range"
           description: >-
-            If enabled, shading will end immediately (only a few seconds later) when sun position moves outside the defined azimuth or elevation range.
-            If disabled, the configured waiting time will be used before ending the shading.
+            Speeds up the END of shading: once the sun leaves the azimuth or elevation range,
+            shading ends after only a few seconds instead of waiting for the configured end waiting time.
+
+
+            **Important:** This option only controls the *timing* of the end — not *which* conditions
+            actually end the shading. For it to have any effect, "Sun Azimuth" and/or "Sun Elevation"
+            must be part of your END conditions. Put them in the **OR** group if a single axis leaving
+            its range should already end the shading. If they are in the **AND** group, shading ends
+            only once *all* selected AND conditions are out of range at the same time (e.g. azimuth AND
+            elevation together) — a single axis leaving its range is then not enough.
+
+
+            If disabled, the configured end waiting time is always used.
           default: false
           selector:
             boolean: {}
@@ -2872,7 +2883,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.21"
+  version: "2026.06.23"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.23
+
+- 🔧 **Improvement:** Clarified the description of the *"End Sun Shading – Immediately When Out Of Range"* option. The previous wording suggested that enabling it would end shading as soon as the sun leaves the azimuth *or* elevation range. In reality the option only controls the *timing* (it shortens the end waiting time to a few seconds) — it does **not** change *which* conditions end the shading. If "Sun Azimuth" / "Sun Elevation" are configured in the **AND** group of the END conditions, shading ends only once *all* of those conditions are out of range at the same time, so a single axis leaving its range is not enough (this also means a wide elevation range such as 0–90° practically never satisfies the elevation part). To get an "end as soon as either axis is out of range" behavior, put azimuth/elevation in the **OR** group. No behavior change — documentation only ([#545](https://github.com/hvorragend/ha-blueprints/issues/545))
+
+---
+
 # CCA 2026.06.21
 
 - 🔧 **Improvement:** Forecast-based shading now warns you when the weather forecast comes back empty. If the weather entity is available but `weather.get_forecasts` returns no forecast data (most often a temporary provider-side hiccup such as Met.no rate-limiting), the forecast values (`forecast_temp_raw` / `forecast_weather_condition_raw`) silently stayed `null`, the forecast conditions evaluated to *"not met"*, and shading never started — with nothing in the log to explain why (you had to dig through the trace to find the `null` values). The blueprint now writes a clear warning to the Home Assistant log (logger `blueprints.hvorragend.cca`) pointing at the empty forecast and how to verify it (Developer Tools → Actions → `weather.get_forecasts`). No behavior change otherwise; this only makes the existing silent failure discoverable


### PR DESCRIPTION
…n (#545)

The option's description suggested it would end shading as soon as the sun leaves the azimuth or elevation range. In reality it only controls the timing (shortens the end waiting time) and does not change which conditions end the shading. With azimuth/elevation in the END AND group, a single axis leaving its range is not enough — and a wide elevation range (0-90°) practically never satisfies the elevation part. Clarified the input description and added a changelog entry. Documentation only, no behavior change.


Claude-Session: https://claude.ai/code/session_01E2EFtBbNbrRrc8m5mnQuh5