### PR TITLE
fix: cancel shading-end pending when shading conditions re-trigger (#554)

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.24
+    **Version**: 2026.06.28
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2883,7 +2883,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.24"
+  version: "2026.06.28"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5375,6 +5375,7 @@ actions:
           - or: # Try to avoid starting the shading several times TODO / FIXME?
               - "{{ not is_cover_tilt_enabled_and_possible and not in_shading_position }}"
               - "{{ is_cover_tilt_enabled_and_possible }}"
+              - "{{ helper_state_pending_end }}" # Allow entry to cancel a stale end-pending
           - or: # Only once a day?
               - "{{ not prevent_flags.shading_multiple_times }}"
               - "{{ prevent_flags.shading_multiple_times and now().strftime('%Y-%m-%d') != helper_ts_shade | timestamp_custom('%Y-%m-%d') }}"
@@ -5392,6 +5393,25 @@ actions:
                   - "{{ is_shading_allowed_window }}"
             then:
               - choose:
+                  #####################################################################
+                  # Shading re-detected while end-pending is active: cancel the pending
+                  # end so the cover stays shaded until end conditions hold for the
+                  # full waiting time without interruption.
+                  #####################################################################
+                  - alias: "Shading re-detected. Cancel pending shading end"
+                    conditions:
+                      - "{{ trigger.id | regex_match('^(t_shading_start_pending)') }}"
+                      - "{{ helper_state_pending_end }}"
+                    sequence:
+                      - variables:
+                          update_values:
+                            pnd: 'non'
+                            ts:
+                              due: 0
+                              arm: 0
+                      - *helper_update
+                      - stop: "Shading End Pending: Canceled (shading re-detected)"
+
                   #####################################################################
                   # Shading start detected. Save next execution time and pending status
                   #####################################################################

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.28
+
+- 🐛 **Fix:** When shading-end was **pending** (waiting for the configured end waiting time to elapse) and the shading conditions were met **again** before the timer fired — because weather changed from cloudy back to bright — the pending end was not canceled. CCA ignored all `t_shading_start_pending*` events while `pnd == 'end'`, so the end timer continued running silently. If conditions happened to still be met at the execution moment, shading ended regardless of what had happened during the waiting period. This violated the documented behavior *"Shading ends if the conditions are not fulfilled **for the entire waiting time**"*. A re-triggered `t_shading_start_pending*` event now cancels the active end-pending (`pnd` → `non`, timestamps cleared); the cover stays in the shading position and waits for the next uninterrupted end-conditions period ([#554](https://github.com/hvorragend/ha-blueprints/issues/554))
+
+---
+
 # CCA 2026.06.24
 
 - 🐛 **Fix:** Forecast-based shading via the **daily/hourly weather forecast service** did not work when a weather entity was configured **without** a separate direct temperature sensor — i.e. the primary and recommended setup. The internal check that decides whether to call `weather.get_forecasts` treated an unset temperature sensor (which resolves to an empty list) as "still configured", so the forecast service was never called. As a result `forecast_temp_raw` and `forecast_weather_condition_raw` stayed `null`, and any forecast condition used as a **required (AND)** condition blocked shading entirely (removing it from AND made shading work again). The check now correctly recognizes an unconfigured temperature sensor, so the weather forecast service is called as intended. Calling `weather.get_forecasts` manually in Developer Tools always returned valid data; only the automation's internal gate was wrong


### PR DESCRIPTION
When pnd=='end' (end-pending active) and a t_shading_start_pending* trigger
fires because shading conditions are met again, the pending end is now
canceled immediately (pnd→non, ts.due→0, ts.arm→0). The cover stays in the
shading position; a new end-pending cycle starts on the next uninterrupted
end-conditions period.

Previously the mutual-exclusivity guard (not helper_state_pending_end)
blocked the start-pending branch entirely, so the end timer ran silently
to completion — violating the documented "for the entire waiting time"
guarantee.

Also extends the "Check for shading start" branch conditions to allow entry
when helper_state_pending_end is true (the cover is already in the shading
position, which would otherwise block the branch for non-tilt covers).