### PR TITLE
fix: apply ventilation floor when no opening schedule exists (#553)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,7 +39,7 @@ State is persisted as a JSON string in an `input_text` helper:
 ```
 1. FORCE    → frc != "non"                                       → Force position
 2. LOCKOUT  → win == "opn"                                       → Open position
-3. BASE=OPN → bas == "opn" AND no privacy/shading/restriction    → Open position
+3. BASE=OPN → bas == "opn" AND is_opening_scheduled AND no privacy/shading/restriction → Open position
 4. VENT     → win == "tlt" AND base would close/shade/privacy    → Ventilation position
 5. PRIVACY  → resident && closing                                → Close position
 6. SHADING  → shd == 1 && allow_shade                            → Shading position
@@ -50,7 +50,9 @@ The variable `effective_state` returns the currently active state from this casc
 
 **Rationale for BASE=OPN before VENT:** A tilted window signals ventilation intent — and a fully open cover provides maximum airflow. So when the time schedule says "open" (`bas=opn`) and nothing else lowers the cover, opening wins over the tilted-vent floor. VENT is a *floor* only when the cover would otherwise go below ventilation position (close, shading, privacy-close, or base=opn with `allow_open=false`).
 
-Implementation: `effective_state` first computes `base_target` (the cover state without VENT consideration: `cls`, `shd`, or `opn`), then applies VENT only when `win == 'tlt'` and `base_target != 'opn'`.
+**BASE=OPN beats VENT only when an opening schedule actually exists** (`is_opening_scheduled = is_up_enabled and not is_time_control_disabled`). `bas` initializes to `'opn'` and is only ever switched to `'cls'` by the scheduled close handler — so in a shading-only setup with no schedule, `bas` stays `'opn'` permanently. Without the schedule gate the VENT floor could never apply there (Issue #553, Bug Pattern Z). When no opening schedule exists, a tilted window therefore still produces `vnt`.
+
+Implementation: `effective_state` first computes `base_target` (the cover state without VENT consideration: `cls`, `shd`, or `opn`), then applies VENT when `win == 'tlt'` and `not (base_target == 'opn' and is_opening_scheduled)`.
 
 ---
 
@@ -600,6 +602,35 @@ suppressed **every** manual position trigger fired while the cover is within tol
 **Rule:** A manual-detection suppression that exists only to mute a *reset gesture* must carry the same precondition as the reset it is muting. Suppressing detection when there is nothing to reset silently discards a real manual change.
 
 **Config note:** Choosing `reset_override_position = 100` (= open) intentionally means "moving the cover fully open resumes automatic control" — so once the override has been cleared the cover follows the schedule again. The fix only ensures the *first* manual move (while `man == 0`) is no longer dropped; it does not turn the open position into a permanent manual hold.
+
+---
+
+### Bug Pattern Z: Tilted-window ventilation never triggers in a schedule-less setup (Issue #553)
+
+**Symptom:** In a **shading-only** setup with no open/close schedule (`auto_options` has neither `auto_up_enabled` nor `auto_down_enabled`, `time_control: time_control_disabled`), a tilted or opened window **never moves a closed cover to the ventilation position**. This worked in v5. The helper shows `bas: 'opn'`, `win: 'tlt'`, and the cover sits at the closed position with no movement. The contact handler's "Window tilted - No drive, sync helper window state" branch (which gates on `effective_state == 'opn'`) catches the event and only syncs `win: 'tlt'` — the drive branch ("Window tilted - Partial ventilation", gated on `effective_state != 'opn'`) is skipped.
+
+**Cause:** `bas` initializes to `'opn'` in every init path (fresh init, v6 parse fallback `default('opn')`, v5 migration unless the v5 state was explicitly `close`) and is **only ever** switched to `'cls'` by the scheduled close handler (`t_close_*`, which needs `auto_down_enabled` + a time/calendar source). Without a schedule, `bas` stays `'opn'` forever → `base_target == 'opn'` → the VENT floor condition (`base_target != 'opn'`) is never true → a closed cover ignores a tilted window. The `2026.05.24` changelog had documented "remove the time schedule (so `bas` never reaches `opn`)" as the way to restore v5 behavior — but removing the schedule does **not** make `bas` non-`opn`, so that workaround never worked.
+
+**Fix:** Gate the BASE=OPN-beats-VENT rule on whether an opening schedule actually exists. New `trigger_variables` flag:
+
+```yaml
+is_opening_scheduled: "{{ is_up_enabled and not is_time_control_disabled }}"
+```
+
+In `effective_state`, replace the VENT floor condition:
+
+```jinja2
+{% set base_open_scheduled = base_target == 'opn' and is_opening_scheduled %}
+{% if w == 'tlt' and allow_vent and not base_open_scheduled %}
+  vnt
+{% else %}
+  {{ base_target }}
+{% endif %}
+```
+
+This is **surgical** — it only changes the VENT-floor decision. When the window is **not** tilted, `effective_state` still returns `'opn'` for `bas == 'opn'`, so shading-end (gated on `effective_state != 'cls'`), the contact "return to open" branch, and every other base=opn consumer are unaffected. Scheduled setups (`is_opening_scheduled == true`) keep the `2026.05.24` BASE=OPN-beats-VENT behavior unchanged.
+
+**Why not Option 1 (treat `bas` as `'cls'` for the whole cascade):** That was the maintainer's originally-documented intent, but making `effective_state` return `'cls'`/`'vnt'` wholesale breaks the shading-end handler, whose branch gate is `effective_state != 'cls'` — shading would never end. The VENT floor must be the *only* thing affected; gating just that line is the correct minimal change.
 
 ---
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.28
+    **Version**: 2026.06.28 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2840,6 +2840,11 @@ trigger_variables:
   # Disabled when explicitly unchecked in auto_options AND the legacy selector is also set to disabled.
   # This preserves backward compatibility: existing users with time_control_input/calendar remain active.
   is_time_control_disabled: "{{ 'time_control_enabled' not in auto_options and 'time_control_disabled' in time_control }}"
+  # An open base state ('opn') only reflects a real "schedule wants open" intent when an
+  # opening schedule actually exists. Without one, bas stays at its 'opn' init default forever
+  # (it is only ever driven to 'cls' by the scheduled close handler), so the VENT floor could
+  # never apply. Used by effective_state to let VENT beat a non-scheduled bas='opn'.
+  is_opening_scheduled: "{{ is_up_enabled and not is_time_control_disabled }}"
 
   # Ventilation and tilt are only available for blinds, not awnings
   is_ventilation_enabled: "{{ not is_awning and 'auto_ventilate_enabled' in auto_options }}"
@@ -2883,7 +2888,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.28"
+  version: "2026.06.28 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -3245,16 +3250,18 @@ variables:
   # Priority Order (highest first):
   # 1. FORCE    → force != "none" → Force-Position
   # 2. LOCKOUT  → window == "open" → Open-Position (prevent lockout)
-  # 3. BASE=OPN → base == "open" AND no shading/privacy/close-restriction → Open-Position
+  # 3. BASE=OPN → base == "open" (scheduled) AND no shading/privacy/close-restriction → Open-Position
   # 4. VENT     → window == "tilted" AND allow_ventilate AND base would close/shade → Ventilate-Position
   # 5. PRIVACY  → resident == 1 AND closing_trigger → Close-Position
   # 6. SHADING  → shade == 1 AND allow_shade → Shading-Position
   # 7. BASE=CLS → base (respects allow_open for "open" state)
   #
-  # Rationale: A tilted window expresses ventilation intent. With base=opn the
-  # cover should fully open (maximum airflow). VENT acts as a "floor" only when
-  # the cover would otherwise go below ventilate position (close, shading,
-  # privacy-close, base=opn but allow_open=false).
+  # Rationale: A tilted window expresses ventilation intent. With a scheduled
+  # base=opn the cover should fully open (maximum airflow). VENT acts as a "floor"
+  # only when the cover would otherwise go below ventilate position (close, shading,
+  # privacy-close, base=opn but allow_open=false). BASE=OPN beats VENT only when an
+  # opening schedule actually exists (is_opening_scheduled): without one, bas stays
+  # at its 'opn' init default permanently, so VENT must still apply (Issue #553).
   #
   # ═══════════════════════════════════════════════════════════════════════════
 
@@ -3290,7 +3297,8 @@ variables:
       {% else %}
         {% set base_target = h.bas %}
       {% endif %}
-      {% if w == 'tlt' and allow_vent and base_target != 'opn' %}
+      {% set base_open_scheduled = base_target == 'opn' and is_opening_scheduled %}
+      {% if w == 'tlt' and allow_vent and not base_open_scheduled %}
         vnt
       {% else %}
         {{ base_target }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.28 V2
+
+- 🐛 **Fix:** In a **shading-only** setup *without* an open/close schedule (no automatic up/down, time control disabled), a tilted or opened window never moved a closed cover to the ventilation position. The internal base state initializes to *"open"* and is only ever switched to *"closed"* by the scheduled close handler — so without a schedule it stayed *"open"* forever, and since *BASE=OPEN* outranks the ventilation *"floor"* in the priority cascade, ventilation could never apply. The cascade now treats *"open"* as a real open intent only when an opening schedule actually exists; without one, a tilted window correctly drives the cover to the ventilation position. This also makes the documented *"remove the time schedule"* workaround from the `2026.05.24` notes work as described. Setups *with* a schedule are unaffected ([#553](https://github.com/hvorragend/ha-blueprints/issues/553))
+
+---
+
 # CCA 2026.06.28
 
 - 🐛 **Fix:** When shading-end was **pending** (waiting for the configured end waiting time to elapse) and the shading conditions were met **again** before the timer fired — because weather changed from cloudy back to bright — the pending end was not canceled. CCA ignored all `t_shading_start_pending*` events while `pnd == 'end'`, so the end timer continued running silently. If conditions happened to still be met at the execution moment, shading ended regardless of what had happened during the waiting period. This violated the documented behavior *"Shading ends if the conditions are not fulfilled **for the entire waiting time**"*. A re-triggered `t_shading_start_pending*` event now cancels the active end-pending (`pnd` → `non`, timestamps cleared); the cover stays in the shading position and waits for the next uninterrupted end-conditions period ([#554](https://github.com/hvorragend/ha-blueprints/issues/554))

--- a/tests/test_blueprint_logic.py
+++ b/tests/test_blueprint_logic.py
@@ -1741,7 +1741,8 @@ EFFECTIVE_STATE_TEMPLATE = """
   {%- else -%}
     {%- set base_target = h.bas -%}
   {%- endif -%}
-  {%- if w == 'tlt' and allow_vent and base_target != 'opn' -%}
+  {%- set base_open_scheduled = base_target == 'opn' and is_opening_scheduled -%}
+  {%- if w == 'tlt' and allow_vent and not base_open_scheduled -%}
     vnt
   {%- else -%}
     {{ base_target }}
@@ -1755,7 +1756,8 @@ def _eval_effective_state(*, helper_json: dict, state_resident: bool = False,
                           sensor_opened: bool = False,
                           sensor_tilted: bool = False,
                           has_opened_sensor: bool = False,
-                          has_tilted_sensor: bool = False) -> str:
+                          has_tilted_sensor: bool = False,
+                          is_opening_scheduled: bool = True) -> str:
     env = make_jinja_env()
     template = env.from_string(EFFECTIVE_STATE_TEMPLATE)
     return template.render(
@@ -1766,6 +1768,7 @@ def _eval_effective_state(*, helper_json: dict, state_resident: bool = False,
         sensor_tilted=sensor_tilted,
         has_opened_sensor=has_opened_sensor,
         has_tilted_sensor=has_tilted_sensor,
+        is_opening_scheduled=is_opening_scheduled,
     ).strip()
 
 
@@ -1782,6 +1785,31 @@ class TestEffectiveStateCascade:
         """bas=opn + win=tlt + shd=0 → 'opn' (new behavior, previously 'vnt')."""
         result = _eval_effective_state(
             helper_json={"frc": "non", "win": "tlt", "bas": "opn", "shd": 0},
+        )
+        assert result == "opn", f"Expected 'opn' but got '{result}'"
+
+    def test_base_open_tilted_no_schedule_returns_vnt(self):
+        """Issue #553: shading-only setup without an opening schedule.
+
+        bas defaults to 'opn' forever (no scheduled close ever flips it to 'cls'),
+        so BASE=OPN must NOT beat VENT — a tilted window has to drive the cover to
+        the ventilation position. With is_opening_scheduled=False, VENT applies.
+        """
+        result = _eval_effective_state(
+            helper_json={"frc": "non", "win": "tlt", "bas": "opn", "shd": 0},
+            is_opening_scheduled=False,
+        )
+        assert result == "vnt", f"Expected 'vnt' but got '{result}'"
+
+    def test_base_open_closed_window_no_schedule_returns_opn(self):
+        """Issue #553: without a tilted window, base=opn still returns 'opn'.
+
+        The fix only affects the VENT floor — a closed window must keep returning
+        'opn' so shading-end and other base=opn logic continue to work.
+        """
+        result = _eval_effective_state(
+            helper_json={"frc": "non", "win": "cls", "bas": "opn", "shd": 0},
+            is_opening_scheduled=False,
         )
         assert result == "opn", f"Expected 'opn' but got '{result}'"
 


### PR DESCRIPTION
In a shading-only setup without an open/close schedule, bas initializes
to 'opn' and is only ever flipped to 'cls' by the scheduled close handler.
Without a schedule it stays 'opn' forever, so BASE=OPN permanently
outranked the VENT floor and a tilted window never moved a closed cover
to the ventilation position.

Gate BASE=OPN-beats-VENT on a new is_opening_scheduled flag
(is_up_enabled and not is_time_control_disabled). When no opening schedule
exists, a tilted window now correctly returns 'vnt'. The change is
surgical: with the window not tilted, effective_state still returns 'opn'
for bas='opn', so shading-end and other base=opn consumers are unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018UMb7SkFi9dGGeMh5ZaSNR