### PR TITLE
fix: ignore attribute-only re-triggers on contact/resident sensors (#…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -288,6 +288,29 @@ The contact handler ("Contact sensor state changed") gates on **both** the previ
 
 **This is intentional, not a bug.** The root cause is an unstable contact sensor reporting `unavailable`. The fix belongs at the sensor (battery / radio range), not in the blueprint. Do **not** remove the `from_state` guard to "process recovery transitions" — that would make CCA act on sensor dropouts. Do not "harmonize" this away.
 
+### Attribute-only re-triggers on contact/resident sensors are ignored (Issue #550)
+
+The contact (`t_contact_tilted_changed`, `t_contact_opened_changed`) and resident (`t_resident_update`) triggers are plain `trigger: state`. By default a HA state trigger with only an `entity_id` fires on **every** change of the state object — including **attribute-only** changes where the actual `on`/`off` value is unchanged (internal `match_all` mode).
+
+The fix is applied **at the trigger**, not in a global condition: each of the three triggers carries `not_to`. Setting *any* of `from`/`to`/`not_from`/`not_to` flips HA out of `match_all`, so the trigger only fires on real state-value transitions and silently drops attribute-only changes:
+
+```yaml
+- trigger: state
+  entity_id: !input contact_window_tilted
+  not_to:
+    - "unavailable"
+    - "unknown"
+  ...
+```
+
+**Why the trigger, not a global condition:** A global `condition` still lets the automation *start* — HA records a (stopped) trace for every triggered run. Filtering at the trigger means the automation never runs at all → no trace, no queue entry, no logbook noise. `not_to`/`not_from` require HA ≥ 2023.4; the blueprint's `min_version` (2024.10.0) covers this.
+
+**Rationale:** A user binding a "noisy" entity to one of these inputs — classically a HA **Threshold helper** built on `sun.elevation`, whose `sensor_value` attribute updates on every elevation step — would otherwise re-fire the whole automation every few minutes although the entity's real state changes only twice a day. There was never any functional harm (`mode: queued`, every branch idempotent), only trace/logbook noise.
+
+**Why `not_to` (not `to`):** Contact/resident sensors can report `on`/`off` *or* `true`/`false`, so an allow-list (`to: [...]`) would be fragile. `not_to: [unavailable, unknown]` only excludes the dropout sentinels, keeps every real transition, and aligns with the existing `invalid_states` handling (the `to_state` invalid-state guard in the global conditions and the contact handler). The `from`-side recovery guard (#505) stays in the action conditions — `not_to` does not touch it.
+
+**Scope:** Only contact + resident. The manual triggers (`t_manual_position`, `t_manual_tilt`) deliberately react to attribute changes (`current_position` / `current_tilt_position`) and must **not** get `not_to`.
+
 ---
 
 ## Known Bug Patterns (with cause and fix)

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.06.28 V2
+    **Version**: 2026.06.28 V3
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2905,7 +2905,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.06.28 V2"
+  version: "2026.06.28 V3"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -3556,6 +3556,10 @@ triggers:
   # Resident sensor state change (for updating helper_state_resident and optional actions)
   - trigger: state
     entity_id: !input resident_sensor
+    # not_to switches HA to "state-change only" and ignores attribute-only changes
+    not_to:
+      - "unavailable"
+      - "unknown"
     enabled: "{{ resident_sensor not in [none, ''] }}"
     id: "t_resident_update"
 
@@ -3679,6 +3683,10 @@ triggers:
 
   - trigger: state
     entity_id: !input contact_window_tilted
+    # not_to switches HA to "state-change only" and ignores attribute-only changes
+    not_to:
+      - "unavailable"
+      - "unknown"
     enabled: "{{ is_ventilation_enabled and contact_window_tilted != [] }}"
     id: "t_contact_tilted_changed"
     for:
@@ -3686,6 +3694,9 @@ triggers:
 
   - trigger: state
     entity_id: !input contact_window_opened
+    not_to:
+      - "unavailable"
+      - "unknown"
     enabled: "{{ is_ventilation_enabled and contact_window_opened != [] }}"
     id: "t_contact_opened_changed"
     for:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.06.28 V3
+
+- 🔧 **Improvement:** The window-contact and resident triggers now ignore pure *attribute* changes and only react to a real `on`/`off` state transition. A "noisy" source bound to one of these inputs — for example a Threshold helper built on `sun.elevation`, whose `sensor_value` attribute updates on every elevation change — could previously re-trigger the automation every few minutes even though its actual state changed only twice a day. There was no functional harm (the automation runs in `queued` mode and every branch is idempotent), but it cluttered the trace/logbook history. This is now filtered **at the trigger itself** (`not_to`), so the automation no longer even starts a run for an attribute-only change — no leftover trace entries ([#550](https://github.com/hvorragend/ha-blueprints/issues/550))
+
+---
+
 # CCA 2026.06.28 V2
 
 - 🐛 **Fix (docs):** The *"Shading END – Optional Conditions (OR)"* help text contained a misleading example claiming shading would *"End only when sun is wrong AND (dark OR cold)"*. That suggested the AND group and the OR group are combined with **AND**. In reality — and as the *"Combined logic"* note in the same help text and the automation trace both show — the two END groups are combined with **OR**: shading ends when *either* all AND-group conditions become invalid *or* any single OR-group condition becomes invalid. The example has been corrected, and the help text now states explicitly that END combines the groups with OR (unlike START, which combines them with AND) and explains that requiring several end conditions together means putting them all in the AND group. No logic change ([#560](https://github.com/hvorragend/ha-blueprints/issues/560))

--- a/tests/test_documented_bug_patterns.py
+++ b/tests/test_documented_bug_patterns.py
@@ -646,3 +646,58 @@ class TestIssue554CancelPendingShadingEnd:
                     )
                     return
         raise AssertionError("once-per-day OR not found in shading-start branch")
+
+
+# ---------------------------------------------------------------------------
+# #550: a Threshold helper (or any noisy source) bound to a contact/resident
+# input re-fires the state trigger on every *attribute* change. Setting any of
+# from/to/not_from/not_to on the trigger flips HA out of match_all, so it only
+# fires on real on/off transitions. The fix uses not_to at the trigger so the
+# automation never even starts a run (no leftover trace) for attribute changes.
+# ---------------------------------------------------------------------------
+class TestIssue550AttributeOnlyTriggersFiltered:
+    """#550: ignore attribute-only re-triggers on contact/resident sensors."""
+
+    FILTERED_IDS = (
+        "t_contact_tilted_changed",
+        "t_contact_opened_changed",
+        "t_resident_update",
+    )
+    MANUAL_IDS = ("t_manual_position", "t_manual_tilt")
+
+    def test_contact_resident_triggers_have_not_to(self):
+        # not_to (any of from/to/not_from/not_to) disables match_all, so the
+        # trigger no longer fires on attribute-only changes.
+        blueprint = _load_blueprint_yaml()
+        for tid in self.FILTERED_IDS:
+            trig = _find_trigger_by_id(blueprint, tid)
+            assert trig is not None, f"trigger {tid} must exist"
+            keys = set(trig)
+            assert keys & {"not_to", "not_from", "to", "from"}, (
+                f"{tid} must set one of from/to/not_from/not_to to ignore "
+                f"attribute-only changes (#550)"
+            )
+
+    def test_not_to_keeps_real_transitions(self):
+        # not_to must only exclude dropout sentinels, never on/off/true/false,
+        # otherwise real window/presence transitions would be dropped too.
+        blueprint = _load_blueprint_yaml()
+        for tid in self.FILTERED_IDS:
+            trig = _find_trigger_by_id(blueprint, tid)
+            not_to = trig.get("not_to") or []
+            assert "unavailable" in not_to
+            for real in ("on", "off", "true", "false"):
+                assert real not in not_to, (
+                    f"{tid} not_to must not exclude the real state {real!r} (#550)"
+                )
+
+    def test_manual_triggers_not_filtered(self):
+        # Manual position/tilt detection legitimately relies on attribute
+        # changes and must NOT get a not_to/to guard.
+        blueprint = _load_blueprint_yaml()
+        for tid in self.MANUAL_IDS:
+            trig = _find_trigger_by_id(blueprint, tid)
+            assert trig is not None, f"trigger {tid} must exist"
+            assert not (set(trig) & {"not_to", "not_from", "to", "from"}), (
+                f"{tid} must keep reacting to attribute changes (#550)"
+            )


### PR DESCRIPTION
…550)

The contact (t_contact_tilted_changed, t_contact_opened_changed) and resident (t_resident_update) triggers are plain state triggers with only an entity_id, so Home Assistant fires them on every state-object change — including attribute-only changes where the on/off value is unchanged (internal match_all mode).

A noisy source bound to one of these inputs (classically a Threshold helper built on sun.elevation, whose sensor_value attribute updates on every elevation step) therefore re-triggered the automation every few minutes although its real state changes only twice a day. No functional harm (queued mode, idempotent branches), but it cluttered the trace and logbook history.

Setting not_to on the three triggers flips HA out of match_all, so they only fire on real state-value transitions and silently drop attribute-only changes. Filtering at the trigger (not a global condition) means the automation never even starts a run for an attribute change: no trace, no queue entry. not_to (rather than a to allow-list) only excludes the unavailable/unknown dropout sentinels, keeps every real on/off/true/false transition, and aligns with the existing invalid_states handling. The from-side recovery guard (#505) stays in the action conditions.

Manual position/tilt triggers, which legitimately rely on attribute changes, are unaffected. Adds a regression test and documents the behavior in CLAUDE.md.


Claude-Session: https://claude.ai/code/session_01CCbbwVs5oiZNcMXz52YaP7