### PR TITLE
Fix #565: Open cover at opening time even when parked at shading position with shd=0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -679,6 +679,24 @@ Additionally, the "Check for shading start" branch entry OR ("Check the helper s
 
 ---
 
+### Bug Pattern AB: Opening deferred to Shading End although shading is inactive (Issue #565)
+
+**Symptom:** The cover sits at the shading position at opening time while the helper shows `shd: 0` and `pnd: 'non'` (e.g. the user moved it there manually, or positions happen to coincide). The opening trigger fires, the trace ends with `"Open time: In shading position, base state updated (movement via Shading End)"`, and the cover never opens — it stays at the shading position for the rest of the day.
+
+**Cause:** The "Normal opening of the cover" branch guarded only on `not in_shading_position` — the physical position alone — assuming that a cover at the shading position is *shaded* and the Shading End flow will open it later. Execution fell through to the default branch, which only sets `bas: 'opn'` and defers the movement. But with `shd == 0` that handoff is impossible: the global trigger gate suppresses all `t_shading_end_pending_[1-7]` triggers unless the helper contains `"shd":1` — the gate upstream makes the deferral dead code (Bug Pattern AA territory).
+
+**Fix:** Gate the deferral on the helper's actual shading state:
+
+```yaml
+- "{{ not in_shading_position or not helper_state_shade }}"
+```
+
+With `shd == 1` + in shading position, the default branch still defers to Shading End (whose triggers pass the global gate because `shd == 1` — the handoff works). With `shd == 0`, "Normal opening" fires and drives the cover open. This also covers the stale-pending case (`pnd == 'beg'`, `shd == 0`, cover at shading position, conditions no longer warranted): Bug Pattern R's fall-through now genuinely reaches the drive instead of dead-ending in the default branch.
+
+**Rule:** A deferral to another flow must be gated on the *helper state* that makes that flow reachable, never on the physical position alone. Position says where the cover is; only the helper says *why* — and the "why" decides which flow owns the next movement (same family as the Bug Pattern AA rule: verify the receiving flow's upstream gates actually let it run).
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.03 V2
+    **Version**: 2026.07.05
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2905,7 +2905,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.03 V2"
+  version: "2026.07.05"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.03
+    **Version**: 2026.07.03 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2905,7 +2905,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.03"
+  version: "2026.07.03 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5204,7 +5204,7 @@ actions:
             ###################################
               - alias: "Normal opening of the cover"
                 conditions:
-                  - "{{ not in_shading_position }}" # Don't switch from Shading to Open here - that's handled by Shading End
+                  - "{{ not in_shading_position or not helper_state_shade }}" # Defer to Shading End only while shading is active (shd == 1) - with shd == 0 the shading-end triggers are blocked and the cover would never open (Issue #565)
                 sequence:
                   - variables:
                       target_position: !input open_position

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.03 V2
+
+- 🐛 **Fix:** If the cover happened to sit at the **shading position** at opening time while shading was **not** active in the helper (`shd: 0`) — for example because it was moved there manually — the cover never opened for the rest of the day. The opening handler skipped the normal opening (assuming an active shading would be ended later by the Shading End logic) and only updated the base state. But that handoff can never happen with `shd: 0`: a global trigger gate blocks all shading-end triggers unless shading is actually active in the helper. The normal opening now only defers to Shading End while shading is genuinely active; with `shd: 0` the cover simply opens normally ([#565](https://github.com/hvorragend/ha-blueprints/issues/565))
+
+---
+
 # CCA 2026.07.03
 
 - 🐛 **Fix:** The `2026.06.28` fix for [#554](https://github.com/hvorragend/ha-blueprints/issues/554) (cancel a pending shading **end** when the shading conditions are met again during the end waiting time) never actually ran: a global trigger gate suppresses all `t_shading_start_pending_*` triggers while shading is active (`shd == 1`) — and during an end-pending, shading is *always* still active. The automation therefore stopped before ever reaching the new cancel logic, and the end timer kept running silently to its original expiry, exactly as before. The global gate now lets shading-start triggers through when an end-pending is armed (`pnd == 'end'`), so the cancel logic finally executes: the pending end is canceled (only after re-checking that the end conditions are genuinely no longer met), the cover stays shaded, and shading only ends after the end conditions hold **for the entire waiting time** without interruption — as documented. The cancel is now also reachable while the window is open/tilted. The gate's noise-suppression purpose is preserved: outside an end-pending, start triggers are still ignored while shading is active ([#554](https://github.com/hvorragend/ha-blueprints/issues/554))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
-# CCA 2026.07.03 V2
+# CCA 2026.07.05
 
 - 🐛 **Fix:** If the cover happened to sit at the **shading position** at opening time while shading was **not** active in the helper (`shd: 0`) — for example because it was moved there manually — the cover never opened for the rest of the day. The opening handler skipped the normal opening (assuming an active shading would be ended later by the Shading End logic) and only updated the base state. But that handoff can never happen with `shd: 0`: a global trigger gate blocks all shading-end triggers unless shading is actually active in the helper. The normal opening now only defers to Shading End while shading is genuinely active; with `shd: 0` the cover simply opens normally ([#565](https://github.com/hvorragend/ha-blueprints/issues/565))
 

--- a/tests/test_documented_bug_patterns.py
+++ b/tests/test_documented_bug_patterns.py
@@ -792,3 +792,52 @@ class TestIssue550AttributeOnlyTriggersFiltered:
             assert not (set(trig) & {"not_to", "not_from", "to", "from"}), (
                 f"{tid} must keep reacting to attribute changes (#550)"
             )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug Pattern AB (#565): a cover sitting at the shading position with shd == 0
+# must still open normally at opening time. The old "not in_shading_position"
+# guard deferred to Shading End unconditionally — but the global trigger gate
+# blocks all shading-end triggers unless the helper shows shd == 1, so with
+# shd == 0 the handoff was dead code and the cover never opened.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+NORMAL_OPENING_ALIAS = "Normal opening of the cover"
+
+
+class TestIssue565OpenAtShadingPositionWithoutActiveShading:
+    """#565: normal opening must only defer to Shading End while shd == 1."""
+
+    @pytest.fixture(scope="class")
+    def branch(self):
+        return _find_branch_by_alias(_load_blueprint_yaml(), NORMAL_OPENING_ALIAS)
+
+    def _condition(self, branch) -> str:
+        conds = [str(c) for c in branch["conditions"]]
+        assert len(conds) == 1, "normal-opening branch is expected to have one condition"
+        return conds[0]
+
+    def _eval(self, branch, *, in_shading_position: bool, helper_state_shade: bool) -> bool:
+        env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+        rendered = env.from_string(self._condition(branch)).render(
+            in_shading_position=in_shading_position,
+            helper_state_shade=helper_state_shade,
+        )
+        return rendered.strip() == "True"
+
+    def test_branch_exists(self, branch):
+        assert branch is not None, f"branch not found: {NORMAL_OPENING_ALIAS!r}"
+
+    def test_opens_when_at_shading_position_but_shading_inactive(self, branch):
+        # shd == 0: the shading-end triggers are gated off globally, so the
+        # deferral can never complete — the branch must fire and open (#565).
+        assert self._eval(branch, in_shading_position=True, helper_state_shade=False)
+
+    def test_still_defers_when_shading_active(self, branch):
+        # shd == 1 and in shading position: Shading End owns the movement.
+        assert not self._eval(branch, in_shading_position=True, helper_state_shade=True)
+
+    def test_opens_when_not_at_shading_position(self, branch):
+        assert self._eval(branch, in_shading_position=False, helper_state_shade=True)
+        assert self._eval(branch, in_shading_position=False, helper_state_shade=False)


### PR DESCRIPTION
The "Normal opening of the cover" branch skipped whenever the cover was
physically at the shading position, deferring the movement to Shading End
via the default branch. But the global trigger gate blocks all
t_shading_end_pending_* triggers unless the helper shows shd:1, so with
shd:0 (e.g. after a manual move to the shading position) the handoff was
dead code and the cover never opened for the rest of the day.

Gate the deferral on the helper's actual shading state: normal opening now
runs when the cover is at the shading position but shading is inactive
(not in_shading_position or not helper_state_shade). Active shading
(shd:1) keeps the existing defer-to-Shading-End behavior unchanged.

Documented as Bug Pattern AB in CLAUDE.md, regression tests added.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZzQ6TFYsa7da3HLAu1A9E