### PR TITLE
fix(#536): match calendar event titles exactly instead of by substring

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.05
+    **Version**: 2026.07.05 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -776,9 +776,13 @@ blueprint:
             <summary><code><strong>CLICK HERE:</strong> How to use calendar control</code></summary>
 
 
-            **Event Titles (case-insensitive):**
+            **Event Titles (exact match, case-insensitive):**
               - **"Open Cover"** - Marks the daytime window (cover should be open)
               - **"Close Cover"** - Marks the evening window (cover should be closed)
+              - The event title must match the configured title exactly (ignoring
+                upper/lower case and surrounding spaces). "Open Cover Bedroom" does
+                **not** match the title "Open Cover" - so several covers can share
+                one calendar with different event titles.
 
             **How it works:**
               - When an "Open Cover" event starts, the automation treats it like morning time
@@ -809,7 +813,7 @@ blueprint:
           name: "📂 Open Event Title"
           description: >-
             Title of calendar events that define the daytime window
-            (case-insensitive match).
+            (exact match, ignoring upper/lower case and surrounding spaces).
             Default: "Open Cover".
           default: "Open Cover"
           selector:
@@ -819,7 +823,7 @@ blueprint:
           name: "📁 Close Event Title"
           description: >-
             Title of calendar events that define the evening/close window
-            (case-insensitive match).
+            (exact match, ignoring upper/lower case and surrounding spaces).
             Default: "Close Cover".
           default: "Close Cover"
           selector:
@@ -2905,7 +2909,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.05"
+  version: "2026.07.05 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -4009,8 +4013,8 @@ conditions:
           - "{{ state_attr(calendar_entity, 'message') is not none }}"
           - >-
             {{
-              calendar_open_title_lc in (state_attr(calendar_entity, 'message') | lower) or
-              calendar_close_title_lc in (state_attr(calendar_entity, 'message') | lower)
+              (calendar_open_title_lc != '' and calendar_open_title_lc == (state_attr(calendar_entity, 'message') | lower | trim)) or
+              (calendar_close_title_lc != '' and calendar_close_title_lc == (state_attr(calendar_entity, 'message') | lower | trim))
             }}
   - condition: template
     value_template: >-
@@ -4737,7 +4741,7 @@ actions:
           {% set events = calendar_events[calendar_entity].events | default([]) %}
           {% for event in events %}
             {% set summary = (event.summary | default('')) | lower | trim %}
-            {% if calendar_open_title_lc != '' and calendar_open_title_lc in summary %}
+            {% if calendar_open_title_lc != '' and calendar_open_title_lc == summary %}
               {% set result.found = true %}
               {% set result.start = event.start %}
               {% set result.end = event.end %}
@@ -4757,7 +4761,7 @@ actions:
           {% set events = calendar_events[calendar_entity].events | default([]) %}
           {% for event in events %}
             {% set summary = (event.summary | default('')) | lower | trim %}
-            {% if calendar_close_title_lc != '' and calendar_close_title_lc in summary %}
+            {% if calendar_close_title_lc != '' and calendar_close_title_lc == summary %}
               {% set result.found = true %}
               {% set result.start = event.start %}
               {% set result.end = event.end %}

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.05 V2
+    **Version**: 2026.07.05
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2909,7 +2909,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.05 V2"
+  version: "2026.07.05"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.05 V2
+
+- 🐛 **Fix:** Calendar event titles were matched as a **substring**, so a cover configured with the open title *"Open Cover"* also reacted to events like *"Open Cover Bedroom"* on the same calendar. Because the parsing kept the **last** matching event of the day, such a cover could ignore its own *"Open Cover"* event (e.g. 06:00) and open at the time of the more specific event (e.g. 06:15) instead. Event titles are now matched **exactly** (ignoring upper/lower case and surrounding spaces) in the open/close event parsing and in the calendar trigger gate. Several covers can therefore share one calendar with prefix-related titles — *"Open Cover"* and *"Open Cover Bedroom"* are now distinct. **Note:** If you relied on the old substring behavior (e.g. events named *"Open Cover (vacation)"* matching the title *"Open Cover"*), rename the events or the configured title so they match exactly ([#536](https://github.com/hvorragend/ha-blueprints/issues/536))
+
+---
+
 # CCA 2026.07.05
 
 - 🐛 **Fix:** If the cover happened to sit at the **shading position** at opening time while shading was **not** active in the helper (`shd: 0`) — for example because it was moved there manually — the cover never opened for the rest of the day. The opening handler skipped the normal opening (assuming an active shading would be ended later by the Shading End logic) and only updated the base state. But that handoff can never happen with `shd: 0`: a global trigger gate blocks all shading-end triggers unless shading is actually active in the helper. The normal opening now only defers to Shading End while shading is genuinely active; with `shd: 0` the cover simply opens normally ([#565](https://github.com/hvorragend/ha-blueprints/issues/565))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,8 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
-# CCA 2026.07.05 V2
-
-- 🐛 **Fix:** Calendar event titles were matched as a **substring**, so a cover configured with the open title *"Open Cover"* also reacted to events like *"Open Cover Bedroom"* on the same calendar. Because the parsing kept the **last** matching event of the day, such a cover could ignore its own *"Open Cover"* event (e.g. 06:00) and open at the time of the more specific event (e.g. 06:15) instead. Event titles are now matched **exactly** (ignoring upper/lower case and surrounding spaces) in the open/close event parsing and in the calendar trigger gate. Several covers can therefore share one calendar with prefix-related titles — *"Open Cover"* and *"Open Cover Bedroom"* are now distinct. **Note:** If you relied on the old substring behavior (e.g. events named *"Open Cover (vacation)"* matching the title *"Open Cover"*), rename the events or the configured title so they match exactly ([#536](https://github.com/hvorragend/ha-blueprints/issues/536))
-
----
-
 # CCA 2026.07.05
 
+- 🐛 **Fix:** Calendar event titles were matched as a **substring**, so a cover configured with the open title *"Open Cover"* also reacted to events like *"Open Cover Bedroom"* on the same calendar. Because the parsing kept the **last** matching event of the day, such a cover could ignore its own *"Open Cover"* event (e.g. 06:00) and open at the time of the more specific event (e.g. 06:15) instead. Event titles are now matched **exactly** (ignoring upper/lower case and surrounding spaces) in the open/close event parsing and in the calendar trigger gate. Several covers can therefore share one calendar with prefix-related titles — *"Open Cover"* and *"Open Cover Bedroom"* are now distinct. **Note:** If you relied on the old substring behavior (e.g. events named *"Open Cover (vacation)"* matching the title *"Open Cover"*), rename the events or the configured title so they match exactly ([#536](https://github.com/hvorragend/ha-blueprints/issues/536))
 - 🐛 **Fix:** If the cover happened to sit at the **shading position** at opening time while shading was **not** active in the helper (`shd: 0`) — for example because it was moved there manually — the cover never opened for the rest of the day. The opening handler skipped the normal opening (assuming an active shading would be ended later by the Shading End logic) and only updated the base state. But that handoff can never happen with `shd: 0`: a global trigger gate blocks all shading-end triggers unless shading is actually active in the helper. The normal opening now only defers to Shading End while shading is genuinely active; with `shd: 0` the cover simply opens normally ([#565](https://github.com/hvorragend/ha-blueprints/issues/565))
 
 ---


### PR DESCRIPTION
A cover configured with the open title "Open Cover" also matched events
like "Open Cover Schlafräume" on the same calendar, because the title
check used a substring test. The parsing loop keeps the last matching
event of the day, so the more specific (later) event silently won and
the cover opened at the wrong time.

Event titles are now compared exactly (case-insensitive, trimmed) in:
- the calendar open-event parsing
- the calendar close-event parsing
- the global trigger gate for t_calendar_event_* triggers

Input descriptions and the calendar help text now document the exact
matching, and the changelog notes the behavior change for users who
relied on substring matching.

Bump version to 2026.07.05 V2.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CAKzksMafeqaWNhgD1PsyY