### PR TITLE
fix: guard all cover_status_helper reads against unconfigured helper

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -773,6 +773,18 @@ The interval `(flip_from, flip_to + 60]` — previous on/off flip to current fli
 
 ---
 
+### Bug Pattern AF: Unconfigured status helper kills variable rendering before the friendly config check
+
+**Symptom:** With the mandatory `cover_status_helper` not configured, every run of the automation dies at trigger time with `Error rendering variables: TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` (Python ≥ 3.13 wording of "unhashable type"). The actions' "MANDATORY HELPER VALIDATION" block — which exists precisely to log a clear "Cover Status Helper is required but not configured" error and stop — never runs, because the top-level `variables:` block is rendered *before* the actions and aborts the run.
+
+**Cause:** `helper_json` called `states(cover_status_helper)` without a `!= []` guard. The input's `default: []` makes the argument a list, and `hass.states.get([])` fails on the dict lookup. Every other state read in the `variables:` block already carried the `x != [] and states(x)` guard — `helper_json` was the single unguarded one. The same unguarded read existed in trigger templates (`t_shading_start/end_execution`, `t_shading_tilt_*`, `t_reset_timeout`, `t_reset_position`), the global conditions (shading pending gate), and the v5→v6 migration check in the actions.
+
+**Fix:** Guard every reachable `states(cover_status_helper)`: in `helper_json` and the global-conditions gate via `... if cover_status_helper != [] else 'unavailable'` (falls through to the existing invalid-state handling → fresh default JSON), in the migration check via a preceding `{{ cover_status_helper != [] }}` condition, and in the helper-reading triggers via `and cover_status_helper != []` in their `enabled:`. With no helper configured the run now reaches the mandatory validation, logs the friendly error, and stops.
+
+**Rule:** Every `states(x)` / `state_attr(x, ...)` on an input whose `default` is `[]` must be guarded with `x != []` (short-circuit) — in *every* context: `variables:`, trigger `value_template`s, global conditions, and action conditions. This is the same upstream-gate family as Bug Pattern AA: a user-facing validation in the actions is dead code if variable rendering upstream can throw first.
+
+---
+
 ## Language & Style Conventions
 
 - **CLAUDE.md**: Written in English.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.05
+    **Version**: 2026.07.05 V2
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2923,7 +2923,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.05"
+  version: "2026.07.05 V2"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -3184,7 +3184,7 @@ variables:
   # Parses the helper JSON and normalises to v6 compact format.
   # Handles three cases: v5 → v6 migration, v6 pass-through, new/empty default.
   helper_json: >-
-    {% set helper_state = states(cover_status_helper) %}
+    {% set helper_state = states(cover_status_helper) if cover_status_helper != [] else 'unavailable' %}
     {% set helper_raw = helper_state | from_json(default={}) if helper_state not in invalid_states and helper_state | regex_match("((\[[^\}]+)?\{s*[^\}\{]{3,}?:.*\}([^\{]+\])?)") else {} %}
     {% set ts_now = as_timestamp(now()) | round(0) %}
 
@@ -3790,7 +3790,7 @@ triggers:
           now() >= (helper.shading.p | as_datetime | as_local)
         }}
       {% endif %}
-    enabled: "{{ is_shading_enabled }}"
+    enabled: "{{ is_shading_enabled and cover_status_helper != [] }}"
     id: "t_shading_start_execution"
 
   - trigger: state
@@ -3825,7 +3825,7 @@ triggers:
         states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_1
       }}
-    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
+    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] and cover_status_helper != [] }}"
     id: "t_shading_tilt_1"
 
   - trigger: template
@@ -3836,7 +3836,7 @@ triggers:
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_2 and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_1
       }}
-    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
+    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] and cover_status_helper != [] }}"
     id: "t_shading_tilt_2"
 
   - trigger: template
@@ -3847,7 +3847,7 @@ triggers:
         state_attr(default_sun_sensor, 'elevation') < shading_tilt_elevation_3 and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_2
       }}
-    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
+    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] and cover_status_helper != [] }}"
     id: "t_shading_tilt_3"
 
   - trigger: template
@@ -3857,7 +3857,7 @@ triggers:
         states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') and
         state_attr(default_sun_sensor, 'elevation') >= shading_tilt_elevation_3
       }}
-    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] }}"
+    enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] and cover_status_helper != [] }}"
     id: "t_shading_tilt_4"
 
   ########################################
@@ -3923,7 +3923,7 @@ triggers:
           now() >= (helper.shading.q | as_datetime | as_local)
         }}
       {% endif %}
-    enabled: "{{ is_shading_enabled }}"
+    enabled: "{{ is_shading_enabled and cover_status_helper != [] }}"
     id: "t_shading_end_execution"
 
   - trigger: template
@@ -3989,7 +3989,7 @@ triggers:
       {% else %}
         {{ false }}
       {% endif %}
-    enabled: "{{ is_reset_timeout }}"
+    enabled: "{{ is_reset_timeout and cover_status_helper != [] }}"
     id: "t_reset_timeout"
     for:
       seconds: 2
@@ -4001,7 +4001,7 @@ triggers:
       {% set pos = state_attr(blind, 'current_position') | float(-100) %}
       {{ helper.man | default(0) | int == 1 and
          (pos - (reset_override_position | float(0))) | abs <= (position_tolerance | float(5)) }}
-    enabled: "{{ is_reset_position }}"
+    enabled: "{{ is_reset_position and cover_status_helper != [] }}"
     id: "t_reset_position"
     for:
       minutes: !input reset_override_position_dwell
@@ -4018,12 +4018,12 @@ conditions:
   - condition: template
     value_template: >-
       {% if trigger.id is match('^t_shading_start_pending_[1-6]$') %}
-        {% set helper = states(cover_status_helper) %}
+        {% set helper = states(cover_status_helper) if cover_status_helper != [] else 'unavailable' %}
         {% set is_shaded = helper not in invalid_states and helper | regex_search('"shd"\s*:\s*1\s*[,}]') %}
         {% set is_end_pending = helper not in invalid_states and helper | regex_search('"pnd"\s*:\s*"end"') %}
         {{ not is_shaded or is_end_pending }}
       {% elif trigger.id is match('^t_shading_end_pending_[1-7]$') %}
-        {{ states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') }}
+        {{ cover_status_helper != [] and states(cover_status_helper) not in invalid_states and states(cover_status_helper) | regex_search('"shd"\s*:\s*1\s*[,}]') }}
       {% else %}
         true
       {% endif %}
@@ -4258,6 +4258,7 @@ actions:
   #     (defensive cleanup; preserves all live state, resets pending to idle).
   # We check the raw helper state, not helper_json (which always has v:6 after migration).
   - if:
+      - "{{ cover_status_helper != [] }}"
       - condition: template
         value_template: >-
           {% set helper_state = states(cover_status_helper) %}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.05 V2
+
+- 🐛 **Fix:** When the mandatory **Cover Status Helper** was not configured, every run of the automation died immediately with the cryptic log error `Error rendering variables: TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` — the friendly configuration error CCA is supposed to log ("Cover Status Helper is required but not configured") was never reached, so nothing worked and there was no hint why. The internal helper parsing read the helper entity's state without first checking whether a helper is configured at all. All helper reads are now guarded: without a configured helper the automation starts normally, reaches the built-in configuration check, writes a clear error to the system log and the logbook, and stops. The shading execution/tilt triggers and the manual-override reset triggers are also disabled while no helper is configured, so they cannot produce template errors either. **Reminder:** the Cover Status Helper (an `input_text` helper with a maximum length of 254) is mandatory — one per CCA automation
+
+---
+
 # CCA 2026.07.05
 
 - ✨ **Feature:** Tilt-capable covers now have a **Tilt Position Tolerance** (next to the existing position tolerance, in the *Tilt Position Feature* settings). The cover status is now told apart by **position *and* tilt angle**, so several states that share the same position can be distinguished by their tilt — e.g. *closed*, *shading* and *ventilate* all at position 0 but with different tilt angles. The tolerance is an absolute dead-band that also absorbs small tilt-motor inaccuracies, mirroring the position tolerance. The same dead-band is applied to manual tilt-change detection, so a tiny tilt jitter reported by the cover is no longer mistaken for a manual intervention ([#558](https://github.com/hvorragend/ha-blueprints/issues/558))


### PR DESCRIPTION
With no Cover Status Helper configured (input default []), helper_json
called states([]) and every run died at variable rendering with
'TypeError: cannot use list as a dict key' before the mandatory helper
validation in the actions could log its friendly error. Guard helper_json,
the global shading-pending gate, the v5->v6 migration check, and disable
the helper-reading triggers (shading execution/tilt, override resets)
while no helper is configured.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BSLf47BLiWBBBxtgYGbTdd