### PR TITLE
feat: optional alternate sun shading position (#580)

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -423,6 +423,35 @@ blueprint:
               max: 100.0
               unit_of_measurement: "%"
 
+        shading_position_alt:
+          name: "🥵 Alternate Sun Shading Position"
+          description: >-
+            An optional second shading position. When the gating entity below is 'on',
+            the cover moves to this position for shading instead of the normal shading position.
+            <br /><br />Leave empty to disable the alternate shading position.
+          default: []
+          selector:
+            number:
+              min: 0.0
+              max: 100.0
+              unit_of_measurement: "%"
+
+        shading_position_alt_entity:
+          name: "🥵 Alternate Sun Shading Position Trigger"
+          description: >-
+            While this entity is 'on', the cover shades to the alternate shading position above
+            instead of the normal shading position. While it is 'off' (or unset), the normal
+            shading position is used. If the cover is already shading when this entity changes,
+            the cover is re-driven to the matching position.
+            <br /><br />Leave empty to disable the alternate shading position.
+          default: []
+          selector:
+            entity:
+              multiple: false
+              domain:
+                - binary_sensor
+                - input_boolean
+
         position_tolerance:
           name: "〰️ Position Tolerance"
           description: >-
@@ -2756,6 +2785,8 @@ trigger_variables:
   close_position: !input close_position
   ventilate_position: !input ventilate_position
   shading_position: !input shading_position
+  shading_position_alt: !input shading_position_alt
+  shading_position_alt_entity: !input shading_position_alt_entity
   position_tolerance: !input position_tolerance
 
   # Tilt positions
@@ -2947,6 +2978,14 @@ variables:
   # Same for tilt if enabled
   current_tilt_position: "{{ state_attr(blind, 'current_tilt_position') | int(default=101) }}"
 
+  # Effective shading position: alternate position while the gating entity is 'on',
+  # otherwise the normal shading position (also the fallback when unset)
+  effective_shading_position: >-
+    {{ shading_position_alt
+       if (shading_position_alt != [] and shading_position_alt_entity != []
+           and states(shading_position_alt_entity) == 'on')
+       else shading_position }}
+
   # COVER TYPE & POSITION COMPARISON LOGIC
   # Position comparison results
   # Handles both blind (0%=closed) and awning (0%=retracted) logic automatically
@@ -2954,21 +2993,21 @@ variables:
     # Current position vs targets (considers awning inversion)
     current_above_open: "{{ current_position < open_position if is_awning else current_position > open_position }}"
     current_above_close: "{{ current_position < close_position if is_awning else current_position > close_position }}"
-    current_above_shading: "{{ current_position < shading_position if is_awning else current_position > shading_position }}"
+    current_above_shading: "{{ current_position < effective_shading_position if is_awning else current_position > effective_shading_position }}"
     current_above_ventilate: "{{ current_position < ventilate_position if is_awning else current_position > ventilate_position }}"
 
     current_below_open: "{{ current_position > open_position if is_awning else current_position < open_position }}"
     current_below_close: "{{ current_position > close_position if is_awning else current_position < close_position }}"
-    current_below_shading: "{{ current_position > shading_position if is_awning else current_position < shading_position }}"
+    current_below_shading: "{{ current_position > effective_shading_position if is_awning else current_position < effective_shading_position }}"
     current_below_ventilate: "{{ current_position > ventilate_position if is_awning else current_position < ventilate_position }}"
 
     # Position ordering (for config validation)
     open_above_close: "{{ open_position < close_position if is_awning else open_position > close_position }}"
     open_above_ventilate: "{{ open_position < ventilate_position if is_awning else open_position > ventilate_position }}"
-    shading_above_close: "{{ shading_position < close_position if is_awning else shading_position > close_position }}"
-    shading_below_open: "{{ shading_position > open_position if is_awning else shading_position < open_position }}"
+    shading_above_close: "{{ effective_shading_position < close_position if is_awning else effective_shading_position > close_position }}"
+    shading_below_open: "{{ effective_shading_position > open_position if is_awning else effective_shading_position < open_position }}"
     ventilate_above_close: "{{ ventilate_position < close_position if is_awning else ventilate_position > close_position }}"
-    shading_below_ventilate: "{{ shading_position > ventilate_position if is_awning else shading_position < ventilate_position }}"
+    shading_below_ventilate: "{{ effective_shading_position > ventilate_position if is_awning else effective_shading_position < ventilate_position }}"
 
   current_sun_azimuth: "{{ state_attr(default_sun_sensor, 'azimuth') }}"
   current_sun_elevation: "{{ state_attr(default_sun_sensor, 'elevation') }}"
@@ -3083,8 +3122,8 @@ variables:
     }}
 
   in_shading_position: >-
-    {% set min = shading_position - position_tolerance %}
-    {% set max = shading_position + position_tolerance %}
+    {% set min = effective_shading_position - position_tolerance %}
+    {% set max = effective_shading_position + position_tolerance %}
     {{
       is_shading_enabled
       and (current_position >= min and current_position <= max)
@@ -3859,6 +3898,18 @@ triggers:
       }}
     enabled: "{{ is_shading_enabled and is_cover_tilt_enabled and default_sun_sensor != [] and cover_status_helper != [] }}"
     id: "t_shading_tilt_4"
+
+  ########################################
+  # Trigger for alternate shading position
+  ########################################
+
+  - trigger: state
+    entity_id: !input shading_position_alt_entity
+    not_to:
+      - "unavailable"
+      - "unknown"
+    enabled: "{{ is_shading_enabled and shading_position_alt_entity != [] and cover_status_helper != [] }}"
+    id: "t_shading_position_alt"
 
   ########################################
   # Triggers for shading end
@@ -5155,7 +5206,7 @@ actions:
                   - "{{ not in_shading_position }}" # Even if this is hardly possible, there may be situations that require it. Purely as a precautionary measure in case the target state and actual state do not match.
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position | int }}"
                       update_values:
                         # Activate shading, base state is open (time-based)
@@ -5661,7 +5712,7 @@ actions:
                                           - "{{ position_comparisons.current_above_shading }}"
                                       - and:
                                           - "{{ is_cover_tilt_enabled_and_possible }}"
-                                          - "{{ position_comparisons.current_above_shading or current_position == shading_position }}"
+                                          - "{{ position_comparisons.current_above_shading or current_position == effective_shading_position }}"
                                       # Cover below the shading position (e.g. closed overnight) while the base state wants it open: raise to the shading cap
                                       - and:
                                           - "{{ position_comparisons.current_below_shading }}"
@@ -5670,7 +5721,7 @@ actions:
                                   - "{{ resident_flags.allow_shade }}"
                                 sequence:
                                   - variables:
-                                      target_position: !input shading_position
+                                      target_position: "{{ effective_shading_position | int }}"
                                       target_tilt_position: "{{ shading_tilt_position | int }}"
                                       update_values:
                                         # Activate shading
@@ -5862,6 +5913,36 @@ actions:
           - *tilt_move_action
           - *helper_update
           - stop: "Shading Tilt executed"
+
+      ############################################################
+      # BRANCH (3b): SHADING POSITION ADJUSTMENT
+      #   Trigger: Alternate-shading-position gating entity toggled
+      #   Source: Shading (already active)
+      #   Target: Re-drive to the effective shading position (normal or alternate)
+      #   Note: Position-only sibling of the tilt adjustment; NOT a shading start
+      #         (shd stays 1, ts.shd untouched), so "shade once per day" is unaffected
+      ############################################################
+
+      - alias: "Check for alternate shading position"
+        conditions:
+          - "{{ is_shading_enabled }}"
+          - "{{ trigger.id is defined }}"
+          - "{{ trigger.id | regex_match('^t_shading_position_alt') }}"
+          - and:
+              - "{{ helper_state_is_shaded }}"
+              - "{{ not helper_state_pending_start }}"
+          - "{{ force_allows_shade }}"
+          - "{{ resident_flags.allow_shade }}" # Do not move into shading while a resident is present and shading is not allowed
+          - "{{ not (contact_window_opened != [] and states(contact_window_opened) in ['true', 'on']) and not (contact_window_tilted != [] and states(contact_window_tilted) in ['true', 'on']) }}"
+          - "{{ not (helper_state_manual and override_flags.shading) }}" # Override check
+        sequence:
+          - variables:
+              target_position: "{{ effective_shading_position | int }}"
+              update_values:
+                man: "{{ 0 if force_allows_shade else helper_json.man | default(0) | int }}"
+          - *cover_move_action
+          - *helper_update
+          - stop: "Alternate shading position executed"
 
       ############################################################
       # BRANCH (4): SHADING END
@@ -6333,7 +6414,7 @@ actions:
                   - condition: !input auto_ventilate_end_condition
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position | int }}"
                       update_values:
                         # Window closed, return to shading (shade is already true)
@@ -6513,7 +6594,7 @@ actions:
                           - "{{ is_shading_enabled }}"
                         sequence:
                           - variables:
-                              target_position: !input shading_position
+                              target_position: "{{ effective_shading_position | int }}"
                               target_tilt_position: "{{ shading_tilt_position | int }}"
                               update_values:
                                 # Resident leaving, shade already active — preserve ts.shd
@@ -6766,7 +6847,7 @@ actions:
                   - "{{ trigger.id == 't_force_enabled_shading' }}"
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position |int }}"
                       update_values:
                         # Force shading activated
@@ -6837,7 +6918,7 @@ actions:
                 conditions: "{{ effective_state == 'shd' and helper_json.frc == 'shd' }}"
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position | int }}"
                       update_values:
                         man: 0
@@ -6917,7 +6998,7 @@ actions:
                 conditions: "{{ effective_state == 'shd' }}"
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position | int }}"
                       update_values:
                         man: 0
@@ -7066,7 +7147,7 @@ actions:
                   - "{{ next_active_force == 'shd' }}"
                 sequence:
                   - variables:
-                      target_position: !input shading_position
+                      target_position: "{{ effective_shading_position | int }}"
                       target_tilt_position: "{{ shading_tilt_position | int }}"
                       update_values:
                         # Switch to force shading
@@ -7156,7 +7237,7 @@ actions:
                               - "{{ resident_flags.allow_shade }}"
                             sequence:
                               - variables:
-                                  target_position: !input shading_position
+                                  target_position: "{{ effective_shading_position | int }}"
                                   target_tilt_position: "{{ shading_tilt_position | int }}"
                                   update_values:
                                     # Force ended, return to shading

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+<!-- Proposed entry for the next release. Version heading intentionally left as TBD:
+     the maintainer decides the version number / whether to fold this into an existing
+     release or a V2. No version bump was applied to the blueprint itself. -->
+# CCA TBD
+
+- ✨ **Feature:** New optional **Alternate Sun Shading Position** (in the *Cover Position* settings, next to the normal shading position). You can now define a second shading position together with a switch entity (a `binary_sensor` or `input_boolean`): while that entity is **on**, the cover shades to the alternate position; while it is **off** (or the fields are left empty), it shades to the normal position exactly as before. If the switch changes while the cover is **already shading**, the cover moves to the matching position right away. This only affects the shading *position* — the shading tilt angle is unchanged — and it does **not** count as an additional sun shading, so *"Only shade once per day"* keeps working normally. Leave both fields empty to keep the previous behavior ([#580](https://github.com/hvorragend/ha-blueprints/issues/580))
+
+---
+
 # CCA 2026.07.05 V2
 
 - 🐛 **Fix:** When the mandatory **Cover Status Helper** was not configured, every run of the automation died immediately with the cryptic log error `Error rendering variables: TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` — the friendly configuration error CCA is supposed to log ("Cover Status Helper is required but not configured") was never reached, so nothing worked and there was no hint why. The internal helper parsing read the helper entity's state without first checking whether a helper is configured at all. All helper reads are now guarded: without a configured helper the automation starts normally, reaches the built-in configuration check, writes a clear error to the system log and the logbook, and stops. The shading execution/tilt triggers and the manual-override reset triggers are also disabled while no helper is configured, so they cannot produce template errors either. **Reminder:** the Cover Status Helper (an `input_text` helper with a maximum length of 254) is mandatory — one per CCA automation

--- a/tests/test_alternate_shading_position.py
+++ b/tests/test_alternate_shading_position.py
@@ -1,0 +1,413 @@
+"""
+Tests for the optional Alternate Sun Shading Position feature (Issue #580).
+
+The feature adds a second shading depth (`shading_position_alt`) plus a gating
+entity (`shading_position_alt_entity`). While the entity is `on`, the cover
+shades to the alternate position; otherwise (or when either input is unset) the
+normal `shading_position` is used. The active depth is derived live from the
+gating entity via the central `effective_shading_position` variable — no extra
+status is persisted in the helper (matches the #558 "helper holds logical state,
+not last physical target" decision).
+
+Key properties verified here (real logic extracted from the blueprint, not a
+copy):
+  - Backward compatibility: with both inputs unset, effective == shading_position.
+  - effective_shading_position lives in the FULL `variables:` block, not in
+    `trigger_variables:` — it calls states(), which is forbidden in the limited
+    trigger context (Invariant 10).
+  - All shading drive sites and the position detection use the effective value.
+  - The mid-shading re-drive trigger `t_shading_position_alt` provably passes the
+    global trigger gate while shading is active (shd == 1).
+  - The re-drive branch does NOT touch shd / ts.shd / pnd / ts.due / ts.arm, so
+    "shade only once per day" is unaffected (hard constraint from #580).
+
+Run with: pytest tests/ -v
+"""
+import pathlib
+import re
+
+import jinja2
+import pytest
+import yaml
+
+
+BLUEPRINT_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "blueprints"
+    / "automation"
+    / "cover_control_automation.yaml"
+)
+
+INVALID_STATES = ["", "unavailable", "unknown", "none", "None"]
+
+
+def _blueprint_text() -> str:
+    return BLUEPRINT_PATH.read_text(encoding="utf-8")
+
+
+def _load_blueprint_yaml() -> dict:
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_constructor(
+        "!input", lambda loader, node: loader.construct_scalar(node)
+    )
+    with open(BLUEPRINT_PATH, encoding="utf-8") as f:
+        return yaml.load(f, Loader=_Loader)  # noqa: S506
+
+
+def _env(entity_states: dict | None = None) -> jinja2.Environment:
+    """Jinja env with the HA globals/filters/tests the templates rely on."""
+    entity_states = entity_states or {}
+    env = jinja2.Environment(undefined=jinja2.Undefined)
+    env.globals["states"] = lambda e: entity_states.get(e, "unknown")
+    env.filters["regex_search"] = (
+        lambda value, pattern: re.search(pattern, str(value)) is not None
+    )
+    env.tests["match"] = (
+        lambda value, pattern: re.match(pattern, str(value)) is not None
+    )
+    return env
+
+
+def _find_branch_by_alias(node, alias: str):
+    if isinstance(node, dict):
+        if node.get("alias") == alias:
+            return node
+        for v in node.values():
+            found = _find_branch_by_alias(v, alias)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _find_branch_by_alias(item, alias)
+            if found is not None:
+                return found
+    return None
+
+
+def _find_trigger_by_id(blueprint: dict, trigger_id: str):
+    for trg in blueprint.get("triggers", []):
+        if isinstance(trg, dict) and trg.get("id") == trigger_id:
+            return trg
+    return None
+
+
+def _global_condition_template(blueprint: dict) -> str:
+    for cond in blueprint.get("conditions", []):
+        if isinstance(cond, dict) and "value_template" in cond:
+            return cond["value_template"]
+    raise AssertionError("global template condition not found")
+
+
+def _branch_update_values(branch: dict) -> dict:
+    for step in branch.get("sequence", []):
+        if isinstance(step, dict) and "variables" in step:
+            return step["variables"].get("update_values", {})
+    return {}
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Inputs
+# ════════════════════════════════════════════════════════════════════════════
+class TestInputs:
+    def test_both_inputs_defined(self):
+        text = _blueprint_text()
+        assert "shading_position_alt:" in text
+        assert "shading_position_alt_entity:" in text
+
+    def test_alt_position_is_optional_number_selector(self):
+        bp = _load_blueprint_yaml()
+        inp = _find_input(bp, "shading_position_alt")
+        assert inp["default"] == []
+        assert inp["selector"]["number"]["min"] == 0.0
+        assert inp["selector"]["number"]["max"] == 100.0
+
+    def test_alt_entity_is_optional_and_domain_restricted(self):
+        bp = _load_blueprint_yaml()
+        inp = _find_input(bp, "shading_position_alt_entity")
+        assert inp["default"] == []
+        domains = inp["selector"]["entity"]["domain"]
+        assert set(domains) == {"binary_sensor", "input_boolean"}
+
+
+def _find_input(node, name):
+    if isinstance(node, dict):
+        if name in node and isinstance(node[name], dict) and "selector" in node[name]:
+            return node[name]
+        for v in node.values():
+            found = _find_input(v, name)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _find_input(item, name)
+            if found is not None:
+                return found
+    return None
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# effective_shading_position — the central mechanism
+# ════════════════════════════════════════════════════════════════════════════
+class TestEffectiveShadingPosition:
+    @pytest.fixture(scope="class")
+    def tmpl(self):
+        return _load_blueprint_yaml()["variables"]["effective_shading_position"]
+
+    def _render(self, tmpl, *, alt, entity, entity_state, normal=25):
+        states = {entity: entity_state} if entity != [] else {}
+        out = (
+            _env(states)
+            .from_string(tmpl)
+            .render(
+                shading_position_alt=alt,
+                shading_position_alt_entity=entity,
+                shading_position=normal,
+            )
+            .strip()
+        )
+        return int(out)
+
+    def test_disabled_falls_back_to_normal(self, tmpl):
+        # Both unset — byte-for-byte the old behavior.
+        assert self._render(tmpl, alt=[], entity=[], entity_state="off") == 25
+
+    def test_alt_unset_entity_set_uses_normal(self, tmpl):
+        assert (
+            self._render(tmpl, alt=[], entity="input_boolean.x", entity_state="on")
+            == 25
+        )
+
+    def test_entity_unset_alt_set_uses_normal(self, tmpl):
+        assert self._render(tmpl, alt=60, entity=[], entity_state="on") == 25
+
+    def test_entity_on_uses_alternate(self, tmpl):
+        assert (
+            self._render(tmpl, alt=60, entity="input_boolean.x", entity_state="on")
+            == 60
+        )
+
+    def test_entity_off_uses_normal(self, tmpl):
+        assert (
+            self._render(tmpl, alt=60, entity="input_boolean.x", entity_state="off")
+            == 25
+        )
+
+    def test_lives_in_variables_not_trigger_variables(self):
+        """states() is forbidden in trigger_variables (Invariant 10)."""
+        bp = _load_blueprint_yaml()
+        assert "effective_shading_position" in bp["variables"]
+        assert "effective_shading_position" not in bp["trigger_variables"]
+
+    def test_defined_before_its_consumers(self):
+        keys = list(_load_blueprint_yaml()["variables"].keys())
+        assert keys.index("effective_shading_position") < keys.index(
+            "position_comparisons"
+        )
+        assert keys.index("effective_shading_position") < keys.index(
+            "in_shading_position"
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Consumers use the effective value, not the raw shading_position
+# ════════════════════════════════════════════════════════════════════════════
+class TestConsumersUseEffective:
+    def test_in_shading_position_uses_effective(self):
+        tmpl = _load_blueprint_yaml()["variables"]["in_shading_position"]
+        # The tolerance band is computed against the effective (not the raw) depth.
+        assert "effective_shading_position - position_tolerance" in tmpl
+        assert "effective_shading_position + position_tolerance" in tmpl
+
+    def test_all_shading_position_comparisons_use_effective(self):
+        pc = _load_blueprint_yaml()["variables"]["position_comparisons"]
+        # Every comparison that involves the shading depth must reflect the
+        # effective (normal/alternate) position, per the maintainer's #580 note.
+        shading_keys = [k for k, v in pc.items() if "shading_position" in v]
+        assert shading_keys, "expected shading-related position comparisons"
+        for key in shading_keys:
+            assert "effective_shading_position" in pc[key], key
+            # No bare (non-effective) shading_position must remain.
+            assert not re.search(r"(?<!effective_)shading_position", pc[key]), key
+
+    def test_all_nine_drive_sites_plus_redrive_use_effective(self):
+        text = _blueprint_text()
+        # 9 original drive sites + the new re-drive branch = 10.
+        assert (
+            text.count('target_position: "{{ effective_shading_position | int }}"')
+            == 10
+        )
+        # No drive site still hard-wires the raw input.
+        assert "target_position: !input shading_position" not in text
+
+    def test_start_shading_guard_compares_against_effective(self):
+        text = _blueprint_text()
+        assert "current_position == effective_shading_position" in text
+        assert "current_position == shading_position " not in text
+
+    def test_ventilation_floor_gate_uses_effective(self):
+        """Bug Pattern AE floor must bind on the *active* depth (#580 follow-up).
+
+        The maintainer's #580 comment lists shading_below_ventilate among the
+        position_comparisons that must reflect the effective position; otherwise
+        the ventilation floor (window tilted) breaks when the alternate depth
+        sits on the opposite side of the ventilate position.
+        """
+        pc = _load_blueprint_yaml()["variables"]["position_comparisons"]
+        tmpl = pc["shading_below_ventilate"]
+        assert "effective_shading_position" in tmpl
+
+        def below(effective, ventilate, is_awning=False):
+            return (
+                _env()
+                .from_string(tmpl)
+                .render(
+                    effective_shading_position=effective,
+                    ventilate_position=ventilate,
+                    is_awning=is_awning,
+                )
+                .strip()
+                == "True"
+            )
+
+        # Blind (0 % = closed): "below" means a numerically smaller position.
+        assert below(30, 50) is True  # alt depth below vent → floor binds
+        assert below(60, 50) is False  # alt depth above vent → floor must NOT bind
+        # Awning (0 % = retracted): inverted.
+        assert below(60, 50, is_awning=True) is True
+        assert below(30, 50, is_awning=True) is False
+
+    def test_shading_above_close_gate_uses_effective(self):
+        """Close-time "lowering blocked if shaded" gate reflects the active depth."""
+        pc = _load_blueprint_yaml()["variables"]["position_comparisons"]
+        tmpl = pc["shading_above_close"]
+        assert "effective_shading_position" in tmpl
+
+        def above(effective, close, is_awning=False):
+            return (
+                _env()
+                .from_string(tmpl)
+                .render(
+                    effective_shading_position=effective,
+                    close_position=close,
+                    is_awning=is_awning,
+                )
+                .strip()
+                == "True"
+            )
+
+        # Blind: shading "above" close means a numerically larger position.
+        assert above(20, 10) is True  # alt depth above close
+        assert above(5, 10) is False  # alt depth below close
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Mid-shading re-drive trigger
+# ════════════════════════════════════════════════════════════════════════════
+class TestReDriveTrigger:
+    def test_trigger_defined_as_state_with_not_to_guard(self):
+        trg = _find_trigger_by_id(_load_blueprint_yaml(), "t_shading_position_alt")
+        assert trg is not None
+        assert trg["trigger"] == "state"
+        assert set(trg["not_to"]) == {"unavailable", "unknown"}
+
+    def test_trigger_enabled_gate(self):
+        trg = _find_trigger_by_id(_load_blueprint_yaml(), "t_shading_position_alt")
+        gate = trg["enabled"]
+        assert "is_shading_enabled" in gate
+        assert "shading_position_alt_entity != []" in gate
+        assert "cover_status_helper != []" in gate
+
+    @pytest.mark.parametrize(
+        "helper, expected",
+        [
+            # Shading active — the re-drive MUST be allowed through.
+            ('{"shd":1,"pnd":"non","ts":{"shd":1779701945}}', True),
+            # Shading inactive — no re-drive needed, but the gate does not
+            # single this trigger out either (falls into the else->true branch).
+            ('{"shd":0,"pnd":"non","ts":{"shd":0}}', True),
+        ],
+    )
+    def test_passes_global_gate(self, helper, expected):
+        bp = _load_blueprint_yaml()
+        tmpl = _global_condition_template(bp)
+        result = (
+            _env({"input_text.cca": helper})
+            .from_string(tmpl)
+            .render(
+                trigger={"id": "t_shading_position_alt"},
+                cover_status_helper="input_text.cca",
+                invalid_states=INVALID_STATES,
+            )
+            .strip()
+            .lower()
+        )
+        assert (result == "true") is expected
+
+    def test_gate_still_suppresses_start_pending_while_shaded(self):
+        """Sanity: the harness really evaluates the gate (contrast case)."""
+        bp = _load_blueprint_yaml()
+        tmpl = _global_condition_template(bp)
+        shaded = '{"shd":1,"pnd":"non","ts":{"shd":1779701945}}'
+        result = (
+            _env({"input_text.cca": shaded})
+            .from_string(tmpl)
+            .render(
+                trigger={"id": "t_shading_start_pending_1"},
+                cover_status_helper="input_text.cca",
+                invalid_states=INVALID_STATES,
+            )
+            .strip()
+            .lower()
+        )
+        # shd==1 and no end-pending → start-pending is suppressed.
+        assert result == "false"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Re-drive branch — must not look like a shading start
+# ════════════════════════════════════════════════════════════════════════════
+class TestReDriveBranch:
+    ALIAS = "Check for alternate shading position"
+
+    @pytest.fixture(scope="class")
+    def branch(self):
+        b = _find_branch_by_alias(_load_blueprint_yaml()["actions"], self.ALIAS)
+        assert b is not None, "re-drive branch not found"
+        return b
+
+    def test_gated_on_its_own_trigger(self, branch):
+        conds = str(branch["conditions"])
+        assert "t_shading_position_alt" in conds
+
+    def test_gated_on_active_shading_only(self, branch):
+        conds = str(branch["conditions"])
+        assert "helper_state_is_shaded" in conds
+        assert "not helper_state_pending_start" in conds
+
+    def test_gated_on_force_resident_and_override(self, branch):
+        conds = str(branch["conditions"])
+        assert "force_allows_shade" in conds
+        assert "resident_flags.allow_shade" in conds
+        assert "helper_state_manual and override_flags.shading" in conds
+
+    def test_lockout_window_checks_present(self, branch):
+        conds = str(branch["conditions"])
+        assert "contact_window_opened" in conds
+        assert "contact_window_tilted" in conds
+
+    def test_drives_position_via_effective(self, branch):
+        seq = str(branch["sequence"])
+        assert "effective_shading_position" in seq
+
+    def test_does_not_touch_shading_start_state(self, branch):
+        """Hard constraint #580.2: a depth change is NOT a new shading start."""
+        uv = _branch_update_values(branch)
+        for forbidden in ("shd", "pnd", "ts"):
+            assert forbidden not in uv, (
+                f"re-drive must not set '{forbidden}' — would corrupt the "
+                f"shade-once-per-day guard / pending state"
+            )
+        # It may only (optionally) reset the manual flag when it actually drives.
+        assert set(uv.keys()) <= {"man"}

--- a/tests/test_tilt_tolerance.py
+++ b/tests/test_tilt_tolerance.py
@@ -69,6 +69,9 @@ def _vars(**overrides) -> dict:
         tilt_position_tolerance=0,
     )
     base.update(overrides)
+    # in_shading_position compares against effective_shading_position (the alternate
+    # shading position feature); with the feature disabled it equals shading_position.
+    base.setdefault("effective_shading_position", base["shading_position"])
     return base
 
 


### PR DESCRIPTION
## Summary

Implements the maintainer-agreed design from #580: an **optional secondary
shading position** that the automation drives to instead of the normal
`shading_position` while a gating entity is `on`.

Closes #580.

## What's new (user-facing)

Two new optional inputs in the *Cover Position* settings:

- **Alternate Sun Shading Position** (`shading_position_alt`) — a second shading
  depth (`number`, 0–100 %).
- **Alternate Sun Shading Position Trigger** (`shading_position_alt_entity`) — a
  `binary_sensor` / `input_boolean`. While it is `on`, the cover shades to the
  alternate position; while it is `off` (or either field is empty), it shades to
  the normal position exactly as before.

If the entity changes **while the cover is already shading**, the cover is
re-driven to the matching position immediately.

## How it works

- One central `effective_shading_position` variable resolves normal vs. alternate
  live from the gating entity. Every shading consumer references it:
  `in_shading_position`, all shading-related `position_comparisons`
  (`current_above/below_shading`, `shading_above_close`, `shading_below_open`,
  `shading_below_ventilate`), the ~9 drive sites, and the start-execution guard.
- New `t_shading_position_alt` state trigger (with `not_to: [unavailable,
  unknown]`, cf. #550) + a dedicated `BRANCH (3b): SHADING POSITION ADJUSTMENT`
  handle the mid-shading re-drive. It is modeled on "Check for shading tilt"
  (only active while `shd == 1`, gated on `force_allows_shade`,
  `resident_flags.allow_shade`, window lockout, and the manual-override check).
- Verified the new trigger id passes the **global trigger gate** in the `shd == 1`
  case (it falls into the gate's `else → true` branch; it is not one of the
  suppressed `*_pending_*` ids).

## Design decisions (per the #580 discussion)

- **Entity selector, not a `condition: {}` input** — the effective position is
  read in the top-level `variables:` block and consumed in `choose:` branch
  conditions, before any action step could evaluate a condition input; and a
  blueprint cannot build a re-drive trigger from a condition input.
- **No new helper field.** The active depth is always derivable live from the
  gating entity (matches the #558 "helper holds logical state, not the last
  physical target" decision). The brief `in_shading_position` volatility right
  after a switch is the same accepted volatility as the tilt stages, healed by
  the re-drive trigger.
- **`prevent_shading_multiple_times` is unaffected** — a depth change is not a
  new shading start (`shd` stays `1`, `ts.shd` untouched).
- **Out of scope:** an alternate *tilt* position (separate discussion if needed).

## Backward compatibility

With both inputs unset (`[]`), `effective_shading_position` falls back to
`shading_position`, so behavior is identical to before. Most users won't set
these.

## Testing

- New `tests/test_alternate_shading_position.py` (inputs, `effective_shading_position`
  resolution, all consumers, the re-drive trigger, the global-gate pass at
  `shd == 1`, and that the re-drive branch never touches `shd`/`ts.shd`/pending).
- Updated the `test_tilt_tolerance.py` fixture to supply `effective_shading_position`.
- `pytest tests/` → **287 passed**.

## Note on versioning

I deliberately did **not** bump the blueprint version (kept `2026.07.05 V2`).
The changelog entry is included as a proposal under a `# CCA TBD` heading —
please set the version / fold it into a release or V2 as you see fit.
