### PR TITLE
docs: Clarify cover type descriptions and position values

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -347,9 +347,11 @@ blueprint:
           description: >-
             Select the type of cover you want to control.
             <br /><br />
-            <strong>Blind/Roller Shutter:</strong> Position 0% = closed (down), 100% = open (up). Shading uses lower positions.
+            <strong>Blind/Roller Shutter:</strong> On the cover entity, 0% = closed (down), 100% = open (up) — matching CCA's Open Position (100%) and Close Position (0%). Shading uses lower positions.
             <br /><br />
-            <strong>Awning/Sunshade:</strong> Position 0% = retracted (closed), 100% = extended (open). Shading uses higher positions.
+            <strong>Awning/Sunshade:</strong> On the cover entity, 0% = retracted (closed), 100% = extended (open). Shading uses higher positions.
+            <br /><br />
+            ⚠️ <strong>Note:</strong> For an awning, CCA's Open Position is the <em>retracted</em> state — enter Open Position = 0% and Close Position = 100% (mirrored compared to a blind).
             <br /><br />
             ⚠️ <strong>Note:</strong> Ventilation and tilt features are not available for awnings.
             <br /><br />


### PR DESCRIPTION
I think the current description could be clearer. At the moment it feels a bit contradictory, and the examples may be interpreted the other way around.

When selecting ☂️ Awning / Sunshade (Inverted), users understand that the blueprint uses inverted logic internally. What is not obvious, however, is that they also need to swap the configured open and closed values.

In Home Assistant, the entity still shows Open as 100% and Closed as 0%, so it is easy to miss that the blueprint’s existing is_awning logic still applies and requires the values to be flipped in this mode.

I know this behavior was kept for legacy compatibility, but I think we can explain it more explicitly here to avoid confusion.