### PR TITLE
fix: re-apply shading tilt and gate man reset in the alt-position re-…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -268,6 +268,29 @@ single (non-staged) shading tilt.
 
 Do not re-add a `tp`/last-tilt helper field to "fix" this.
 
+### Alternate shading position resolves live via `effective_shading_position` (#580)
+
+An optional second shading depth (`shading_position_alt`) is active while the
+gating entity (`shading_position_alt_entity`, `binary_sensor`/`input_boolean`)
+is `on`. The single source of truth is the `effective_shading_position`
+variable (full `variables:` block — it calls `states()`, so it must not move
+into `trigger_variables:`, Invariant 10). **Every** shading consumer reads it:
+`in_shading_position`, all shading-related `position_comparisons`, and every
+drive site (`target_position`). Never reference the raw `shading_position`
+input in a consumer — that silently breaks the alt depth.
+
+The mid-shading depth switch is handled by `t_shading_position_alt` + the
+"Check for alternate shading position" branch (3b), modeled on "Check for
+shading tilt": only while `shd == 1`, gated on force/resident/window/manual.
+It re-applies the shading **tilt** after the position move (a position drive
+physically disturbs the slat angle on tilt covers) and clears `man` only when
+it actually drives (`not in_shading_position` in the if-guard, Invariants 1+7).
+A depth change is **not** a shading start: `shd`, `ts.shd`, and the pending
+keys stay untouched, so `prevent_shading_multiple_times` is unaffected. No
+helper field stores the active depth (same rationale as #558 — the helper
+holds logical state; the brief `in_shading_position` volatility after a switch
+is accepted and healed by the re-drive trigger).
+
 ### Resident handler bypasses `helper_state_manual` / `override_flags.*`
 
 The resident sensor handler (`resident_leaving` / `resident_arriving`) does **not** check `not (helper_state_manual and override_flags.X)` in any of its branches. All other handlers (Open, Close, Shading-Start, Shading-End, Contact, Manual) do.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.05 V2
+    **Version**: 2026.07.12
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2956,7 +2956,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.05 V2"
+  version: "2026.07.12"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -5921,8 +5921,10 @@ actions:
       #   Trigger: Alternate-shading-position gating entity toggled
       #   Source: Shading (already active)
       #   Target: Re-drive to the effective shading position (normal or alternate)
-      #   Note: Position-only sibling of the tilt adjustment; NOT a shading start
-      #         (shd stays 1, ts.shd untouched), so "shade once per day" is unaffected
+      #   Note: Re-applies the shading tilt after the position move (a position
+      #         drive physically disturbs the slat angle on tilt covers);
+      #         NOT a shading start (shd stays 1, ts.shd untouched), so
+      #         "shade once per day" is unaffected
       ############################################################
 
       - alias: "Check for alternate shading position"
@@ -5940,9 +5942,13 @@ actions:
         sequence:
           - variables:
               target_position: "{{ effective_shading_position | int }}"
+              target_tilt_position: "{{ shading_tilt_position | int }}"
               update_values:
-                man: "{{ 0 if force_allows_shade else helper_json.man | default(0) | int }}"
-          - *cover_move_action
+                man: "{{ 0 if force_allows_shade and not in_shading_position else helper_json.man | default(0) | int }}"
+          - if: "{{ force_allows_shade and not in_shading_position }}"
+            then:
+              - *cover_move_action
+              - *tilt_move_action
           - *helper_update
           - stop: "Alternate shading position executed"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,8 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
-<!-- Proposed entry for the next release. Version heading intentionally left as TBD:
-     the maintainer decides the version number / whether to fold this into an existing
-     release or a V2. No version bump was applied to the blueprint itself. -->
-# CCA TBD
+# CCA 2026.07.12
 
-- ✨ **Feature:** New optional **Alternate Sun Shading Position** (in the *Cover Position* settings, next to the normal shading position). You can now define a second shading position together with a switch entity (a `binary_sensor` or `input_boolean`): while that entity is **on**, the cover shades to the alternate position; while it is **off** (or the fields are left empty), it shades to the normal position exactly as before. If the switch changes while the cover is **already shading**, the cover moves to the matching position right away. This only affects the shading *position* — the shading tilt angle is unchanged — and it does **not** count as an additional sun shading, so *"Only shade once per day"* keeps working normally. Leave both fields empty to keep the previous behavior ([#580](https://github.com/hvorragend/ha-blueprints/issues/580))
+- ✨ **Feature:** New optional **Alternate Sun Shading Position** (in the *Cover Position* settings, next to the normal shading position). You can now define a second shading position together with a switch entity (a `binary_sensor` or `input_boolean`): while that entity is **on**, the cover shades to the alternate position; while it is **off** (or the fields are left empty), it shades to the normal position exactly as before. If the switch changes while the cover is **already shading**, the cover moves to the matching position right away (on tilt covers the shading tilt angle is re-applied after the move). This does **not** count as an additional sun shading, so *"Only shade once per day"* keeps working normally. Leave both fields empty to keep the previous behavior ([#580](https://github.com/hvorragend/ha-blueprints/issues/580))
 
 ---
 

--- a/tests/test_alternate_shading_position.py
+++ b/tests/test_alternate_shading_position.py
@@ -411,3 +411,33 @@ class TestReDriveBranch:
             )
         # It may only (optionally) reset the manual flag when it actually drives.
         assert set(uv.keys()) <= {"man"}
+
+    def test_reapplies_shading_tilt_after_position_move(self, branch):
+        """A position drive physically disturbs the slat angle on tilt covers,
+        so the branch must re-apply the shading tilt like every other shading
+        drive site (position + tilt as a pair)."""
+        for step in branch["sequence"]:
+            if isinstance(step, dict) and "variables" in step:
+                assert (
+                    step["variables"].get("target_tilt_position")
+                    == "{{ shading_tilt_position | int }}"
+                )
+                break
+        else:
+            raise AssertionError("variables step not found")
+        seq = str(branch["sequence"])
+        assert "set_cover_tilt_position" in seq
+
+    def test_man_reset_gated_on_actual_drive(self, branch):
+        """Invariant 7: man may only be cleared when the cover actually moves.
+        Both the man template and the drive guard must carry the position check
+        (in the if-guard, not the branch conditions — Invariant 1)."""
+        uv = _branch_update_values(branch)
+        assert "not in_shading_position" in uv["man"]
+        drive_if = next(
+            step["if"]
+            for step in branch["sequence"]
+            if isinstance(step, dict) and "if" in step
+        )
+        assert "not in_shading_position" in str(drive_if)
+        assert "not in_shading_position" not in str(branch["conditions"])


### PR DESCRIPTION
…drive (#580 follow-up)

Two follow-up fixes to the alternate shading position feature (#581):

- The "Check for alternate shading position" branch only drove the cover position. On tilt covers a position drive physically disturbs the slat angle, leaving the tilt off shading_tilt_position and in_shading_position false until the next elevation-stage trigger. The branch now sets target_tilt_position and calls tilt_move_action after cover_move_action, like every other shading drive site (no-op for non-tilt covers).

- man was cleared unconditionally even when cover_move_action's tolerance guard skipped the drive (e.g. alt depth within position_tolerance of the normal depth). The reset and the drive are now gated on not in_shading_position in the if-guard (Invariants 1 + 7, mirrors the Bug Pattern X fix shape).

Also: release as version 2026.07.12 (changelog TBD heading resolved), document the effective_shading_position design decision in CLAUDE.md, and extend the test suite for both fixes (289 passed).


Claude-Session: https://claude.ai/code/session_01K6AMethRFq2fsHVENqT5Ek