### PR TITLE
docs: fix handbook markdown rendering on GitHub Pages

### DIFF
--- a/docs/handbook/actions.md
+++ b/docs/handbook/actions.md
@@ -3,9 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Additional Actions** section of the blueprint.
 
-<center><p><small>
-  All these settings are optional
-</small></p></center>
+All these settings are optional
 
 <a id="auto_up_action_before"></a>
 

--- a/docs/handbook/brightness.md
+++ b/docs/handbook/brightness.md
@@ -3,12 +3,10 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Brightness Configuration** section of the blueprint.
 
-<center><p><small>
-  <strong>Only for morning opening &amp; evening closing!</strong><br />
+<strong>Only for morning opening &amp; evening closing!</strong><br />
   This condition allows the cover to open earlier in the morning or close earlier in the evening,<br />
   triggered by ambient brightness reaching its threshold.<br />
   <strong>This is NOT related to sun protection / shading.</strong>
-</small></p></center>
 
 <a id="default_brightness_sensor"></a>
 

--- a/docs/handbook/conditions.md
+++ b/docs/handbook/conditions.md
@@ -3,9 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Additional Conditions** section of the blueprint.
 
-<center><p><small>
-  All these settings are optional
-</small></p></center>
+All these settings are optional
 
 <a id="auto_global_condition"></a>
 

--- a/docs/handbook/configcheck.md
+++ b/docs/handbook/configcheck.md
@@ -3,7 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Configuration Check** section of the blueprint.
 
-<center><p><small> <strong>🔗 Use the <a href="https://hvorragend.github.io/ha-blueprints/validator/" target="_blank">Online Configuration Validator</a></strong> <br /> Validate your YAML configuration for errors, typos, and deprecated parameters before deploying. <br /> ✅ Instant feedback • 🔍 Typo detection • ⚠️ Migration guidance • 🔒 Privacy-friendly (client-side) </small></p></center>
+<strong>🔗 Use the <a href="https://hvorragend.github.io/ha-blueprints/validator/" target="_blank">Online Configuration Validator</a></strong> <br /> Validate your YAML configuration for errors, typos, and deprecated parameters before deploying. <br /> ✅ Instant feedback • 🔍 Typo detection • ⚠️ Migration guidance • 🔒 Privacy-friendly (client-side)
 
 <a id="check_config"></a>
 

--- a/docs/handbook/contacts.md
+++ b/docs/handbook/contacts.md
@@ -3,11 +3,9 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Contact Sensors for Ventilation** section of the blueprint.
 
-<center><p><small>
-  Settings if the feature ‘💨 - Ventilation Mode — React to open/tilted windows, prevent lockout’ has been activated above.
+Settings if the feature ‘💨 - Ventilation Mode — React to open/tilted windows, prevent lockout’ has been activated above.
   <br />
   All these settings are optional.
-</small></p></center>
 
 <a id="contact_window_opened"></a>
 
@@ -17,21 +15,15 @@
 
 Contact sensor of a door or window handle for detecting <ins>total opening</ins>. If this sensor switches to on/true, the cover is <ins>fully opened</ins>. At the same time, a lockout protection is <ins>always</ins> activated. The cover is not closed and the sun shading is not activated when the contact is open.
 
-<details>
-<summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
-
+### Further descriptions
 
 It must be a binary two-way contact sensor.
 If a three-way sensor is available, it must be converted to a binary two-way sensor using a [template sensor](https://www.home-assistant.io/integrations/template/).
 See also the [following posts](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539/593) in the forum.
 
-
 <strong>Important note:</strong> Please do not enter the same sensor in both fields for the contact sensors. This does not work and leads to strange situations.
 
-
 <strong>If the sensor has no status</strong> — typical for a battery-powered contact after a restart of your hub, which only reports again when the window is next moved — the automation continues with the <ins>last known</ins> window status. It deliberately does not treat the window as closed, because that could lower the cover onto an open window. So while the last known status was <ins>open or tilted</ins>, the automation waits and the cover holds its position; everything resumes as soon as the sensor reports again.
-
-</details>
 
 <a id="contact_window_tilted"></a>
 
@@ -41,21 +33,15 @@ See also the [following posts](https://community.home-assistant.io/t/cover-contr
 
 The contact sensor is required for the <ins>partial</ins> ventilation mode. If the contact changes to on/true, the cover is moved to the <ins>ventilation</ins> position. The prerequisite is that the cover is already closed. After the status changes to off/false, the close position is activated again. The same applies in the shading-out situation.
 
-<details>
-<summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
-
+### Further descriptions
 
 It must be a binary two-way contact sensor.
 If a three-way sensor is available, it must be converted to a binary two-way sensor using a [template sensor](https://www.home-assistant.io/integrations/template/).
 See also the [following posts](https://community.home-assistant.io/t/cover-control-automation-cca-a-comprehensive-and-highly-configurable-roller-blind-blueprint/680539/593) in the forum.
 
-
 <strong>Important note:</strong> Please do not enter the same sensor in both fields for the contact sensors. This does not work and leads to strange situations.
 
-
 <strong>If the sensor has no status</strong> — typical for a battery-powered contact after a restart of your hub, which only reports again when the window is next moved — the automation continues with the <ins>last known</ins> window status. It deliberately does not treat the window as closed, because that could lower the cover onto an open window. So while the last known status was <ins>open or tilted</ins>, the automation waits and the cover holds its position; everything resumes as soon as the sensor reports again.
-
-</details>
 
 <a id="lockout_tilted_options"></a>
 
@@ -72,10 +58,10 @@ For the tilted window (or door, of course), you can individually specify where a
 *Blueprint input: `auto_ventilate_options`*
 
 Various different ventilation options.
-<details> <summary><code><strong>CLICK HERE:</strong> Further descriptions</code></summary>
 
+### Further descriptions
 
-  - <ins>Disables the drive delay when ventilation starts (window opens/tilts):</ins>
+- <ins>Disables the drive delay when ventilation starts (window opens/tilts):</ins>
     <br />
     By default, the "Fixed Drive Delay" and "Random Drive Delay" are applied to all cover movements — including ventilation start.
     If you use a large fixed delay to stagger many covers (e.g. for Somfy RF queue limits), this can feel sluggish when only one or two covers need to react to a window opening.
@@ -109,8 +95,6 @@ Various different ventilation options.
     <br />
     Useful e.g. for a terrace door: after coming back inside and tilting the door, the cover stays up instead of moving down.
 
-</details>
-
 <a id="contact_delay_trigger"></a>
 
 ## 🕛 Contact Trigger Delay
@@ -135,7 +119,6 @@ This delay is applied inside the contact sensor handling. After the delay, CCA r
 - You switch the window contact and the resident sensor off in quick
   succession — with a delay of 0.5–1 s, CCA will see the resident as
   already gone and return to open instead of close
-
 
 **⚠️ Race Condition: Window closed + Resident off in quick succession:**
 If `contact_window_opened` and the resident sensor are turned off within milliseconds of each other, CCA may still see the resident as present at trigger time and incorrectly close the cover. Setting this delay to **0.5–1 second** gives the resident sensor enough time to settle before CCA makes its routing decision.

--- a/docs/handbook/delays.md
+++ b/docs/handbook/delays.md
@@ -3,11 +3,9 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Delay Settings** section of the blueprint.
 
-<center><p><small>
-  Take into account that, for example, waiting times are added when brightness changes or shading is started.
+Take into account that, for example, waiting times are added when brightness changes or shading is started.
   <br />
   It is therefore better to use smaller values here. It is only a matter of separating the different covers in terms of time.
-</small></p></center>
 
 <a id="drive_delay_fix"></a>
 

--- a/docs/handbook/features.md
+++ b/docs/handbook/features.md
@@ -3,9 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Automation Options** section of the blueprint.
 
-<center><p><small>
-  Configure what CCA controls and how it behaves. Most settings use safe defaults. Expand the descriptions below only if you need details.
-</small></p></center>
+Configure what CCA controls and how it behaves. Most settings use safe defaults. Expand the descriptions below only if you need details.
 
 <a id="auto_options"></a>
 
@@ -16,14 +14,11 @@
 Select which opening, closing, and special behaviors CCA should manage.
 *Not sure? The defaults (Morning Opening, Evening Closing, Time Control) work for most setups.*
 
-<details>
-<summary><code><strong>📖 CLICK HERE:</strong> How these options work together</code></summary>
-
+### How these options work together
 
 **Basic Controls (When to move):**
 
 - **Morning Opening / Evening Closing** — Enable automatic opening and/or closing.
-
 
 **Fine-Tuning (When to trigger):**
 
@@ -36,20 +31,17 @@ Early = earliest the cover may move; Late = guaranteed move (safety net).
 Set the condition logic (AND/OR) when both are active.
 Configure thresholds and sensors in the dedicated sections below.
 
-
 **Advanced Features (How to react):**
 
 - **💨 Ventilation** — React to open/tilted windows, prevent lockout.
 
 - **🥵 Sun Protection** — Partially close when sun shines directly on the window (midday heat).
 
-
 **☀️ Sun Elevation vs. 🥵 Sun Protection are two different things!**
 
 - **Sun Elevation** = *When* to open/close (sunrise/sunset trigger) — configure in *Sun Elevation Settings*
 
 - **Sun Protection** = *Shading* during midday when the sun shines directly on the window
-
 
 **Example: Sun Elevation + Time Control (most common setup)**
 
@@ -65,14 +57,10 @@ Configure thresholds and sensors in the dedicated sections below.
 
 - **22:00** — Late closing time → cover would close regardless (safety net)
 
-
 **Notes on multiple triggering**
 
 Even if multiple opening, closing, shading, etc. is activated, this only works if a trigger is available.
 However, the numeric state triggers only trigger under certain circumstances. See: [FAQ: Why are my numeric triggers not firing?](https://hvorragend.github.io/ha-blueprints/FAQ#q-why-are-my-numeric-triggers-not-firing)
-
-
-</details>
 
 <a id="time_control"></a>
 
@@ -82,8 +70,8 @@ However, the numeric state triggers only trigger under certain circumstances. Se
 
 Select how time-based opening and closing is scheduled. *(Only relevant when **Time Control** is enabled above — uncheck **⏲️ Time Control** in the options list to disable the time windows entirely.)*
 
-<details>
-<summary><code><strong>📖 CLICK HERE:</strong> Further descriptions</code></summary>
+### Further descriptions
+
 <br />
 <ins>Input fields for time control</ins><br /><br />
 The times for opening and closing the cover are configured in the Time Control section below.
@@ -104,9 +92,6 @@ windows entirely — Brightness and Sun Elevation triggers may then fire at any 
 <strong>Warning:</strong> without time windows there is no guaranteed <strong>Late</strong>
 opening/closing safety net; the cover only moves when a sensor condition is actually met.
 
-
-</details>
-
 <a id="brightness_sun_operator"></a>
 
 ## 🔀 Condition Logic: Brightness & Sun Elevation
@@ -115,7 +100,7 @@ opening/closing safety net; the cover only moves when a sensor condition is actu
 
 How should Brightness and Sun Elevation conditions be combined when **both** are active?
 
-<details> <summary><code><strong>📖 CLICK HERE:</strong> OR vs. AND - Which to choose?</code></summary>
+### OR vs. AND - Which to choose?
 
 **⚡ OR** *(Default — recommended for most users)*
 The cover opens/closes as soon as **either** condition is met.
@@ -128,7 +113,6 @@ Example: Opens only when it's bright enough *and* the sun is above the threshold
 More conservative — reduces false triggers on overcast mornings.
 
 *Has no effect when only one of the two conditions is enabled.*
-</details>
 
 <a id="individual_config"></a>
 
@@ -138,14 +122,13 @@ More conservative — reduces false triggers on overcast mornings.
 
 **Fine-tune automation behavior for your specific hardware and preferences.**
 
-<details> <summary><code><strong>📖 CLICK HERE:</strong> What each category controls</code></summary>
+### What each category controls
 
 This section lets you customize how CCA behaves in different scenarios:
 - **Position Management**: Control cover movements between states (e.g., avoid raising when closing for the evening)
 - **Feature Control**: Disable automatic transitions (e.g., stay shaded after sun disappears, don't open after ventilation ends)
 - **Daily Frequency Limits**: Prevent repeated actions (e.g., open only once per day)
 - **Hardware Compatibility**: Work around device-specific quirks with position/tilt commands
-
 
 **Hardware-Specific Details**
 
@@ -156,8 +139,5 @@ Some devices (e.g., Shelly, Homematic) have issues when 'set_cover_position' and
 - Shelly: Use script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066)
 - Homematic: Use custom service [homematicip_local.set_cover_combined_position](https://github.com/SukramJ/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position)
 - Other devices: Implement via "Additional Actions" in the Service Calls section
-</details>
-
-</details>
 
 {% endraw %}

--- a/docs/handbook/force.md
+++ b/docs/handbook/force.md
@@ -3,8 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Force Features** section of the blueprint.
 
-<center><p><small>
-  Emergency override controls for weather protection and special scenarios
+Emergency override controls for weather protection and special scenarios
   <br />
   Force functions allow you to immediately move covers to specific positions, overriding all other automation logic.
   <br />
@@ -14,7 +13,6 @@
   <br />
   <br />
   All settings in this section are optional
-</small></p></center>
 
 <a id="auto_recover_after_force"></a>
 
@@ -23,7 +21,8 @@
 *Blueprint input: `auto_recover_after_force`* *(default: `auto_recover_disabled`)*
 
 Seamless control with automatic recovery: When enabled, the cover automatically returns to its intended position when a force function is disabled.
-<details> <summary><code><strong>HOW IT WORKS:</strong> Smart Background Tracking</code></summary>
+
+### How it works: Smart Background Tracking
 
 **Continuous Status Tracking:**
 - The helper constantly monitors what the cover *should* be doing (open, close, shading, ventilate)
@@ -36,8 +35,6 @@ Seamless control with automatic recovery: When enabled, the cover automatically 
 - ❄️ Frost Protection (force-open, auto-resume after sunrise)
 - 🔥 Emergency Scenarios (temporary manual control, then auto-recovery)
 - 🏠 Cleaning/Maintenance (force-open, then auto-return when done)
-
-</details>
 
 <a id="force_pause"></a>
 

--- a/docs/handbook/override.md
+++ b/docs/handbook/override.md
@@ -3,8 +3,6 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Manual Override** section of the blueprint.
 
-<br />
-
 <a id="ignore_after_manual_config"></a>
 
 ## 🖐️ Ignoring/override after manual position changes
@@ -12,7 +10,8 @@
 *Blueprint input: `ignore_after_manual_config`*
 
 Ignore or override the following actions after manual position changes.
-<details> <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
+
+### Further description
 
 Ultimately, this means that the cover will not be opened, closed, etc. if a manual interaction has previously been made, e.g. using a wall switch.
 
@@ -22,10 +21,6 @@ As soon as a cover has been moved manually, the status is recorded in the Cover 
 
   - If option is not activated: The covers are moved even if a manual correction has been made.
   - If option is activated: The action to open, close, etc. is not performed because a conscious decision was made to do otherwise due to a manual intervention.
-
-
-
-</details>
 
 <a id="reset_override_config"></a>
 

--- a/docs/handbook/positions.md
+++ b/docs/handbook/positions.md
@@ -3,15 +3,13 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Cover Position Settings** section of the blueprint.
 
-<center><p><small>
-  <strong>Important notes on configuring the position values</strong>
+<strong>Important notes on configuring the position values</strong>
   <br />
   Please ensure that all position values are unique and do not conflict with each other.
   <br />
   <strong>Position Logic:</strong><br />
   - For Blinds/Shutters: open_position (100%) > shading_position (25%) > close_position (0%)<br />
-  - For Awnings: open_position (0%) < shading_position (75%) < close_position (100%)<br />
-</small></p></center>
+  - For Awnings: open_position (0%) < shading_position (75%) < close_position (100%)
 
 <a id="position_source"></a>
 
@@ -19,13 +17,13 @@
 
 *Blueprint input: `position_source`* *(default: `current_position_attr`)*
 
-How does your cover provide position information? <details> <summary><code><strong>CLICK HERE: When to use each option</strong></code></summary>
+How does your cover provide position information? 
 
-  - **current_position attribute** (Standard): Most covers use this. If CCA detects positions correctly, keep this setting.
+### When to use each option
+
+- **current_position attribute** (Standard): Most covers use this. If CCA detects positions correctly, keep this setting.
   - **position attribute**: Select this if your cover entity has a 'position' attribute but no 'current_position' attribute. Check in Developer Tools → States if unsure.
   - **Custom sensor**:   Use this if: Your cover doesn't report positions at all / You have an external sensor tracking the cover position / Manual position changes aren't detected with the other options
-
-</details>
 
 <a id="custom_position_sensor"></a>
 
@@ -41,9 +39,11 @@ Select sensor that provides position (0-100%). Only used if 'Custom sensor' sele
 
 *Blueprint input: `cover_type`* *(default: `blind`)*
 
-Select the type of cover you want to control. <br /><br /> <strong>Blind/Roller Shutter:</strong> Position 0% = closed (down), 100% = open (up). Shading uses lower positions. <br /><br /> <strong>Awning/Sunshade:</strong> Position 0% = retracted (closed), 100% = extended (open). Shading uses higher positions. <br /><br /> ⚠️ <strong>Note:</strong> Ventilation and tilt features are not available for awnings. <br /><br /> <details> <summary><code><strong>CLICK HERE:</strong> Position value examples</code></summary>
+Select the type of cover you want to control. <br /><br /> <strong>Blind/Roller Shutter:</strong> Position 0% = closed (down), 100% = open (up). Shading uses lower positions. <br /><br /> <strong>Awning/Sunshade:</strong> Position 0% = retracted (closed), 100% = extended (open). Shading uses higher positions. <br /><br /> ⚠️ <strong>Note:</strong> Ventilation and tilt features are not available for awnings.
+
+### Position value examples
+
 <strong>For Blinds/Shutters:</strong><br /> - Open Position: 100% (fully up)<br /> - Shading Position: 25% (partially down for sun protection)<br /> - Ventilate Position: 30% (slightly down for air flow)<br /> - Close Position: 0% (fully down)<br /> <br /> <strong>For Awnings:</strong><br /> - Open Position: 0% (retracted/closed)<br /> - Shading Position: 75% (extended for sun protection)<br /> - Close Position: 100% (fully extended)<br /> <br /> <em>Note: Ventilate Position is not used for awnings.</em>
-</details>
 
 <a id="open_position"></a>
 

--- a/docs/handbook/resident.md
+++ b/docs/handbook/resident.md
@@ -3,8 +3,7 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Resident Settings** section of the blueprint.
 
-<center><p><small>
-  <br />
+<br />
   (1) The purpose of resident mode is to the close the cover (without checking the defined times) when the resident sensor switches to ‘on/true’. For example, when a resident goes to sleep.
   <br />
   (2) The cover will stay closed as long as the sensor remains in this state.
@@ -14,7 +13,6 @@
   (4) In addition, the usual automatic opening of the cover is prevented as long as the sensor is set to ‘on/true’ or the resident.
   <br /><br />
   All these settings are optional.
-</small></p></center>
 
 <a id="resident_sensor"></a>
 

--- a/docs/handbook/shading.md
+++ b/docs/handbook/shading.md
@@ -3,12 +3,11 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Sun Shading / Sun Protection** section of the blueprint.
 
-<center><p><small>
-  Settings if the feature '🥵 - Sun Protection / Shading — Partially close when sun shines on window' has been activated above.
+Settings if the feature '🥵 - Sun Protection / Shading — Partially close when sun shines on window' has been activated above.
   <br />
   All these settings are optional / The attributes of default sun sensor (configured above) is used.
-</small></p></center>
-<details> <summary><code><strong>CLICK HERE:</strong> How the shading process works (two phases)</code></summary>
+
+### How the shading process works (two phases)
 
 **Phase 1 — Pending (trigger):**
 When ANY configured shading trigger fires (sun azimuth, elevation, brightness, temperature, forecast), the automation arms a "pending" timer. This sets the status to <em>t_shading_start_pending</em> and starts the waiting time.
@@ -24,7 +23,6 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 - <strong>Helper shows stale data:</strong> Check the input_text helper entity in Developer Tools → States. Look for <code>"pnd":"beg"</code> and verify that <code>"ts.due"</code> is a valid future timestamp.
 
 **Debugging tip:** Enable the Logbook option and check the automation trace after the waiting time expires. Look for the <em>t_shading_start_execution</em> trigger — if it doesn't appear, the template trigger may not be evaluating correctly. If it appears but the trace shows "conditions not met", check which specific condition fails using Developer Tools → Template.
-</details>
 
 <a id="shading_conditions_start_and"></a>
 
@@ -34,9 +32,7 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 
 **Conditions that MUST ALL be met to START shading**
 
-<details>
-<summary><code><strong>CLICK HERE:</strong> How START conditions work</code></summary>
-
+### How START conditions work
 
 **Required (AND) conditions for START:**
 
@@ -46,13 +42,11 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 
 - Use for critical conditions
 
-
 **Example - Conservative approach:**
 
 - Select ALL: Azimuth, Elevation, Brightness, Temperature
 
 - Result: Shading only when everything is perfect
-
 
 **Example - Flexible approach:**
 
@@ -62,10 +56,7 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 
 - Result: Sun must be in range, plus other criteria
 
-
 **Important:** Conditions without a configured sensor are automatically satisfied (skipped). You can safely leave all conditions selected — only those with a matching sensor configured below will actually be evaluated. However, if a sensor IS configured but returns "unavailable" or "unknown", the condition will FAIL — sun shading then does not start, but the rest of the automation (opening, closing, ventilation) keeps working normally. Once the sensor reports again, the sun shading conditions are re-evaluated, so a shading that was missed while the sensor was down is not lost.
-
-</details>
 
 <a id="shading_conditions_start_or"></a>
 
@@ -74,7 +65,8 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 *Blueprint input: `shading_conditions_start_or`*
 
 **Conditions where AT LEAST ONE must be met to START shading**
-<details> <summary><code><strong>CLICK HERE:</strong> When to use OR conditions</code></summary>
+
+### When to use OR conditions
 
 **Optional (OR) conditions for START:**
 - At least ONE must be valid
@@ -89,7 +81,6 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 
 **Combined logic:**
 - Final = (ALL AND conditions) AND (ONE OR condition)
-</details>
 
 <a id="shading_conditions_end_and"></a>
 
@@ -98,7 +89,8 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 *Blueprint input: `shading_conditions_end_and`*
 
 **Conditions that MUST ALL become invalid to END shading**
-<details> <summary><code><strong>CLICK HERE:</strong> How END conditions work</code></summary>
+
+### How END conditions work
 
 **Required (AND) conditions for END:**
 - ALL selected conditions must become invalid
@@ -116,7 +108,6 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 - Result: Keep shading until BOTH brightness AND temp drop
 
 **Tip:** Usually END should be MORE permissive than START
-</details>
 
 <a id="shading_conditions_end_or"></a>
 
@@ -125,7 +116,8 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 *Blueprint input: `shading_conditions_end_or`* *(default: `['cond_azimuth', 'cond_elevation', 'cond_brightness', 'cond_temp1', 'cond_temp2', 'cond_forecast_temp', 'cond_forecast_weather']`)*
 
 **Conditions where AT LEAST ONE must become invalid to END shading**
-<details> <summary><code><strong>CLICK HERE:</strong> Typical END configurations</code></summary>
+
+### Typical END configurations
 
 **Optional (OR) conditions for END:**
 - At least ONE must become invalid to end
@@ -149,7 +141,6 @@ After the waiting time expires, the automation re-evaluates ALL configured condi
 **Combined logic:**
 - Final = (ALL AND invalid) OR (ONE OR invalid)
 - The AND group and the OR group are themselves combined with **OR** (unlike START, where they are combined with AND). To require several end conditions together, put them ALL in the AND group and leave the OR group empty.
-</details>
 
 <a id="shading_azimuth_start"></a>
 
@@ -270,10 +261,10 @@ Shading will end only when temperature drops below (minimum - hysteresis value) 
 *Blueprint input: `shading_forecast_sensor`*
 
 Weather entity for forecast data (temperature & conditions). This is the primary and recommended method for forecast-based shading.
-<details>
-  <summary><code><strong>CLICK HERE:</strong> How to configure</code></summary>
 
-  Select a weather entity (e.g., weather.home, weather.openweathermap).
+### How to configure
+
+Select a weather entity (e.g., weather.home, weather.openweathermap).
 
   The system will:
 
@@ -292,8 +283,6 @@ Weather entity for forecast data (temperature & conditions). This is the primary
   So you can define via the forecast that shading is only started at an
   expected daily maximum temperature.
 
-</details>
-
 <a id="shading_forecast_type"></a>
 
 ## 📊 Sun Shading - Forecast Source
@@ -309,10 +298,10 @@ Please select whether you want to use the **daily** or **hourly** weather foreca
 *Blueprint input: `shading_forecast_temp_sensor`*
 
 **Alternative method:** Use a sensor that directly provides forecasted max temperature.
-<details>
-  <summary><code><strong>CLICK HERE:</strong> When to use this</code></summary>
 
-  Use this if:
+### When to use this
+
+Use this if:
 
   - Your weather integration provides dedicated forecast sensors
 
@@ -332,8 +321,6 @@ Please select whether you want to use the **daily** or **hourly** weather foreca
 
   **Limitation:** Weather condition checks are not available with sensors.
 
-</details>
-
 <a id="shading_forecast_temp"></a>
 
 ## 📊 Sun Shading - Forecast Temperature Value
@@ -344,19 +331,16 @@ This setting defines the <strong>minimum temperature threshold</strong> based on
 - Minimum temperature threshold for shading activation.
 - Works with both weather entity and temperature sensor.
 - Leave empty to disable temperature-based forecast shading.
-<details>
-  <summary><code><strong>CLICK HERE:</strong> Further description</code></summary>
 
-  To enhance reliability, the system can compare this threshold against two sources:
+### Further description
+
+To enhance reliability, the system can compare this threshold against two sources:
 
   - The forecasted temperature (this comparison is always active)
 
   - Temperature Sensor 2 (e.g. outdoor) (can be enabled via the checkbox in the next configuration field)
 
-
   <strong>Troubleshooting:</strong> If this condition is in your AND list, the forecast source (weather entity or temperature sensor above) MUST provide a valid numeric temperature value. Check Developer Tools → States that your weather entity or sensor shows a numeric temperature, not "unavailable" or "unknown". If the forecast returns no data, this condition will fail and block shading execution.
-
-</details>
 
 <a id="shading_forecast_temp_hysteresis"></a>
 
@@ -384,9 +368,11 @@ Check the following weather conditions when activating the shading. Be cautious 
 
 *Blueprint input: `shading_config`*
 
-These options allow you to fine-tune how the system handles temperature-based shading. <p><em>Click on the titles to get further help.</em></p> <details> <summary><code><strong>Independent Shading via Temperature Comparison</strong></code></summary>
+These options allow you to fine-tune how the system handles temperature-based shading. <p><em>Click on the titles to get further help.</em></p> 
 
-  Enables shading based solely on temperature — <ins>independently of all other conditions</ins> like brightness, sun position (azimuth <em>and</em> elevation), or time of day.
+### Independent Shading via Temperature Comparison
+
+Enables shading based solely on temperature — <ins>independently of all other conditions</ins> like brightness, sun position (azimuth <em>and</em> elevation), or time of day.
   - By default, only the external <em>forecasted temperature</em> is compared with the threshold configured in <em>"Independent Temperature Threshold"</em>.
   - You can also enable another comparison by selecting the other checkbox.
 
@@ -402,15 +388,14 @@ These options allow you to fine-tune how the system handles temperature-based sh
 
   <strong>Note:</strong> The independent path uses its own <em>"Independent Temperature Threshold"</em>, which is separate from <em>"Forecast Temperature Value"</em> used in the normal AND/OR conditions. Set the independent threshold lower to allow early shading on hot days without loosening the normal forecast gate.
 
-</details> <br /> <details> <summary><code><strong>Also trigger if 'Temperature Sensor 2' exceeds 'Forecast Temperature Value'</strong></code></summary>
+### Also trigger if 'Temperature Sensor 2' exceeds 'Forecast Temperature Value'
 
-  This activates an extended comparison for the independent shading path. The shading condition will be true if <em>one</em> of the following conditions is met:
+This activates an extended comparison for the independent shading path. The shading condition will be true if <em>one</em> of the following conditions is met:
   - The external forecasted temperature exceeds the <em>"Independent Temperature Threshold"</em>, or<br />
   - <em>"Temperature Sensor 2"</em> reports a temperature above the <em>"Independent Temperature Threshold"</em>.
 
   This mechanism improves the responsiveness and reliability of the shading system by using real-time sensor input as an optional condition, especially when forecast data is uncertain.
   Note: This function has nothing to do with normal temperature comparison, but is used exclusively in the context of the forecast function.
-</details>
 
 <a id="shading_independent_temp"></a>
 

--- a/docs/handbook/sun.md
+++ b/docs/handbook/sun.md
@@ -3,11 +3,9 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Sun Elevation Settings** section of the blueprint.
 
-<center><p><small>
-  <strong>Only for morning opening &amp; evening closing!</strong><br />
+<strong>Only for morning opening &amp; evening closing!</strong><br />
   This condition opens the cover when the sun rises above a threshold and closes it when the sun drops below a threshold.<br />
   <strong>This is NOT sun protection / shading</strong> (which controls midday partial closing).
-</small></p></center>
 
 <a id="default_sun_sensor"></a>
 

--- a/docs/handbook/time.md
+++ b/docs/handbook/time.md
@@ -3,13 +3,11 @@
 
 > Part of the [CCA Handbook](index). These options live in the **Time Control Configuration** section of the blueprint.
 
-<center><p><small>
-  Configure the time windows for morning opening and evening closing.<br />
+Configure the time windows for morning opening and evening closing.<br />
   Time control can be enabled and the type selected in the <strong>Automation Options</strong> section above.
   <br />
   For comprehensive explanations, examples, and timing diagrams, see:
   <a href="https://hvorragend.github.io/ha-blueprints/TIME_CONTROL_VISUALIZATION">Time Control Guide</a>
-</small></p></center>
 
 <a id="time_up_early"></a>
 
@@ -98,7 +96,8 @@ When <ins>closing</ins> the blinds, you have the option of checking the times fo
 *Blueprint input: `calendar_entity`*
 
 Select a Home Assistant calendar for time control.
-<details> <summary><code><strong>CLICK HERE:</strong> How to use calendar control</code></summary>
+
+### How to use calendar control
 
 **Event Titles (exact match, case-insensitive):**
   - **"Open Cover"** - Marks the daytime window (cover should be open)
@@ -124,8 +123,6 @@ Select a Home Assistant calendar for time control.
   - Can define different times for each day
   - Can create exceptions (holidays, vacations)
   - Changes take effect immediately without automation reload
-
-</details>
 
 <a id="calendar_open_title"></a>
 


### PR DESCRIPTION
kramdown does not process markdown inside block-level HTML, so the <details>/<summary> blocks carried over from the blueprint rendered as one raw-text blob (literal ** and list dashes). The handbook is a reference, so the collapsibles are unwrapped: summaries become h3 headings (CLICK HERE prefixes dropped), the centered small-print section intros become normal paragraphs, dangling <br /> runs before headings removed.


Claude-Session: https://claude.ai/code/session_017SoFLgnTfKJvZAPKTqc5SE