### PR TITLE
Trace tools: resolve branches by alias, not by position

### DIFF
--- a/docs/trace-analyzer/index.html
+++ b/docs/trace-analyzer/index.html
@@ -1457,22 +1457,87 @@
         // Updated for CCA Blueprint v2026.04.x+ (State Machine v6, JSON Helper v6)
         // =====================================================================
 
-        // Branch definitions from CCA Blueprint
-        // Branches 0-11 + Default (Config Check)
+        // Branch definitions from the CCA blueprint, keyed by the branch ALIAS.
+        //
+        // A trace only tells us the POSITIONAL index of the branch that ran
+        // ("action/N/choose/M"), never its name. Resolving M through a hardcoded
+        // index map breaks silently the moment a branch is inserted into the
+        // choose: - which has happened repeatedly, mislabelling every trace from
+        // the insertion point on. Aliases do not move, so they are the key here.
+        //
+        // The index is still needed as a fallback: a truncated trace has no config
+        // section (see repairTruncatedJson), and then the position is all we have.
+        // BRANCH_ORDER is that fallback and MUST match the choose: order.
+        //
+        // tests/test_trace_tools_branch_map.py fails if either the order or a
+        // definition drifts away from the blueprint. Do not hand-edit one without
+        // running the tests.
+        const BRANCH_ORDER = [
+            'Check for opening',
+            'Check for closing cover',
+            'Check for shading start',
+            'Check for shading tilt',
+            'Check for alternate shading position',
+            'Check for shading end',
+            'Contact sensor state changed',
+            'Resident sensor status change handler',
+            'Force function triggered',
+            'Drive to target position after force pause disabled',
+            'Return to background position after force disable',
+            'Checking for manual position changes',
+            'Reset manual detection',
+            'Reset shading status that is no longer required - but still saved',
+            'Recovery after restart or outage - restore target state'
+        ];
+
         const BRANCH_DEFINITIONS = {
-            0: { name: 'Opening', description: 'Automatic cover opening control', icon: '🔼' },
-            1: { name: 'Closing', description: 'Automatic cover closing control', icon: '🔻' },
-            2: { name: 'Shading Start', description: 'Activates sun protection/shading', icon: '☀️' },
-            3: { name: 'Shading Tilt', description: 'Adjusts tilt during active shading', icon: '📐' },
-            4: { name: 'Shading End', description: 'Deactivates sun protection', icon: '🌥️' },
-            5: { name: 'Contact Sensor', description: 'Window/door state changes (ventilation/lockout)', icon: '🪟' },
-            6: { name: 'Resident Update', description: 'Resident sensor changed – updates helper & moves cover', icon: '👤' },
-            7: { name: 'Force Functions', description: 'Forced position via entity (open/close/vent/shade)', icon: '⚡' },
-            8: { name: 'Return After Force', description: 'Returns to background state after force disable', icon: '↩️' },
-            9: { name: 'Manual Detection', description: 'Detects manual position changes', icon: '🖐️' },
-            10: { name: 'Reset Override', description: 'Resets manual override status', icon: '🔄' },
-            11: { name: 'Midnight Reset', description: 'Resets shading status at end of day', icon: '🌙' }
+            'Check for opening': { name: 'Opening', description: 'Automatic cover opening control', icon: '🔼' },
+            'Check for closing cover': { name: 'Closing', description: 'Automatic cover closing control', icon: '🔻' },
+            'Check for shading start': { name: 'Shading Start', description: 'Activates sun protection/shading', icon: '☀️' },
+            'Check for shading tilt': { name: 'Shading Tilt', description: 'Adjusts tilt during active shading', icon: '📐' },
+            'Check for alternate shading position': { name: 'Alternate Shading Position', description: 'Switches between the normal and the alternate shading position', icon: '🔀' },
+            'Check for shading end': { name: 'Shading End', description: 'Deactivates sun protection', icon: '🌥️' },
+            'Contact sensor state changed': { name: 'Contact Sensor', description: 'Window/door state changes (ventilation/lockout)', icon: '🪟' },
+            'Resident sensor status change handler': { name: 'Resident Update', description: 'Resident sensor changed – updates helper & moves cover', icon: '👤' },
+            'Force function triggered': { name: 'Force Functions', description: 'Forced position via entity (open/close/vent/shade)', icon: '⚡' },
+            'Drive to target position after force pause disabled': { name: 'Force Pause Resumed', description: 'Force pause ended – drives to the target state again', icon: '▶️' },
+            'Return to background position after force disable': { name: 'Return After Force', description: 'Returns to background state after force disable', icon: '↩️' },
+            'Checking for manual position changes': { name: 'Manual Detection', description: 'Detects manual position changes', icon: '🖐️' },
+            'Reset manual detection': { name: 'Reset Override', description: 'Resets manual override status', icon: '🔄' },
+            'Reset shading status that is no longer required - but still saved': { name: 'Midnight Reset', description: 'Resets shading status at end of day', icon: '🌙' },
+            'Recovery after restart or outage - restore target state': { name: 'Recovery', description: 'Restores the target state after a restart or an outage', icon: '🩹' }
         };
+
+        const UNKNOWN_BRANCH = { name: null, description: 'Unknown branch', icon: '❓' };
+
+        // Branch aliases of the trace currently loaded. Taken from the trace's own
+        // config when present, so a trace from an older or newer blueprint version
+        // still resolves correctly; falls back to BRANCH_ORDER for truncated traces.
+        let branchAliases = BRANCH_ORDER;
+
+        function branchAliasesFromConfig(config) {
+            const actions = (config && (config.actions || config.action)) || [];
+            for (const step of actions) {
+                const choose = step && step.choose;
+                if (Array.isArray(choose) && choose.length > 5) {
+                    return choose.map(b => (b && b.alias) || null);
+                }
+            }
+            return null;
+        }
+
+        function setBranchAliases(config) {
+            branchAliases = branchAliasesFromConfig(config) || BRANCH_ORDER;
+        }
+
+        function branchDefFor(branchNum) {
+            const alias = branchAliases[branchNum];
+            const def = alias ? BRANCH_DEFINITIONS[alias] : null;
+            if (def) return def;
+            // Unknown alias: a branch this tool has never heard of. Say so instead of
+            // guessing - a confidently wrong label is worse than an honest question mark.
+            return { ...UNKNOWN_BRANCH, name: alias || `Branch ${branchNum}` };
+        }
 
         // Trigger ID explanations
         const TRIGGER_EXPLANATIONS = {
@@ -1838,6 +1903,9 @@
         }
 
         function analyzeTrace(trace) {
+            // Resolve branch names against this trace's own config (see BRANCH_ORDER)
+            setBranchAliases(trace.config);
+
             // Extract main info from trace structure
             const traceInfo = trace.trace || {};
             const lastStep = traceInfo.last_step || 'N/A';
@@ -2408,10 +2476,10 @@
                 const mainAction = getMainChooseAction(innerTrace, lastStep);
 
                 // Analyze all branches to understand which were evaluated
-                for (let i = 0; i < 14; i++) {
+                for (let i = 0; i < branchAliases.length; i++) {
                     const branchPath = `action/${mainAction}/choose/${i}/conditions`;
                     const branchKey = `action/${mainAction}/choose/${i}`;
-                    const branchDef = BRANCH_DEFINITIONS[i];
+                    const branchDef = branchDefFor(i);
 
                     let status = 'skip';
                     let reason = 'Not evaluated';
@@ -2455,9 +2523,9 @@
                         }
                     }
 
-                    const icon = branchDef ? branchDef.icon : '❓';
-                    const name = branchDef ? branchDef.name : `Branch ${i}`;
-                    const desc = branchDef ? branchDef.description : 'Unknown branch';
+                    const icon = branchDef.icon;
+                    const name = branchDef.name;
+                    const desc = branchDef.description;
 
                     let statusIcon = '⊘';
                     if (status === 'pass') statusIcon = '✓';
@@ -2737,12 +2805,12 @@
             const match = lastStep.match(/action\/\d+\/choose\/(\d+)/);
             if (match) {
                 const branchNum = parseInt(match[1]);
-                const branchDef = BRANCH_DEFINITIONS[branchNum];
+                const branchDef = branchDefFor(branchNum);
                 return {
                     number: branchNum,
-                    name: branchDef ? branchDef.name : `Branch ${branchNum}`,
-                    description: branchDef ? branchDef.description : 'Unknown branch',
-                    icon: branchDef ? branchDef.icon : '❓',
+                    name: branchDef.name || `Branch ${branchNum}`,
+                    description: branchDef.description,
+                    icon: branchDef.icon,
                     matched: true,
                     outcome: exec.outcome,
                     stopMsg: exec.stopMsg,

--- a/docs/trace-compare/index.html
+++ b/docs/trace-compare/index.html
@@ -1061,20 +1061,75 @@
         // =====================================================================
 
         // Branches 0-11 + Default (Config Check)
+        // Branch definitions from the CCA blueprint, keyed by the branch ALIAS.
+        //
+        // A trace only tells us the POSITIONAL index of the branch that ran
+        // ("action/N/choose/M"), never its name. Resolving M through a hardcoded
+        // index map breaks silently the moment a branch is inserted into the
+        // choose: - which has happened repeatedly, mislabelling every trace from
+        // the insertion point on. Aliases do not move, so they are the key here.
+        //
+        // BRANCH_ORDER is the fallback for traces whose config section is missing,
+        // and MUST match the choose: order.
+        //
+        // tests/test_trace_tools_branch_map.py fails if either the order or a
+        // definition drifts away from the blueprint.
+        const BRANCH_ORDER = [
+            'Check for opening',
+            'Check for closing cover',
+            'Check for shading start',
+            'Check for shading tilt',
+            'Check for alternate shading position',
+            'Check for shading end',
+            'Contact sensor state changed',
+            'Resident sensor status change handler',
+            'Force function triggered',
+            'Drive to target position after force pause disabled',
+            'Return to background position after force disable',
+            'Checking for manual position changes',
+            'Reset manual detection',
+            'Reset shading status that is no longer required - but still saved',
+            'Recovery after restart or outage - restore target state'
+        ];
+
         const BRANCH_DEFINITIONS = {
-            0: { name: 'Opening', description: 'Automatic cover opening', icon: '🔼' },
-            1: { name: 'Closing', description: 'Automatic cover closing', icon: '🔻' },
-            2: { name: 'Shading Start', description: 'Activates sun protection', icon: '☀️' },
-            3: { name: 'Shading Tilt', description: 'Adjusts tilt during shading', icon: '📐' },
-            4: { name: 'Shading End', description: 'Deactivates sun protection', icon: '🌥️' },
-            5: { name: 'Contact Sensor', description: 'Window/door state change (ventilation/lockout)', icon: '🪟' },
-            6: { name: 'Resident Update', description: 'Resident sensor changed – moves cover', icon: '👤' },
-            7: { name: 'Force Functions', description: 'Forced position (open/close/vent/shade)', icon: '⚡' },
-            8: { name: 'Return After Force', description: 'Returns to background state after force', icon: '↩️' },
-            9: { name: 'Manual Detection', description: 'Manual position change detected', icon: '🖐️' },
-            10: { name: 'Reset Override', description: 'Resets manual override', icon: '🔄' },
-            11: { name: 'Midnight Reset', description: 'End of day reset', icon: '🌙' }
+            'Check for opening': { name: 'Opening', description: 'Automatic cover opening', icon: '🔼' },
+            'Check for closing cover': { name: 'Closing', description: 'Automatic cover closing', icon: '🔻' },
+            'Check for shading start': { name: 'Shading Start', description: 'Activates sun protection', icon: '☀️' },
+            'Check for shading tilt': { name: 'Shading Tilt', description: 'Adjusts tilt during shading', icon: '📐' },
+            'Check for alternate shading position': { name: 'Alternate Shading Position', description: 'Switches between normal and alternate shading position', icon: '🔀' },
+            'Check for shading end': { name: 'Shading End', description: 'Deactivates sun protection', icon: '🌥️' },
+            'Contact sensor state changed': { name: 'Contact Sensor', description: 'Window/door state change (ventilation/lockout)', icon: '🪟' },
+            'Resident sensor status change handler': { name: 'Resident Update', description: 'Resident sensor changed – moves cover', icon: '👤' },
+            'Force function triggered': { name: 'Force Functions', description: 'Forced position (open/close/vent/shade)', icon: '⚡' },
+            'Drive to target position after force pause disabled': { name: 'Force Pause Resumed', description: 'Force pause ended – drives to the target state again', icon: '▶️' },
+            'Return to background position after force disable': { name: 'Return After Force', description: 'Returns to background state after force', icon: '↩️' },
+            'Checking for manual position changes': { name: 'Manual Detection', description: 'Manual position change detected', icon: '🖐️' },
+            'Reset manual detection': { name: 'Reset Override', description: 'Resets manual override', icon: '🔄' },
+            'Reset shading status that is no longer required - but still saved': { name: 'Midnight Reset', description: 'End of day reset', icon: '🌙' },
+            'Recovery after restart or outage - restore target state': { name: 'Recovery', description: 'Restores the target state after a restart or an outage', icon: '🩹' }
         };
+
+        function branchAliasesFromConfig(config) {
+            const actions = (config && (config.actions || config.action)) || [];
+            for (const step of actions) {
+                const choose = step && step.choose;
+                if (Array.isArray(choose) && choose.length > 5) {
+                    return choose.map(b => (b && b.alias) || null);
+                }
+            }
+            return null;
+        }
+
+        function resolveBranch(branchNum, config) {
+            const aliases = branchAliasesFromConfig(config) || BRANCH_ORDER;
+            const alias = aliases[branchNum];
+            const def = alias ? BRANCH_DEFINITIONS[alias] : null;
+            if (def) return { number: branchNum, alias, ...def };
+            // Unknown alias: say so instead of guessing.
+            return { number: branchNum, alias, name: alias || `Branch ${branchNum}`,
+                     description: 'Unknown branch', icon: '❓' };
+        }
 
         // Trigger explanations
         const TRIGGER_EXPLANATIONS = {
@@ -1477,8 +1532,7 @@
             let branch = null;
             const branchMatch = lastStep.match(/choose\/(\d+)/);
             if (branchMatch) {
-                const num = parseInt(branchMatch[1]);
-                branch = { number: num, ...BRANCH_DEFINITIONS[num] };
+                branch = resolveBranch(parseInt(branchMatch[1]), trace.config);
             }
 
             // Status Merger: Treat "finished" and "stopped" as Finished
@@ -1671,12 +1725,12 @@
             if (loadedTraces.length < 2) return;
 
             const branchCounts = {};
-            for (let i = 0; i < 12; i++) branchCounts[i] = 0;
+            BRANCH_ORDER.forEach(alias => { branchCounts[alias] = 0; });
 
             let finished = 0, stopped = 0, failed = 0;
 
             loadedTraces.forEach(t => {
-                if (t.branch) branchCounts[t.branch.number]++;
+                if (t.branch && t.branch.alias in branchCounts) branchCounts[t.branch.alias]++;
                 if (t.state === 'finished') finished++;
                 else if (t.state === 'failed') failed++;
                 else stopped++;
@@ -1999,9 +2053,9 @@
             const counts = Object.values(analyzedData.branchCounts);
             const max = Math.max(...counts, 1);
 
-            container.innerHTML = Object.keys(BRANCH_DEFINITIONS).map(num => {
-                const count = analyzedData.branchCounts[num];
-                const def = BRANCH_DEFINITIONS[num];
+            container.innerHTML = BRANCH_ORDER.map(alias => {
+                const count = analyzedData.branchCounts[alias];
+                const def = BRANCH_DEFINITIONS[alias];
                 return `
                     <div class="branch-stat-item ${count > 0 ? 'active' : ''}">
                         <div class="branch-stat-icon">${def.icon}</div>

--- a/tests/test_trace_tools_branch_map.py
+++ b/tests/test_trace_tools_branch_map.py
@@ -1,0 +1,114 @@
+"""
+The trace tools must agree with the blueprint about which branch is which.
+
+A Home Assistant trace only records the POSITIONAL index of the branch that ran
+("action/N/choose/M"), never its name. The tools therefore resolve M against the
+branch aliases: from the trace's own `config` section when it is present, and
+against the hardcoded BRANCH_ORDER fallback when it is not (a truncated trace has
+no config - see repairTruncatedJson).
+
+That fallback is the part that rots. It has silently drifted out of sync with the
+blueprint every time a branch was inserted into the choose:, and the failure mode is
+the worst kind - the tool does not error, it confidently names the wrong branch. A
+user reports "the cover closed although the window was open", the analyzer says
+"Resident Update", and the branch that actually ran was the contact handler.
+
+These tests make that drift a red suite instead of a support dead end.
+"""
+import json
+import pathlib
+import re
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+BLUEPRINT = ROOT / "blueprints" / "automation" / "cover_control_automation.yaml"
+TOOLS = {
+    "trace-analyzer": ROOT / "docs" / "trace-analyzer" / "index.html",
+    "trace-compare": ROOT / "docs" / "trace-compare" / "index.html",
+}
+
+
+class _Loader(yaml.SafeLoader):
+    pass
+
+
+_Loader.add_constructor("!input", lambda loader, node: ["__input__"])
+
+
+def _blueprint_branch_aliases() -> list[str]:
+    """The aliases of the main dispatch choose, in execution order."""
+    with open(BLUEPRINT, encoding="utf-8") as f:
+        bp = yaml.load(f, Loader=_Loader)
+    for step in bp["actions"]:
+        if isinstance(step, dict) and isinstance(step.get("choose"), list) and len(step["choose"]) > 5:
+            return [b["alias"] for b in step["choose"]]
+    raise AssertionError("main dispatch choose not found in the blueprint")
+
+
+def _js_array(html: str, name: str) -> list[str]:
+    """Pull a `const <name> = [ ... ];` string array out of the tool's JS."""
+    m = re.search(rf"const\s+{name}\s*=\s*\[(.*?)\];", html, re.S)
+    assert m, f"{name} not found"
+    return re.findall(r"'((?:[^'\\]|\\.)*)'", m.group(1))
+
+
+def _js_object_keys(html: str, name: str) -> list[str]:
+    """Pull the quoted keys of a `const <name> = { ... };` object out of the JS."""
+    m = re.search(rf"const\s+{name}\s*=\s*\{{(.*?)\n        \}};", html, re.S)
+    assert m, f"{name} not found"
+    return re.findall(r"^\s{12}'((?:[^'\\]|\\.)*)'\s*:", m.group(1), re.M)
+
+
+@pytest.mark.parametrize("tool", TOOLS)
+class TestBranchMap:
+    def test_fallback_order_matches_the_blueprint(self, tool):
+        """BRANCH_ORDER is what a truncated trace (no config) is resolved against.
+        If it drifts, every trace from the insertion point on is mislabelled."""
+        html = TOOLS[tool].read_text(encoding="utf-8")
+        assert _js_array(html, "BRANCH_ORDER") == _blueprint_branch_aliases()
+
+    def test_every_branch_has_a_definition(self, tool):
+        """A branch with no entry falls back to 'Branch N' / 'Unknown branch'."""
+        html = TOOLS[tool].read_text(encoding="utf-8")
+        defined = set(_js_object_keys(html, "BRANCH_DEFINITIONS"))
+        missing = [a for a in _blueprint_branch_aliases() if a not in defined]
+        assert not missing, f"{tool}: no BRANCH_DEFINITIONS entry for {missing}"
+
+    def test_no_stale_definitions(self, tool):
+        """A leftover entry for a branch that no longer exists is dead weight and a
+        sign the map was edited without looking at the blueprint."""
+        html = TOOLS[tool].read_text(encoding="utf-8")
+        aliases = set(_blueprint_branch_aliases())
+        stale = [k for k in _js_object_keys(html, "BRANCH_DEFINITIONS") if k not in aliases]
+        assert not stale, f"{tool}: BRANCH_DEFINITIONS has entries for unknown branches {stale}"
+
+    def test_the_index_is_not_used_as_the_primary_key(self, tool):
+        """Guard against a revert to `BRANCH_DEFINITIONS[branchNum]`: the whole point is
+        that the index is only the fallback, the alias is the key."""
+        html = TOOLS[tool].read_text(encoding="utf-8")
+        assert not re.search(r"BRANCH_DEFINITIONS\[\s*(branchNum|num|i)\s*\]", html), (
+            f"{tool}: BRANCH_DEFINITIONS is indexed by position again - that is the bug "
+            "this map was restructured to prevent"
+        )
+
+
+class TestConfigResolution:
+    """The tools must prefer the aliases carried in the trace's own config, so a trace
+    from a different blueprint version still resolves correctly."""
+
+    @pytest.mark.parametrize("tool", TOOLS)
+    def test_the_resolver_reads_the_trace_config(self, tool):
+        html = TOOLS[tool].read_text(encoding="utf-8")
+        assert "branchAliasesFromConfig" in html
+        assert re.search(r"(setBranchAliases|resolveBranch)\(.*?\.config", html), (
+            f"{tool}: the resolver never looks at the trace's config section"
+        )
+
+    def test_the_blueprint_aliases_are_unique(self):
+        """Alias-keyed resolution only works while the aliases are unique - which the
+        Code Quality gate in CLAUDE.md requires anyway ('unique alias per branch')."""
+        aliases = _blueprint_branch_aliases()
+        dupes = [a for a in set(aliases) if aliases.count(a) > 1]
+        assert not dupes, f"duplicate branch aliases: {dupes}"


### PR DESCRIPTION
The trace tools name the **wrong branch** for most traces, and have done so silently for a
while. The trace is the primary remote-support instrument, so a confidently wrong label is
worse than no tool at all.

396 tests pass.

---

## The cause

Both tools identify the branch that ran by parsing the trace path and looking the number up in
a static map:

```js
const match = lastStep.match(/action\/\d+\/choose\/(\d+)/);
const branchNum = parseInt(match[1]);
const branchDef = BRANCH_DEFINITIONS[branchNum];
```

`M` in `action/N/choose/M` is the **positional index** of the branch in the `choose:` list —
not the `# BRANCH (n)` number in the YAML comments (those carry `3b` / `8a` suffixes and were
never the index). The map is therefore only correct as long as nobody inserts a branch. Two
were inserted without updating it:

- `Check for alternate shading position` (#580) → index 4
- `Drive to target position after force pause disabled` → index 9

## What the tools report today

| `choose` index | tools say | branch that actually ran | |
|---|---|---|---|
| 0–3 | Opening / Closing / Shading Start / Shading Tilt | *(same)* | ✅ |
| 4 | Shading End | **Check for alternate shading position** | ❌ |
| 5 | Contact Sensor | Check for shading end | ❌ |
| 6 | Resident Update | **Contact sensor state changed** | ❌ |
| 7 | Force Functions | Resident sensor status change handler | ❌ |
| 8 | Return After Force | Force function triggered | ❌ |
| 9 | Manual Detection | **Drive to target position after force pause disabled** | ❌ |
| 10 | Reset Override | Return to background position after force disable | ❌ |
| 11 | Midnight Reset | Checking for manual position changes | ❌ |
| 12–14 | *(no entry)* | Reset manual detection / Midnight Reset / Recovery | ❌ |

A user reports *"the cover closed although the window was open"*, uploads a trace, and the
analyzer says **Resident Update** — while the branch that actually ran was the **contact
handler**.

On top of that, the analyzer hardcoded a 14-branch loop and trace-compare a 12-branch one,
both short of the actual 15.

## The fix

**The alias is reachable.** A downloaded HA trace carries the automation `config`, which
contains each branch's `alias:`. The tools do not normally discard it — `config` is only
stripped inside `repairTruncatedJson()`, the fallback for traces that were pasted truncated:

```js
// Strategy 1: Cut off at "config" section - we don't need it!
// The config section contains static blueprint YAML, not runtime data
```

So the alias is available in the happy path and missing exactly in the degraded path, where a
positional index is all that is left. The index map therefore cannot simply be deleted — it has
to stay as the fallback, but it must stop being the primary key:

- **`BRANCH_DEFINITIONS` is keyed by the branch `alias`.** Aliases do not move when a branch is
  inserted, and they are already required to be unique and descriptive (a Code-Quality gate in
  `CLAUDE.md`).
- **The branch is resolved against the aliases in the trace's own `config`**, so a trace from a
  different blueprint version still resolves correctly.
- **`BRANCH_ORDER`** is the fallback for configless (truncated) traces, and is the only
  positional thing left.
- **An unknown alias shows the alias itself** instead of guessing a name.
- The hardcoded `14` / `12` loop bounds are gone.

Verified against a simulated trace:

| | before | after |
|---|---|---|
| `choose/6` (with config) | Resident Update | **Contact Sensor** |
| `choose/14` | *(no entry)* | **Recovery** |
| configless trace | — | falls back to `BRANCH_ORDER`, correct |
| trace from a blueprint with a different branch count | mislabelled | **correct** |
| branch the tool has never seen | wrong label | shows the alias |

## The test

`tests/test_trace_tools_branch_map.py` pins the contract for **both** tools:

- `BRANCH_ORDER` must equal the blueprint's `choose:` aliases, in order
- every branch must have a `BRANCH_DEFINITIONS` entry
- no stale entries for branches that no longer exist
- the index must not become the primary key again (guards against a revert to
  `BRANCH_DEFINITIONS[branchNum]`)
- the resolver must actually read the trace's `config`
- the blueprint's branch aliases must be unique — alias-keying depends on it

Mutation-verified: dropping a branch from `BRANCH_ORDER`, and reverting to the index lookup,
each turn the suite red.

The map has drifted three times in the same way. This is what stops the fourth.
