### PR TITLE
feat: make restart/outage recovery opt-in, disabled by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -505,6 +505,20 @@ is accepted and healed by the re-drive trigger).
 
 Two halves of one mechanism. Neither works without the other.
 
+**The recovery half is opt-in (`enable_recovery`, default `false`, CCA 2026.07.13).**
+Users reported unwanted cover movements right after a HA restart — the recovery is
+*supposed* to move the cover when the cascade demands it (e.g. applying a stored
+shading intent or catching up a missed opening), but many users prefer "never touch
+the covers after a restart" over catching up. All 12 `t_recovery` triggers carry
+`enabled: "{{ is_recovery_enabled and ... }}"`, so with the switch off no recovery
+run ever starts (no trace, no drive, no helper write — same rationale as #550:
+filter at the trigger). Consequence with the switch off: every "Repaired by
+BRANCH 12" entry in the orphan-audit table below does **not** apply — dropped
+events stay dropped until the next regular trigger, which is the documented
+pre-2026.07.12 behavior the user explicitly chose. **Half 1 (the gate) is
+independent of the switch and always active** — it only prevents wrong movements
+and wrong helper writes, it never causes any.
+
 #### Half 1 — the gate (global conditions)
 
 Three tiers, and the tier a source belongs to is decided by **what CCA can do without it**.

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.12 V3
+    **Version**: 2026.07.13
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -28,7 +28,7 @@ blueprint:
 
         Using a cover group? See [FAQ: Can I use a cover group?](https://hvorragend.github.io/ha-blueprints/FAQ#q-can-i-use-a-cover-group)
 
-        While the cover is unavailable (e.g. during a restart), the automation pauses — without a position it cannot decide anything. As soon as the cover is back, it catches up on everything that was missed in the meantime.
+        While the cover is unavailable (e.g. during a restart), the automation pauses — without a position it cannot decide anything. To catch up on missed events once the cover is back, enable **🔄 Recovery after a restart or an outage** in the *Automation Options*.
 
       selector:
         entity:
@@ -168,6 +168,24 @@ blueprint:
               sort: false
               custom_value: false
               mode: list
+
+        enable_recovery:
+          name: "🔄 Recovery after a restart or an outage"
+          description: >-
+            When enabled, CCA recalculates the target state after a Home Assistant restart
+            (or after a required source becomes usable again) and catches up on everything
+            that was missed in the meantime: a missed opening/closing is performed, the sun
+            shading conditions are re-evaluated, and a force function switched during the
+            outage is applied. **This can move the cover right after a restart.**
+
+            When disabled (default), the cover is never touched after a restart — but events
+            that fell into the restart or outage are lost: a missed closing simply does not
+            happen until the next regular trigger fires.
+
+            📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/features#enable_recovery).
+          default: false
+          selector:
+            boolean: {}
 
     position_section:
       name: "Cover Position Settings"
@@ -2299,6 +2317,11 @@ trigger_variables:
   # Ventilation and tilt are only available for blinds, not awnings
   is_ventilation_enabled: "{{ not is_awning and 'auto_ventilate_enabled' in auto_options }}"
 
+  # Recovery after restart/outage (t_recovery -> BRANCH 12). Opt-in: when disabled,
+  # no recovery trigger fires and the cover is never moved after a restart - missed
+  # events stay missed. The availability gates are independent and always active.
+  is_recovery_enabled: !input enable_recovery
+
   # Reset override flag computation
   reset_override_config: !input reset_override_config
   reset_override_time: !input reset_override_time
@@ -2346,7 +2369,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.12 V3"
+  version: "2026.07.13"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -3453,6 +3476,7 @@ triggers:
   - trigger: homeassistant
     event: start
     id: "t_recovery"
+    enabled: "{{ is_recovery_enabled }}"
 
   - trigger: state
     entity_id: !input blind
@@ -3463,6 +3487,7 @@ triggers:
     id: "t_recovery"
     for: &recovery_settle
       seconds: 30
+    enabled: "{{ is_recovery_enabled }}"
 
   - trigger: state
     entity_id: !input cover_status_helper
@@ -3470,7 +3495,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ cover_status_helper != [] }}"
+    enabled: "{{ is_recovery_enabled and cover_status_helper != [] }}"
 
   - trigger: state
     entity_id: !input custom_position_sensor
@@ -3478,7 +3503,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ position_source == 'custom_sensor' and custom_position_sensor != [] }}"
+    enabled: "{{ is_recovery_enabled and position_source == 'custom_sensor' and custom_position_sensor != [] }}"
 
   - trigger: state
     entity_id: !input contact_window_opened
@@ -3486,7 +3511,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_ventilation_enabled and contact_window_opened != [] }}"
+    enabled: "{{ is_recovery_enabled and is_ventilation_enabled and contact_window_opened != [] }}"
 
   - trigger: state
     entity_id: !input contact_window_tilted
@@ -3494,7 +3519,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_ventilation_enabled and contact_window_tilted != [] }}"
+    enabled: "{{ is_recovery_enabled and is_ventilation_enabled and contact_window_tilted != [] }}"
 
   - trigger: state
     entity_id: !input resident_sensor
@@ -3502,7 +3527,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ resident_sensor != [] }}"
+    enabled: "{{ is_recovery_enabled and resident_sensor != [] }}"
 
   # Condition-only sources
   - trigger: state
@@ -3511,7 +3536,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_shading_enabled and default_brightness_sensor != [] }}"
+    enabled: "{{ is_recovery_enabled and is_shading_enabled and default_brightness_sensor != [] }}"
 
   - trigger: state
     entity_id: !input default_sun_sensor
@@ -3519,7 +3544,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_shading_enabled and default_sun_sensor != [] }}"
+    enabled: "{{ is_recovery_enabled and is_shading_enabled and default_sun_sensor != [] }}"
 
   - trigger: state
     entity_id: !input shading_forecast_sensor
@@ -3527,7 +3552,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_shading_enabled and shading_forecast_sensor != [] }}"
+    enabled: "{{ is_recovery_enabled and is_shading_enabled and shading_forecast_sensor != [] }}"
 
   - trigger: state
     entity_id: !input calendar_entity
@@ -3535,7 +3560,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ is_calendar_enabled and calendar_entity != [] }}"
+    enabled: "{{ is_recovery_enabled and is_calendar_enabled and calendar_entity != [] }}"
 
   - trigger: state
     entity_id: !input workday_sensor
@@ -3543,7 +3568,7 @@ triggers:
     not_to: *invalid_recovery_states
     id: "t_recovery"
     for: *recovery_settle
-    enabled: "{{ workday_sensor_today != [] }}"
+    enabled: "{{ is_recovery_enabled and workday_sensor_today != [] }}"
 
   # Resets
   - trigger: template

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.13
+
+- ⚠️ **Change:** The **recovery after a restart or an outage** (introduced in `2026.07.12`) is now **opt-in and disabled by default**. Several users do not want their covers to move right after a Home Assistant restart — the recovery recalculates the target state from scratch and drives the cover if it is not where the cascade says it should be (e.g. catching up on a missed opening or applying a stored sun-shading intent). A new switch **"🔄 Recovery after a restart or an outage"** in the *Automation Options* section controls the feature: when **off** (default), no recovery run is triggered at all — the cover is never touched after a restart, at the cost that events which fell into the restart/outage stay lost until the next regular trigger fires (the pre-`2026.07.12` behavior). When **on**, everything works exactly as introduced in `2026.07.12`. The availability protection from `2026.07.12` (pausing while the cover, status helper, or position sensor has no usable state, plus the last-known fallbacks for window contacts and the resident sensor) is **independent of this switch and always active** — it only prevents wrong movements and wrong helper writes, it never causes any
+
+---
+
 # CCA 2026.07.12 V3
 
 - 🔧 **Improvement:** Internal architecture rework ("transition architecture"), no functional change intended. Every branch of the action tree now computes exactly two things — the state transition (`update_values`) and an optional actuation plan (`drive_plan`: drive yes/no, target position/tilt, action set, pre-drive delay) — and hands both to a single shared epilogue (`apply_transition`) that performs *delay → drive → helper write* in a fixed order. The helper write is unconditional in that epilogue, so **every execution path is terminal by construction**: the "pending armed forever because a path ended without a helper write" bug class (e.g. [#395](https://github.com/hvorragend/ha-blueprints/issues/395) and the two 2026.07.01 fixes) can no longer be reintroduced by a single forgotten step. A new test suite enforces this structurally

--- a/docs/handbook/features.md
+++ b/docs/handbook/features.md
@@ -5,7 +5,7 @@
 
 Configure what CCA controls and how it behaves. Most settings use safe defaults. Expand the descriptions below only if you need details.
 
-**On this page:** [👉 What should CCA control?](#auto_options) · [⏲️ Time Control Type](#time_control) · [🔀 Condition Logic: Brightness & Sun Elevation](#brightness_sun_operator) · [⚙️ Behavior Customization](#individual_config)
+**On this page:** [👉 What should CCA control?](#auto_options) · [⏲️ Time Control Type](#time_control) · [🔀 Condition Logic: Brightness & Sun Elevation](#brightness_sun_operator) · [⚙️ Behavior Customization](#individual_config) · [🔄 Recovery after a restart or an outage](#enable_recovery)
 
 ---
 
@@ -150,6 +150,27 @@ Some devices (e.g., Shelly, Homematic) have issues when 'set_cover_position' and
 - Shelly: Use script [cover_position_tilt.yaml](https://gist.github.com/lukasvice/b364724d84c3ac4e160f7a7d8fa37066)
 - Homematic: Use custom service [homematicip_local.set_cover_combined_position](https://github.com/SukramJ/custom_homematic?tab=readme-ov-file#homematicip_localset_cover_combined_position)
 - Other devices: Implement via "Additional Actions" in the Service Calls section
+
+---
+
+<a id="enable_recovery"></a>
+
+## 🔄 Recovery after a restart or an outage
+
+> 🧩 Input: `enable_recovery` · Default: `false`
+
+When enabled, CCA recalculates its target state after a Home Assistant restart — and whenever a required source (the cover, the status helper, a position sensor, a window contact, …) becomes usable again after an outage. It then catches up on everything that was missed in the meantime:
+
+- A missed scheduled/calendar **opening or closing** is performed.
+- The **sun-shading conditions** are re-evaluated: if shading is due now, it starts; if it is over, it ends.
+- A **force function** switched on or off during the outage is applied.
+- A **manual-override reset** whose moment fell into the outage is caught up.
+
+**This can move the cover right after a restart** — for example, a shading intent stored before the restart is applied, or a missed morning opening is caught up. A manual override always survives the recovery; only the lockout protection (window fully open) takes precedence.
+
+When **disabled** (default), no recovery run is triggered at all: the cover is never touched after a restart. The trade-off is that events which fell into the restart or outage stay lost — a closing scheduled during a restart simply does not happen, and sun-shading changes that occurred during the outage are not replayed. The automation resumes with the next regular trigger.
+
+**Independent of this switch**, CCA always pauses while the cover, the status helper, or the configured position sensor has no usable state (nothing can be decided without a position), and window contacts / the resident sensor fall back to their last known value while a battery sensor is silent. That protection only *prevents* wrong movements — it never causes any.
 
 ---
 

--- a/docs/validator/validator.js
+++ b/docs/validator/validator.js
@@ -17,7 +17,7 @@ class CCAValidator {
             'alias', 'description', 'trace', 'use_blueprint', 'id', 'mode', 'max', 'max_exceeded',
 
             // Core
-            'blind', 'cover_type', 'auto_options', 'individual_config',
+            'blind', 'cover_type', 'auto_options', 'individual_config', 'enable_recovery',
 
             // Helper
             'cover_status_helper', 'drive_time',

--- a/tests/test_restart_recovery.py
+++ b/tests/test_restart_recovery.py
@@ -508,6 +508,21 @@ class TestRecoveryTriggers:
         gate = [ln for ln in text.splitlines() if "t_calendar_event_start|t_recovery" in ln]
         assert gate, "t_recovery missing from the weather.get_forecasts gate"
 
+    def test_recovery_is_opt_in_and_defaults_to_off(self):
+        """Users must explicitly opt in to cover movements after a restart. Every
+        t_recovery trigger is gated at the trigger (no run, no trace, no drive
+        while disabled - same rationale as the #550 trigger-level filtering)."""
+        for t in self._recovery():
+            assert "is_recovery_enabled" in t.get("enabled", ""), t
+        section = BP["blueprint"]["input"]["feature_section"]["input"]
+        assert section["enable_recovery"]["default"] is False
+
+    def test_recovery_flag_is_a_static_trigger_variable(self):
+        """`enabled:` is evaluated in the limited trigger context (Invariant 10) -
+        the flag must be a plain !input, not a template calling states()."""
+        assert "is_recovery_enabled" in BP["trigger_variables"]
+        assert "states(" not in str(BP["trigger_variables"]["is_recovery_enabled"])
+
 
 # ════════════════════════════════════════════════════════════════════════════
 # Invariant 13: the top-level choose is a trigger.id dispatcher


### PR DESCRIPTION
The full recovery after a restart or an outage (2026.07.12) recalculates
the target state and drives the cover if it is not where the cascade says
it should be - which is exactly what some users do not want: covers must
never move right after a Home Assistant restart.

A new switch 'Recovery after a restart or an outage' (enable_recovery,
Automation Options, default off) now gates all 12 t_recovery triggers via
enabled:, so with the switch off no recovery run ever starts - no trace,
no drive, no helper write. Missed events then stay missed until the next
regular trigger fires (the pre-2026.07.12 behavior).

The availability gates from 2026.07.12 (block while cover/helper/position
sensor are unusable, last-known fallbacks for contacts and resident) are
independent of the switch and stay always active - they only prevent
wrong movements, they never cause any.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K6sNVMnZwECyWBRGbxbpyK