### PR TITLE
fix: the VENT floor ignores a sun- or brightness-driven opening

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,7 +50,9 @@ The variable `effective_state` returns the currently active state from this casc
 
 **Rationale for BASE=OPN before VENT:** A tilted window signals ventilation intent — and a fully open cover provides maximum airflow. So when the time schedule says "open" (`bas=opn`) and nothing else lowers the cover, opening wins over the tilted-vent floor. VENT is a *floor* only when the cover would otherwise go below ventilation position (close, shading, privacy-close, or base=opn with `allow_open=false`).
 
-**BASE=OPN beats VENT only when an opening schedule actually exists** (`is_opening_scheduled = is_up_enabled and not is_time_control_disabled`). `bas` initializes to `'opn'` and is only ever switched to `'cls'` by the scheduled close handler — so in a shading-only setup with no schedule, `bas` stays `'opn'` permanently. Without the schedule gate the VENT floor could never apply there (Issue #553, Bug Pattern Z). When no opening schedule exists, a tilted window therefore still produces `vnt`.
+**BASE=OPN beats VENT only when an opening automation actually exists** (`is_opening_scheduled`). `bas` initializes to `'opn'` and is only ever switched to `'cls'` by the close handler — so in a shading-only setup with no opening automation, `bas` stays `'opn'` permanently. Without the gate the VENT floor could never apply there (Issue #553, Bug Pattern Z). When no opening automation exists, a tilted window therefore still produces `vnt`.
+
+The flag mirrors the `enabled:` gates of the **opening triggers**, not the time control switch: `bas` only ever reaches `'opn'` through the opening handler, and that handler is reached by four sources — time fields (`t_open_1/2`), calendar (`t_calendar_event_start`), brightness (`t_open_4`) and sun elevation (`t_open_5`). The latter two open the cover with time control switched **off** (the opening branch passes them through via `is_time_control_disabled`), so their `bas: 'opn'` is a real intent too. Gating on `not is_time_control_disabled` misread it as the init default and let VENT drag an open cover down to the ventilation position (Bug Pattern AL).
 
 Implementation: `effective_state` first computes `base_target` (the cover state without VENT consideration: `cls`, `shd`, or `opn`), then applies VENT when `win == 'tlt'` and `not (base_target == 'opn' and is_opening_scheduled)`.
 
@@ -1067,7 +1069,7 @@ suppressed **every** manual position trigger fired while the cover is within tol
 
 **Cause:** `bas` initializes to `'opn'` in every init path (fresh init, v6 parse fallback `default('opn')`, v5 migration unless the v5 state was explicitly `close`) and is **only ever** switched to `'cls'` by the scheduled close handler (`t_close_*`, which needs `auto_down_enabled` + a time/calendar source). Without a schedule, `bas` stays `'opn'` forever → `base_target == 'opn'` → the VENT floor condition (`base_target != 'opn'`) is never true → a closed cover ignores a tilted window. The `2026.05.24` changelog had documented "remove the time schedule (so `bas` never reaches `opn`)" as the way to restore v5 behavior — but removing the schedule does **not** make `bas` non-`opn`, so that workaround never worked.
 
-**Fix:** Gate the BASE=OPN-beats-VENT rule on whether an opening schedule actually exists. New `trigger_variables` flag:
+**Fix:** Gate the BASE=OPN-beats-VENT rule on whether an opening automation actually exists. New `trigger_variables` flag (the `not is_time_control_disabled` clause shipped here was too narrow — see Bug Pattern AL for the current definition):
 
 ```yaml
 is_opening_scheduled: "{{ is_up_enabled and not is_time_control_disabled }}"
@@ -1273,6 +1275,29 @@ Gating `is_time_field_enabled`/`is_calendar_enabled` on the checkbox is essentia
 - "Move cover after shading end" wrapped its whole body in `if not prevent_flags.opening_after_shading_end` with **no else**, followed by `stop:`. With the prevent option set and tilt not possible (the tilt-only branch requires tilt), the sequence stopped without a helper write.
 
 **Fix:** Give every drive choose inside the execution handlers a `default:` that records the state and clears the pending, and give every `if:` before a `stop:` an `else:` that clears the pending. See the "Every execution path must be terminal" rule in Invariant 8.
+
+---
+
+### Bug Pattern AL: The VENT floor gate reads "opening is scheduled" as "opening is *time*-scheduled"
+
+**Symptom:** In a setup that opens the cover by **sun elevation** or **brightness** with time control switched **off** (`auto_up_enabled` + `auto_sun_enabled` / `auto_brightness_enabled`, no `time_control_enabled`), the morning opening drives the cover to the open position as expected — but tilting a window afterwards **pulls it back down** to the ventilation position. With time control enabled the identical situation keeps the cover open. The helper shows `bas: 'opn'`, `win: 'tlt'`, and the trace shows `effective_state == 'vnt'`.
+
+**Cause:** `is_opening_scheduled` — the gate that lets BASE=OPN beat the VENT floor (Bug Pattern Z) — was `is_up_enabled and not is_time_control_disabled`. Its purpose is to tell a **real** `bas: 'opn'` (written by the opening handler) apart from the **init default** (`bas` starts at `'opn'` and only the close handler ever moves it). But `bas` reaches `'opn'` through *any* opening trigger, and time control is only two of the four sources: `t_open_4` (brightness) and `t_open_5` (sun elevation) are gated on their own feature flags alone, and the opening branch explicitly passes them through while time control is off (`is_time_control_disabled` is the first alternative of its scenario OR). So a sun-driven opening set `bas: 'opn'` legitimately, and the gate then classified it as the init default and applied the VENT floor to it.
+
+**Fix:** Mirror the `enabled:` gates of the opening triggers instead of the time control switch:
+
+```yaml
+is_opening_scheduled: >-
+  {{ is_up_enabled and (
+       is_time_field_enabled or
+       is_calendar_enabled or
+       (is_brightness_enabled and default_brightness_sensor != []) or
+       (is_sun_elevation_enabled and default_sun_sensor != [])) }}
+```
+
+The sensor-presence clauses are not cosmetic: `t_open_4` / `t_open_5` carry `enabled: "{{ is_brightness_enabled and default_brightness_sensor != [] }}"` (resp. the sun sensor), so a feature flag without its sensor enables no trigger and must not lift the floor. #553 stays fixed by construction — a shading-only setup has no `auto_up_enabled`, and `auto_up_enabled` with *every* source switched off (which has no opening trigger either, so `bas` really is stuck at its default) also still ventilates. `recovered_state` reads the same variable, so the recovery mirror follows automatically (Invariant 13).
+
+**Rule:** A flag that asks "did an automation really write this state?" must be derived from the **triggers that write it**, not from one of the feature switches that happens to enable some of them. Whenever a new source for an existing handler is added, every "does this handler exist?" flag has to be re-derived — the same upstream/downstream mismatch as Bug Pattern AA, just in the variables instead of the gates. `tests/test_opening_schedule_gate.py` pins the flag against the real trigger `enabled:` templates so a fifth opening source cannot silently drift.
 
 ---
 

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.13 V4
+    **Version**: 2026.07.13 V5
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -2371,11 +2371,20 @@ trigger_variables:
   # selector value 'time_control_disabled' is no longer evaluated (its stored configs are
   # disabled via the missing checkbox anyway, matching their original intent).
   is_time_control_disabled: "{{ 'time_control_enabled' not in auto_options }}"
-  # An open base state ('opn') only reflects a real "schedule wants open" intent when an
-  # opening schedule actually exists. Without one, bas stays at its 'opn' init default forever
-  # (it is only ever driven to 'cls' by the scheduled close handler), so the VENT floor could
-  # never apply. Used by effective_state to let VENT beat a non-scheduled bas='opn'.
-  is_opening_scheduled: "{{ is_up_enabled and not is_time_control_disabled }}"
+  # An open base state ('opn') only reflects a real "open" intent when an opening automation
+  # exists that can drive bas to 'opn'. Without one, bas stays at its 'opn' init default forever
+  # (it is only ever driven to 'cls' by the close handler), so the VENT floor could never apply.
+  # The gate therefore mirrors the enabled: gates of the opening triggers: time fields and
+  # calendar are only two of the four sources - brightness and sun elevation open the cover
+  # without any time control (the opening branch passes them through via is_time_control_disabled)
+  # and their bas='opn' is just as real. Used by effective_state (and its recovery mirror) to let
+  # VENT beat a bas='opn' that no opening automation ever set.
+  is_opening_scheduled: >-
+    {{ is_up_enabled and (
+         is_time_field_enabled or
+         is_calendar_enabled or
+         (is_brightness_enabled and default_brightness_sensor != []) or
+         (is_sun_elevation_enabled and default_sun_sensor != [])) }}
 
   # Ventilation and tilt are only available for blinds, not awnings
   is_ventilation_enabled: "{{ not is_awning and 'auto_ventilate_enabled' in auto_options }}"
@@ -2433,7 +2442,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.13 V4"
+  version: "2026.07.13 V5"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.13 V5
+
+- 🐛 **Fix:** If you open the cover by **sun elevation or brightness with the time control switched off**, a **tilted window pulled the freshly opened cover back down** to the ventilation position — and it stayed there until the next day (or until a force function moved it). The rule that an open cover wins over the ventilation position ("a fully open cover ventilates best") only recognised an opening driven by the **time schedule or the calendar** as a real one; an opening driven by the sun or by brightness was mistaken for the untouched starting value and was overruled by the ventilation position. All four opening sources now count equally. Setups **without any opening automation** (sun shading only) are unaffected: there the ventilation position still applies to a tilted window, exactly as since `2026.05.31`
+
+---
+
 # CCA 2026.07.13 V4
 
 - 🐛 **Fix:** An unavailable **entity of a force function** read as "switched off" — so an outage of that entity (it may be a switch or a binary sensor, not just a helper toggle) **silently cancelled the running force function** and let the cover drive to its scheduled position. This was permanent: the force triggers only react to a real *off → on* / *on → off* change, so an entity returning from "unavailable" straight to "on" never re-activated the force. CCA now keeps the **last known force function** while its entity has no usable status, and re-reads it as soon as the entity reports again — a force function that was genuinely switched off during the outage is still recognised and ended correctly

--- a/tests/test_opening_schedule_gate.py
+++ b/tests/test_opening_schedule_gate.py
@@ -1,0 +1,193 @@
+"""is_opening_scheduled - the gate that lets BASE=OPN beat the VENT floor.
+
+The flag answers exactly one question: "is bas == 'opn' a real open intent, or is it
+just the init default that nothing ever moves?" (Issue #553, Bug Pattern Z). bas is
+only ever driven to 'opn' by the opening handler, and the opening handler only runs on
+a t_open_* / t_calendar_event_start trigger - so the flag must be true iff at least one
+of those triggers is enabled. Time control is only two of the four sources: brightness
+and sun elevation open the cover with time control switched off (Bug Pattern AL).
+
+The tests therefore render the real flag out of the blueprint and compare it against the
+real `enabled:` templates of the real opening triggers - a new opening source that forgets
+to update the flag fails here.
+"""
+import pathlib
+
+import jinja2
+import pytest
+import yaml
+
+
+BLUEPRINT_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "blueprints"
+    / "automation"
+    / "cover_control_automation.yaml"
+)
+
+
+def _load_blueprint() -> dict:
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    # An unconfigured !input is [] in HA; a configured one is set per test config below.
+    _Loader.add_constructor("!input", lambda loader, node: [])
+    with open(BLUEPRINT_PATH, encoding="utf-8") as f:
+        return yaml.load(f, Loader=_Loader)  # noqa: S506
+
+
+BP = _load_blueprint()
+TRIGGER_VARS = BP["trigger_variables"]
+
+# The trigger_variables the flag is built from, in blueprint order.
+DERIVED = [
+    "is_calendar_enabled",
+    "is_up_enabled",
+    "is_brightness_enabled",
+    "is_sun_elevation_enabled",
+    "is_time_field_enabled",
+    "is_time_control_disabled",
+    "is_opening_scheduled",
+]
+
+# Every trigger that can drive bas to 'opn' (i.e. that the opening branch dispatches on).
+OPENING_TRIGGER_IDS = ["t_open_1", "t_open_2", "t_open_4", "t_open_5", "t_calendar_event_start"]
+
+env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+
+
+def _render_bool(template: str, variables: dict) -> bool:
+    """Render and parse like HA does - a bare 'false' string would be TRUTHY."""
+    out = env.from_string(template).render(**variables).strip()
+    if out == "True":
+        return True
+    if out == "False":
+        return False
+    return bool(out)
+
+
+def _config(auto_options, time_control="time_control_input", calendar_entity=None,
+            brightness_sensor=None, sun_sensor="sun.sun") -> dict:
+    """A user config, as the !input values reach trigger_variables ([] = not configured)."""
+    return {
+        "auto_options": auto_options,
+        "time_control": time_control,
+        "calendar_entity": calendar_entity if calendar_entity is not None else [],
+        "default_brightness_sensor": brightness_sensor if brightness_sensor is not None else [],
+        "default_sun_sensor": sun_sensor if sun_sensor is not None else [],
+    }
+
+
+def _trigger_vars(config: dict) -> dict:
+    """Render the derived trigger_variables in blueprint order, feeding each into the next."""
+    variables = dict(config)
+    for key in DERIVED:
+        variables[key] = _render_bool(TRIGGER_VARS[key], variables)
+    return variables
+
+
+def _opening_triggers_enabled(config: dict) -> bool:
+    """True when at least one real opening trigger is enabled for this config."""
+    variables = _trigger_vars(config)
+    for trigger in BP["triggers"]:
+        if trigger.get("id") in OPENING_TRIGGER_IDS:
+            if _render_bool(trigger["enabled"], variables):
+                return True
+    return False
+
+
+class TestFlagMirrorsTheOpeningTriggers:
+    """is_opening_scheduled == is_up_enabled and (any opening trigger enabled)."""
+
+    CONFIGS = {
+        "time schedule": _config(["auto_up_enabled", "time_control_enabled"]),
+        "calendar": _config(
+            ["auto_up_enabled", "time_control_enabled"],
+            time_control="time_control_calendar",
+            calendar_entity="calendar.covers",
+        ),
+        "sun only, no time control": _config(["auto_up_enabled", "auto_sun_enabled"]),
+        "brightness only, no time control": _config(
+            ["auto_up_enabled", "auto_brightness_enabled"],
+            brightness_sensor="sensor.brightness",
+        ),
+        "sun + time control": _config(
+            ["auto_up_enabled", "auto_sun_enabled", "time_control_enabled"]
+        ),
+        # Issue #553: shading-only, no opening automation at all -> bas stays at its init default
+        "shading only": _config(["auto_shading_enabled", "auto_ventilate_enabled"]),
+        # auto_up checked but every source switched off -> no opening trigger exists either
+        "opening enabled without any source": _config(["auto_up_enabled"], time_control=[]),
+        # source checked but its sensor is missing -> the trigger is disabled
+        "sun enabled without a sun sensor": _config(
+            ["auto_up_enabled", "auto_sun_enabled"], sun_sensor=[]
+        ),
+        "brightness enabled without a sensor": _config(
+            ["auto_up_enabled", "auto_brightness_enabled"]
+        ),
+        # opening automation off, but the sources are on (they only close then)
+        "closing only, sun": _config(["auto_down_enabled", "auto_sun_enabled"]),
+    }
+
+    @pytest.mark.parametrize("name", list(CONFIGS))
+    def test_flag_is_true_exactly_when_an_opening_trigger_can_fire(self, name):
+        config = self.CONFIGS[name]
+        variables = _trigger_vars(config)
+        expected = variables["is_up_enabled"] and _opening_triggers_enabled(config)
+        assert variables["is_opening_scheduled"] is expected, name
+
+
+class TestVentFloorAgainstTheRealCascade:
+    """End-to-end: the real effective_state, driven by the real flag."""
+
+    def _effective_state(self, config: dict, helper: dict, tilted: bool) -> str:
+        variables = _trigger_vars(config)
+        entity_states = {"binary_sensor.tilted": "on" if tilted else "off"}
+        cascade_env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+        cascade_env.globals["states"] = lambda entity_id: entity_states.get(entity_id, "unknown")
+        variables.update(
+            helper_json=helper,
+            resident_config=[],
+            state_resident=False,
+            contact_window_opened=[],
+            contact_window_tilted="binary_sensor.tilted",
+        )
+        return cascade_env.from_string(BP["variables"]["effective_state"]).render(**variables).strip()
+
+    OPEN_BASE = {"bas": "opn", "shd": 0, "frc": "non", "win": "tlt"}
+
+    def test_sun_driven_opening_beats_the_vent_floor(self):
+        """Bug Pattern AL: the sun opening drove bas to 'opn' - that is a real open intent,
+        so a tilted window must not pull the cover back down to the ventilation position."""
+        config = _config(["auto_up_enabled", "auto_sun_enabled", "auto_ventilate_enabled"])
+        assert self._effective_state(config, self.OPEN_BASE, tilted=True) == "opn"
+
+    def test_brightness_driven_opening_beats_the_vent_floor(self):
+        config = _config(
+            ["auto_up_enabled", "auto_brightness_enabled", "auto_ventilate_enabled"],
+            brightness_sensor="sensor.brightness",
+        )
+        assert self._effective_state(config, self.OPEN_BASE, tilted=True) == "opn"
+
+    def test_time_driven_opening_beats_the_vent_floor(self):
+        config = _config(
+            ["auto_up_enabled", "time_control_enabled", "auto_ventilate_enabled"]
+        )
+        assert self._effective_state(config, self.OPEN_BASE, tilted=True) == "opn"
+
+    def test_shading_only_setup_still_ventilates(self):
+        """Issue #553 stays fixed: with no opening automation, bas='opn' is the init
+        default and the VENT floor must apply."""
+        config = _config(["auto_shading_enabled", "auto_ventilate_enabled"])
+        assert self._effective_state(config, self.OPEN_BASE, tilted=True) == "vnt"
+
+    def test_opening_enabled_without_any_source_still_ventilates(self):
+        """Same as #553: the checkbox alone drives nothing, so bas='opn' is still the default."""
+        config = _config(["auto_up_enabled", "auto_ventilate_enabled"], time_control=[])
+        assert self._effective_state(config, self.OPEN_BASE, tilted=True) == "vnt"
+
+    def test_closed_base_still_ventilates_with_a_sun_schedule(self):
+        """The gate only lifts the floor for bas='opn' - a closed base keeps the vent floor."""
+        config = _config(["auto_up_enabled", "auto_sun_enabled", "auto_ventilate_enabled"])
+        helper = {"bas": "cls", "shd": 0, "frc": "non", "win": "tlt"}
+        assert self._effective_state(config, helper, tilted=True) == "vnt"


### PR DESCRIPTION
## Symptom

With an opening driven by **sun elevation or brightness while time control is switched off**
(`auto_up_enabled` + `auto_sun_enabled` / `auto_brightness_enabled`, no `time_control_enabled`),
the morning opening works — and then a **tilted window pulls the freshly opened cover back down**
to the ventilation position. It stays there for the rest of the day (until the next morning's
opening trigger, or a force function). With time control enabled, the identical situation keeps
the cover open.

The helper shows `bas: 'opn'`, `win: 'tlt'`, and the trace shows `effective_state == 'vnt'`.

## Cause

`is_opening_scheduled` — the gate added in #553 that lets BASE=OPN beat the VENT floor — was:

```yaml
is_opening_scheduled: "{{ is_up_enabled and not is_time_control_disabled }}"
```

Its job is to tell a **real** `bas: 'opn'` (written by the opening handler) apart from the
**init default** (`bas` starts at `'opn'` and only the close handler ever moves it away).
But `bas` reaches `'opn'` through *any* opening trigger, and time control is only two of the
four sources:

| Trigger | `enabled:` gate |
|---|---|
| `t_open_1` / `t_open_2` | `is_time_field_enabled` |
| `t_calendar_event_start` | `is_calendar_enabled` |
| `t_open_4` (brightness) | `is_brightness_enabled and default_brightness_sensor != []` |
| `t_open_5` (sun elevation) | `is_sun_elevation_enabled and default_sun_sensor != []` |

The last two fire with time control switched off, and the opening branch explicitly passes them
through — `is_time_control_disabled` is the *first* alternative of its scenario OR. So a
sun-driven opening legitimately wrote `bas: 'opn'`, and the gate then classified it as the
untouched init default and applied the VENT floor to it.

**Regression from #553** (`e90913c`, merged 2026-06-28, shipped in `2026.06.28 V2`), which
introduced the flag. Before it, the VENT condition was a plain `base_target != 'opn'`, so every
`bas: 'opn'` beat the floor regardless of which trigger had written it — correct for these
setups. #553 needed to tell a *written* `bas` apart from the *default* one and reached for the
time control switch to do it.

## Fix

Mirror the `enabled:` gates of the opening triggers instead of the time control switch:

```yaml
is_opening_scheduled: >-
  {{ is_up_enabled and (
       is_time_field_enabled or
       is_calendar_enabled or
       (is_brightness_enabled and default_brightness_sensor != []) or
       (is_sun_elevation_enabled and default_sun_sensor != [])) }}
```

The sensor-presence clauses are load-bearing, not cosmetic: `t_open_4` / `t_open_5` are gated on
`is_X_enabled and <sensor> != []`, so a feature flag without its sensor enables no trigger and
must not lift the floor.

**#553 stays fixed by construction:**

- a shading-only setup has no `auto_up_enabled` → flag stays `false` → a tilted window still
  drives to the ventilation position;
- `auto_up_enabled` with *every* source switched off has no opening trigger either, so `bas`
  really is stuck at its init default → the floor still applies (this case was not covered by
  the old definition at all).

**Recovery (Invariant 13):** `recovered_state` mirrors the `effective_state` cascade by hand and
reads the same `is_opening_scheduled`, so it follows automatically — no second edit needed, and
`TestCascadeParity` covers both. `recovered_base` *does* gate on `is_time_control_disabled`, but
that is a different question and deliberately stays: without a time schedule there is nothing to
re-derive a base state *from* (`is_daytime_phase` is unconditionally `true` then, so the branch
would blindly write `opn` — at night, too), so it keeps the helper's last written value. A
sun-driven opening missed during an outage is therefore not caught up; that is a known
limitation, not a wrong drive.

## Tests

New `tests/test_opening_schedule_gate.py` renders the flag **and** the real trigger `enabled:`
templates out of the blueprint and asserts

> `is_opening_scheduled` is true **iff** `is_up_enabled` and at least one opening trigger is enabled

across ten configurations (time / calendar / sun / brightness / no source / source without its
sensor / closing-only), plus end-to-end checks of the real `effective_state` cascade. A fifth
opening source can therefore not silently drift away from the flag.

Reverting the blueprint change makes 4 of these tests fail. Full suite: 564 passed.

## Not covered here (possible follow-up)

A config with `auto_up_enabled` but **no** opening source at all (no time control, no calendar,
no sun, no brightness) has no opening trigger — the cover can never open, and nothing warns
about it. `check_config` could catch this; happy to add it if wanted.
