### PR TITLE
Fix handbook link in Sun Shading section description

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.07.14 V2
+    **Version**: 2026.07.19
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
@@ -1146,7 +1146,7 @@ blueprint:
           All these settings are optional / The attributes of default sun sensor (configured above) is used.
         </small></p></center>
 
-        📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/contacts#contact_delay_status).
+        📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/shading).
       icon: mdi:shield-sun-outline
       collapsed: true
       input:
@@ -2517,7 +2517,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.07.14 V2"
+  version: "2026.07.19"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.07.19
+
+- 🐛 **Fix:** The handbook link in the description of the **Sun Shading / Sun Protection** section pointed to the contact-sensor page (`handbook/contacts#contact_delay_status`) instead of the shading page. It now links to `handbook/shading`
+
+---
+
 # CCA 2026.07.14 V2
 
 - 🔧 **Improvement:** A **sun shading that survived midnight** is now treated as proof that CCA was blocked for a whole day (the nightly 23:55 clean-up would otherwise have cleared it — think of a global condition that stayed false for days). The next run tidies up **first** instead of acting on the days-old shading state — previously it could drive straight into a shading position from last week. Deliberately conservative: an old-but-clean status is left alone, because quiet stretches are normal — a setup whose opening and closing times come from the calendar *time control* ("Open Cover"/"Close Cover" events) may legitimately skip whole weekends without a single run


### PR DESCRIPTION
The section description of 'Sun Shading / Sun Protection' linked to the contact-sensor handbook page (handbook/contacts#contact_delay_status) instead of the shading page. Point it to handbook/shading.

Bump version to 2026.07.19.


Claude-Session: https://claude.ai/code/session_01JafK4uJJ1t75Uc1kLDsf2n