### PR TITLE
fix: report a scheduling config that has no trigger source at all

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -62,6 +62,8 @@ blueprint:
 
             *Not sure? The defaults (Morning Opening, Evening Closing, Time Control) work for most setups.*
 
+            *⚠️ For a fixed-time schedule (open/close at set times, no sensors), **⏲️ Time Control must stay checked** — it is the only trigger for Morning Opening and Evening Closing then. Unchecking it disables both entirely.*
+
 
             📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/features#auto_options).
 
@@ -78,7 +80,7 @@ blueprint:
                   value: "auto_up_enabled"
                 - label: "🔻 Evening Closing — Automatically close the cover each evening"
                   value: "auto_down_enabled"
-                - label: "⏲️ Time Control — Use time windows (Early/Late) to constrain when triggers fire"
+                - label: "⏲️ Time Control — Open/close at the Early/Late times; without Brightness/Sun sensors this is the only opening/closing trigger"
                   value: "time_control_enabled"
                 - label: "🔅 Brightness Control — Trigger opening/closing based on ambient brightness sensor"
                   value: "auto_brightness_enabled"
@@ -96,7 +98,7 @@ blueprint:
         time_control:
           name: "⏲️ Time Control Type"
           description: >-
-            Select how time-based opening and closing is scheduled. *(Only relevant when **⏲️ Time Control** is checked in the **👉 What should CCA control?** list above — uncheck it there to disable the time windows entirely.)*
+            Select how time-based opening and closing is scheduled. *(Only relevant when **⏲️ Time Control** is checked in the **👉 What should CCA control?** list above — uncheck it there to disable the time windows entirely. Careful: without Brightness/Sun sensors the time windows are the only opening/closing trigger, so unchecking stops automatic opening and closing altogether.)*
 
             📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/features#time_control).
 
@@ -7444,6 +7446,18 @@ actions:
                 # ========== RUNTIME CONFIGURATION CHECKS ==========
                 # Only runtime checks remain here. Static configuration checks have been moved
                 # to the online validator: https://hvorragend.github.io/ha-blueprints/validator/
+
+                # ========== SCHEDULING CHECKS ==========
+
+                - condition: >-
+                    {{
+                      (is_up_enabled or is_down_enabled) and
+                      not is_time_field_enabled and
+                      not is_calendar_enabled and
+                      not (is_brightness_enabled and default_brightness_sensor != []) and
+                      not (is_sun_elevation_enabled and default_sun_sensor != [])
+                    }}
+                  message: "Morning Opening / Evening Closing is enabled but has NO trigger source: Time Control is disabled (or the calendar has no entity) and no Brightness/Sun sensor is configured. The cover will never open or close automatically. For fixed-time schedules, enable the '⏲️ Time Control' checkbox in 'What should CCA control?' - the Early/Late time fields are the schedule. Configurations saved before ~2026.05 must re-enable this checkbox once (breaking change 2026.07.12)"
 
                 # ========== ENTITY ATTRIBUTE & STATE CHECKS ==========
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # CCA 2026.07.19
 
+- 🔧 **Improvement:** A configuration with **Morning Opening / Evening Closing enabled but no trigger source at all** — ⏲️ Time Control unchecked (or its calendar without an entity) and no Brightness/Sun sensor configured — is now reported instead of failing silently. Such a cover can never move automatically, and after the `2026.07.12` breaking change this is exactly the state that configurations from before ~2026.05 wake up in (user reports: *"evening closing and morning opening no longer work at all"*). The **✔️ Check Configuration** run (manual start) now names the problem in the log, and the [online validator](https://hvorragend.github.io/ha-blueprints/validator/) reports it as an **error** — including the case where a leftover legacy `time_control: time_control_disabled` silently selects no time source even though the checkbox is on
+- 🔧 **Improvement:** The **⏲️ Time Control texts** no longer describe the feature only as a *constraint* on other triggers. For a pure fixed-time schedule ("just close at 22:00", no sensors) the Early/Late time fields **are** the schedule — unchecking ⏲️ Time Control disables opening/closing entirely. The checkbox label, the section help texts, the handbook and the FAQ now say so explicitly, and the FAQ gained a step-by-step checklist for *"I checked Time Control and it still does not open/close"*
+- 🔧 **Improvement:** The validator's messages about **parameters removed in older CCA versions** now say explicitly that the leftover lines are ignored, harmless, and can simply be deleted — they previously read as if the configuration itself were broken
 - 🐛 **Fix:** The handbook link in the description of the **Sun Shading / Sun Protection** section pointed to the contact-sensor page (`handbook/contacts#contact_delay_status`) instead of the shading page. It now links to `handbook/shading`
 
 ---

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -214,6 +214,15 @@ auto_options:
 
 **How the breakage shows up:** With **pure time/calendar control**, the covers simply **stop opening/closing**. With a **hybrid setup (time + Brightness or Sun Elevation)**, the opposite happens: the sensor triggers keep firing but lose their time fence — the covers **open too early in the morning** (e.g. around sunrise, when the sun/brightness threshold is crossed, instead of waiting for the configured earliest time) and can **close too late in the evening**. If your covers suddenly move at unusual times after updating, check the **⏲️ Time Control** checkbox and re-save the automation (see [#595](https://github.com/hvorragend/ha-blueprints/issues/595)).
 
+**"I checked ⏲️ Time Control and it still does not open/close"** — work through this checklist:
+
+1. It must be the **checkbox** in the **👉 What should CCA control?** list — not the **Time Control Type** dropdown. The dropdown only picks the source (time fields vs. calendar) and does nothing while the checkbox is off.
+2. **Time Control Type** must be **"✏️ Use the time input fields"** (`time_control_input`) for fixed times. A leftover legacy value `time_control_disabled` selects *no* time source even with the checkbox on — the [validator](https://hvorragend.github.io/ha-blueprints/validator/) flags this.
+3. **Save the automation in the UI** (or reload automations if you edited the YAML file directly) — trigger switches are only re-evaluated when the automation reloads.
+4. A common trap: the update to a version with the new checkbox does **not** mean you should *uncheck* it because you "don't use sensors". The opposite is true — **for a pure fixed-time schedule the Early/Late time fields are the only trigger**, and they only exist while ⏲️ Time Control is checked. "Just close at 22:00" = ⏲️ Time Control ON + *Drive down early* = 22:00.
+5. Then run the automation **manually once** with **✔️ Check Configuration** enabled — a configuration without any opening/closing trigger source is reported in the log by name.
+6. Deprecated keys that the validator flags in your YAML (from older CCA versions) are **ignored by the automation and do no harm** — they cannot cause this problem; delete them at your leisure.
+
 **Backward compatibility:**
 - The `brightness_sun_operator` parameter (AND/OR link between brightness and sun conditions) has moved to this section as well. Its value is preserved; only the UI location changed.
 

--- a/docs/handbook/features.md
+++ b/docs/handbook/features.md
@@ -30,6 +30,9 @@ Select which opening, closing, and special behaviors CCA should manage.
 Keep this ON even when using Brightness or Sun Elevation — the time fields set the boundaries.
 Early = earliest the cover may move; Late = guaranteed move (safety net).
 **Uncheck to disable all time windows** (pure sensor control — no guaranteed Late safety net).
+**⚠️ Without Brightness/Sun sensors the time windows are the *only* opening/closing trigger** —
+a fixed-time schedule ("just close at 22:00") *is* Time Control. Unchecking it then disables
+Morning Opening and Evening Closing entirely, even though both stay checked in this list.
 
 - **🔅 Brightness** / **☀️ Sun Elevation** — Additional triggers that fire *within* the time window.
 Set the condition logic (AND/OR) when both are active.
@@ -98,6 +101,9 @@ list to disable the time windows entirely — Brightness and Sun Elevation trigg
 fire at any time of day.
 <strong>Warning:</strong> without time windows there is no guaranteed <strong>Late</strong>
 opening/closing safety net; the cover only moves when a sensor condition is actually met.
+And without any Brightness/Sun sensors there is <strong>no opening/closing trigger left at
+all</strong> — a pure fixed-time setup must keep <strong>⏲️ Time Control</strong> checked,
+because the Early/Late time fields <em>are</em> its schedule.
 
 ---
 

--- a/docs/validator/validator.js
+++ b/docs/validator/validator.js
@@ -209,6 +209,7 @@ class CCAValidator {
                     message += ` Use '${info.replacement}' instead.`;
                 }
                 message += ` Migration: ${info.migration}`;
+                message += ` (This leftover line comes from an older CCA version; it is ignored and does no harm - you can simply delete it.)`;
                 this.addWarning(message);
             }
         }
@@ -413,9 +414,19 @@ class CCAValidator {
         // matches blueprint is_time_control_disabled
         const isTimeControlDisabled = !autoOptions.includes('time_control_enabled');
 
+        // A sensor trigger source exists only when the feature is enabled AND its sensor is set;
+        // matches the source list of the blueprint's is_opening_scheduled gate.
+        const hasSensorSource =
+            (autoOptions.includes('auto_brightness_enabled') && c.default_brightness_sensor && c.default_brightness_sensor.length > 0) ||
+            (autoOptions.includes('auto_sun_enabled') && c.default_sun_sensor && c.default_sun_sensor.length > 0);
+        const upDownEnabled = autoOptions.includes('auto_up_enabled') || autoOptions.includes('auto_down_enabled');
+
         if (isTimeControlDisabled) {
             this.addInfo('⏰ Time control is disabled (time_control_enabled not in auto_options) - skipping time validation');
             this.addWarning('⚠️ Breaking change (2026.07.12): time control is disabled whenever "time_control_enabled" is missing from auto_options. If this configuration predates the options consolidation (~2026.05) and you still want time windows, add time_control_enabled to auto_options.');
+            if (upDownEnabled && !hasSensorSource) {
+                this.addError('🚫 Morning Opening / Evening Closing is enabled but has NO trigger source: time control is disabled and no Brightness/Sun sensor is configured - the cover will NEVER open or close automatically. For a fixed-time schedule (e.g. close at 22:00) Time Control IS the schedule: add time_control_enabled to auto_options (check "⏲️ Time Control" in the UI) and set the Early/Late time fields.');
+            }
             if (autoOptions.includes('auto_sun_enabled') || autoOptions.includes('auto_brightness_enabled')) {
                 this.addWarning('⚠️ Sun Elevation / Brightness triggers are enabled WITHOUT time windows: they fire as soon as their threshold is crossed - covers may open around sunrise instead of a configured earliest time, and close late in the evening (issue #595). If that is not intended, add time_control_enabled to auto_options.');
             }
@@ -424,6 +435,9 @@ class CCAValidator {
 
         if (timeControl === 'time_control_disabled') {
             this.addWarning('⚠️ time_control: time_control_disabled is obsolete and no longer evaluated. Time control is enabled (time_control_enabled in auto_options) but no time source is selected - set time_control to time_control_input or time_control_calendar.');
+            if (upDownEnabled && !hasSensorSource) {
+                this.addError('🚫 Morning Opening / Evening Closing is enabled but has NO trigger source: the stored legacy value time_control: time_control_disabled selects no time source, and no Brightness/Sun sensor is configured - the cover will NEVER open or close automatically. Set time_control to time_control_input (UI: "Time Control Type" → "Use the time input fields") to make the Early/Late time fields the schedule again.');
+            }
             return;
         }
 


### PR DESCRIPTION
An opening/closing automation with time control unchecked and no brightness/sun sensor can never fire - exactly the state pre-2026.05 configs woke up in after the #544 breaking change. The manual config check and the online validator now name it, the time-control texts say that fixed-time schedules ARE time control, and the FAQ gained a troubleshooting checklist (user report: firebowl, community forum).


Claude-Session: https://claude.ai/code/session_01XdCoMv7YEJHr8QoLXqjqky