### PR TITLE
Fix broken links in blueprint description and shading section

### DIFF
--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -7,8 +7,8 @@ blueprint:
     **Version**: 2026.07.25
 
     ### 🔗 Resources & Support
-    📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#-key-features)
-    🚀 **Setup**: [Quick Start Guide](https://hvorragend.github.io/ha-blueprints/#-quick-start-5-steps) | [Prerequisites](https://hvorragend.github.io/ha-blueprints/#-essential-prerequisites)
+    📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#key-features)
+    🚀 **Setup**: [Quick Start Guide](https://hvorragend.github.io/ha-blueprints/#quick-start-5-steps) | [Prerequisites](https://hvorragend.github.io/ha-blueprints/#essential-prerequisites)
     📚 **Docs**: 📖 [Handbook](https://hvorragend.github.io/ha-blueprints/handbook/) | ❓ [FAQ](https://hvorragend.github.io/ha-blueprints/FAQ) | ☀️ [Dynamic Sun Elevation](https://hvorragend.github.io/ha-blueprints/DYNAMIC_SUN_ELEVATION) | ⏰ [Time Control Visualization](https://hvorragend.github.io/ha-blueprints/TIME_CONTROL_VISUALIZATION)
     🔧 **Validator**: Validate YAML for errors, typos, and deprecated parameters with the [CCA Configuration Validator](https://hvorragend.github.io/ha-blueprints/validator/)
     ✨ **Online Tools**:  🔍 [CCA Trace Analyzer](https://hvorragend.github.io/ha-blueprints/trace-analyzer/) | 📈 [CCA Trace Compare](https://hvorragend.github.io/ha-blueprints/trace-compare/)
@@ -1147,9 +1147,9 @@ blueprint:
           Settings if the feature '🥵 - Sun Protection / Shading — Partially close when sun shines on window' has been activated above.
           <br />
           All these settings are optional / The attributes of default sun sensor (configured above) is used.
+          <br />
+          📖 More details in the <a href="https://hvorragend.github.io/ha-blueprints/handbook/shading">CCA Handbook</a>.
         </small></p></center>
-
-        📖 More details in the [CCA Handbook](https://hvorragend.github.io/ha-blueprints/handbook/shading).
       icon: mdi:shield-sun-outline
       collapsed: true
       input:


### PR DESCRIPTION
- The CCA Handbook link in the Sun Shading / Sun Protection section
  description was shown as raw markdown text, because Home Assistant
  renders section descriptions as HTML, not markdown. Converted to an
  HTML anchor inside the existing <small> block, matching the style of
  the other sections.
- The Key Features, Quick Start Guide and Prerequisites links in the
  blueprint description used outdated anchors (#-key-features,
  #-quick-start-5-steps, #-essential-prerequisites) left over from
  emoji headings; the docs start page headings have no emojis, so the
  links opened at the top of the page. Updated to the current anchors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FfdZ3R7DWMvdQzhq8akYDD