### PR TITLE
fix: tilted window keeps ventilation when opened contact is unavailable

### DIFF
--- a/.claude/skills/cca-assistant/SKILL.md
+++ b/.claude/skills/cca-assistant/SKILL.md
@@ -41,7 +41,7 @@ loading the reference first:
 | Anything that looks inconsistent and invites "harmonizing" (resident/override gates, pending preserve vs. discard, invalid sensor states, #558/#580) | [references/design-decisions.md](references/design-decisions.md) |
 | Availability gates, `t_recovery`, `automation_resumed`, the recovery gate — or adding any new gate that can stop a run | [references/recovery.md](references/recovery.md) (includes the orphan-audit checklist) |
 | Live opening/closing branch entry conditions, `base_gates`, `closing_position_hold`, the caught-up base flip — or adding any new gate to the live open/close branch | [references/recovery-parity.md](references/recovery-parity.md) (semantic contract, decision matrix, shared projections) |
-| Debugging a regression, changing global conditions / trigger `enabled:` / helper-JSON regexes / flow handoffs | [references/bug-patterns.md](references/bug-patterns.md) (patterns A–AS with cause and fix) |
+| Debugging a regression, changing global conditions / trigger `enabled:` / helper-JSON regexes / flow handoffs | [references/bug-patterns.md](references/bug-patterns.md) (patterns A–AT with cause and fix) |
 
 The always-binding rules (the 15 invariants as one-liners, code style, quality
 gates, version bumping) are indexed in `.claude/CLAUDE.md`.
@@ -181,7 +181,7 @@ prevent_flags:
 
 ### Normalized event flags (computed once per run — use these, not raw sensor idioms)
 ```yaml
-window_opened_now / window_tilted_now / window_any_now / window_opened_clear
+window_opened_now / window_tilted_now / window_any_now
 lockout_now.closing / .shading_start / .shading_end
 shading_once_guard_ok
 drive_delay_standard
@@ -296,7 +296,7 @@ Full rules: Invariant 12 in [references/invariants.md](references/invariants.md)
 
 ### Regressions
 Match the symptom against [references/bug-patterns.md](references/bug-patterns.md)
-(A–AS, each with symptom / cause / fix / derived rule) before writing a fix —
+(A–AT, each with symptom / cause / fix / derived rule) before writing a fix —
 most "new" bugs are a documented pattern reaching a new code path.
 
 ---

--- a/.claude/skills/cca-assistant/references/architecture.md
+++ b/.claude/skills/cca-assistant/references/architecture.md
@@ -125,10 +125,12 @@ the anchor definitions and the v5→v6 migration persist.
 
 **Event normalization** (post-forecast variables block): the live sensor idioms
 are computed once per run and referenced by all branch conditions —
-`window_opened_now`, `window_tilted_now`, `window_any_now`,
-`window_opened_clear` (explicitly closed/unconfigured — NOT the negation of
-`window_opened_now`; an unavailable sensor is neither), `lockout_now.closing/
+`window_opened_now`, `window_tilted_now`, `window_any_now`, `lockout_now.closing/
 shading_start/shading_end`, `shading_once_guard_ok`, `drive_delay_standard`.
+An invalid (unavailable/unknown) contact reads as "off" in every handler —
+tilted branches gate on `not window_opened_now`, never on an explicit
+"opened reads closed" check (a stricter `window_opened_clear` variant existed
+until 2026.08.13 and caused Bug Pattern AT / #650).
 The contact handler re-reads the sensors **after its settle delay** into local
 `contact_opened_now` / `contact_tilted_now` / `was_ventilating` — do not replace
 those with the trigger-time globals. `override_blocks.opening/closing/

--- a/.claude/skills/cca-assistant/references/bug-patterns.md
+++ b/.claude/skills/cca-assistant/references/bug-patterns.md
@@ -799,3 +799,43 @@ transition; persist the desired state, suppress only `drive_plan.run`, then reco
 current state when the blocker is released (Invariant 15). Tests:
 `TestPatternASBlockedEffectsKeepStateCurrent` in
 `tests/test_documented_bug_patterns.py` and the paired manual/force parity scenarios.
+
+### Bug Pattern AT: A vent-hold branch demands an *explicit* "opened reads closed" while the rest of the system reads invalid as "off" (Issue #650)
+
+**Symptom:** The window is tilted, the cover rests at the ventilation position. The
+"ultimate" evening closing trigger (latest closing time) fires and the cover **closes
+completely** — the ventilation is canceled although the tilted contact is alive and `on`.
+The trace shows the closing handler falling through to the "Normal closing" default; the
+*opened* contact reads `unavailable`/`unknown` at that moment (battery handles/contacts
+that hubs mark unavailable after hours without an event, or template helpers built on
+such handles — the same device class as Bug Pattern AN / #622; the #650 reporter's
+Siegenia handle helper read `unknown`, confirmed by the follow-up run's logbook dump:
+`Effective: vnt`, position 0 %, `opn=unknown tlt=on`). The identical hole existed in
+"Ventilation after shading ends".
+
+**Cause:** The AN fix (#622) deliberately lets these runs pass the stateless-contact gate
+on the premise that *"an invalid contact reads as 'off' in every handler"* — with
+`win == 'tlt'` the invalid opened read agrees with the last known truth. But two branches
+still contradicted that premise: the closing handler's "Window tilted. No lockout. Move to
+ventilation position instead of closing" and the shading-end "Ventilation after shading
+ends" gated on `window_opened_clear` (opened must read an **explicit** `off`/`false`), not
+on `not window_opened_now`. With the opened contact invalid the vent-hold branch was
+skipped and execution fell through to a branch that drives **past** the tilted window —
+strictly worse than the reading the guard distrusted: the cascade (`effective_state`,
+`recovered_state`, `shading_end_state`, contact handler, resident handlers, force
+recovery — all `not window_opened_now`) says `vnt` in exactly this situation.
+
+**Fix:** Both branches gate on `not window_opened_now` (2026.08.13), the now-unused
+`window_opened_clear` variable was removed. Invariant 5's canonical form ("opened contact
+not *active*") was already the relaxed check.
+
+**Rule:** A guard on a branch must be judged against its **fall-through**, not in
+isolation: being extra-conservative about a sensor reading is wrong when the conditions
+below the branch drive to a *more* dangerous target on the same reading. And AN's premise
+is binding — any handler that interprets a window contact must read an invalid contact as
+"off" (`not window_opened_now` / `not window_tilted_now`), so all consumers stay
+consistent with the gate that decided to let the run through. Tests:
+`TestPatternATVentHoldSurvivesInvalidOpenedContact` in
+`tests/test_documented_bug_patterns.py`.
+
+---

--- a/blueprints/automation/cover_control_automation.yaml
+++ b/blueprints/automation/cover_control_automation.yaml
@@ -4,7 +4,7 @@ blueprint:
     # ⭐ Cover Control Automation (CCA) ⭐
     Cover Control Automation is a comprehensive Home Assistant blueprint which automatically manages your window coverings (such as roller shutters and blinds) based on time, the position of the sun, and weather conditions. It adapts intelligently to your preferences, largely eliminating the need for manual adjustments.
 
-    **Version**: 2026.08.02
+    **Version**: 2026.08.13
 
     ### 🔗 Resources & Support
     📢 **Latest Changes**: [Changelog](https://hvorragend.github.io/ha-blueprints/CHANGELOG) | ✨ **Highlights**: [Key Features](https://hvorragend.github.io/ha-blueprints/#key-features)
@@ -2578,7 +2578,7 @@ trigger_variables:
 ################################################################################
 
 variables:
-  version: "2026.08.02"
+  version: "2026.08.13"
 
   # Force pause
   is_paused: "{{ force_pause != [] and states(force_pause) in ['on', 'true'] }}"
@@ -4859,9 +4859,6 @@ actions:
       window_opened_now: "{{ contact_window_opened != [] and states(contact_window_opened) in ['true', 'on'] }}"
       window_tilted_now: "{{ contact_window_tilted != [] and states(contact_window_tilted) in ['true', 'on'] }}"
       window_any_now: "{{ window_opened_now or window_tilted_now }}"
-      # Explicitly closed/unconfigured - NOT the negation of window_opened_now:
-      # an unavailable sensor is neither "open" nor "explicitly closed".
-      window_opened_clear: "{{ contact_window_opened == [] or states(contact_window_opened) in ['false', 'off'] }}"
 
       # Lockout evaluation per context: a fully open window always locks out,
       # a tilted window only when the matching lockout option is enabled.
@@ -6333,7 +6330,7 @@ actions:
                   - *auto_ventilate_condition_check
                   - "{{ window_tilted_now }}"
                   - "{{ not lockout_tilted_when_closing }}"
-                  - "{{ window_opened_clear }}"
+                  - "{{ not window_opened_now }}"
                 sequence:
                   - variables:
                       # This is still the scheduled closing event. Its Manual
@@ -6942,7 +6939,7 @@ actions:
                       - "{{ resident_flags.allow_ventilate }}"
                       - *auto_ventilate_condition_check
                       - "{{ window_tilted_now }}"
-                      - "{{ window_opened_clear }}"
+                      - "{{ not window_opened_now }}"
                       - or:
                           - "{{ position_comparisons.current_below_ventilate }}"
                           - and:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 **Note:** Previous changes are archived here: [CHANGELOG_OLD.md](https://hvorragend.github.io/ha-blueprints/CHANGELOG_OLD).
 
+# CCA 2026.08.13
+
+- 🐛 **Fix:** The **evening closing could cancel an active ventilation**: with the window tilted and the cover at the 💨 Ventilation Position, the closing trigger (e.g. the latest closing time) **closed the cover completely** whenever the window's *opened* contact sensor happened to read unavailable/unknown at that moment — typical for battery handles and contacts (or template helpers built on them), which some hubs mark unavailable after hours without an event. The tilted contact was alive and reporting "tilted" the whole time, and everywhere else CCA already treats an unreachable opened contact as "not open" (that is what lets these runs proceed at all since `2026.07.25`) — only the "window tilted → keep the ventilation position" checks of the evening closing and of the sun shading end still insisted on an explicit "closed" reading and fell through to a full close. Both now accept the same reading as the rest of the automation: a tilted window keeps its ventilation position even while the opened contact is momentarily unreachable ([#650](https://github.com/hvorragend/ha-blueprints/issues/650))
+
+---
+
 # CCA 2026.08.02
 
 - ⚠️ **Change:** The minimum supported Home Assistant version is now **2025.4.0**. CCA's transition architecture relies on the variable-scope behavior introduced in HA 2025.4: values assigned inside nested `if`/`choose` actions update the enclosing script scope. On older versions those assignments remain local, which silently prevents movement decisions, after-actions and drive bookkeeping from reaching the shared transition epilogue

--- a/tests/test_documented_bug_patterns.py
+++ b/tests/test_documented_bug_patterns.py
@@ -1597,3 +1597,104 @@ class TestIssue544TimeControlDisable:
             "is_calendar_enabled", ["time_control_enabled"], "time_control_calendar",
             calendar_entity="calendar.covers",
         ) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pattern AT (#650): the vent-hold branches must read an invalid opened contact
+# as "not open" (not window_opened_now), never demand an explicit 'off'
+# (window_opened_clear) — the fall-through drives past the tilted window.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+SHADING_END_VENT_ALIAS = "Ventilation after shading ends"
+
+
+class TestPatternATVentHoldSurvivesInvalidOpenedContact:
+    """#650: ventilation canceled by the closing trigger while the opened
+    contact reads unavailable/unknown (battery handle asleep, AN premise)."""
+
+    @pytest.fixture(scope="class")
+    def blueprint(self):
+        return _load_blueprint_yaml()
+
+    def _eval_cond(self, env, cond, variables):
+        if isinstance(cond, str):
+            return env.from_string(cond).render(**variables).strip() == "True"
+        if isinstance(cond, dict):
+            if "and" in cond:
+                return all(self._eval_cond(env, c, variables) for c in cond["and"])
+            if "or" in cond:
+                return any(self._eval_cond(env, c, variables) for c in cond["or"])
+            return True  # condition: !input ... user condition counts as passed
+        return True
+
+    def _flags(self, blueprint, opened_state: str, tilted_state: str) -> dict:
+        """Render the blueprint's own normalized flags against mocked states."""
+        entity_states = {
+            "binary_sensor.opened": opened_state,
+            "binary_sensor.tilted": tilted_state,
+        }
+        env = jinja2.Environment(undefined=jinja2.Undefined)
+        env.globals["states"] = lambda e: entity_states.get(e, "unknown")
+        base = {
+            "contact_window_opened": "binary_sensor.opened",
+            "contact_window_tilted": "binary_sensor.tilted",
+        }
+        flags = dict(base)
+        for name in ("window_opened_now", "window_tilted_now"):
+            definition = _find_variable_definition(blueprint, name)
+            assert definition is not None, f"{name} definition not found"
+            flags[name] = (
+                env.from_string(str(definition)).render(**base).strip() == "True"
+            )
+        return flags
+
+    def _closing_branch_matches(self, blueprint, opened_state, tilted_state) -> bool:
+        branch = _find_branch_by_alias(blueprint, TILTED_CLOSE_ALIAS)
+        assert branch is not None
+        variables = self._flags(blueprint, opened_state, tilted_state)
+        variables.update(
+            is_ventilation_enabled=True,
+            resident_flags={"allow_ventilate": True},
+            lockout_tilted_when_closing=False,
+        )
+        env = jinja2.Environment(undefined=jinja2.Undefined)
+        return all(
+            self._eval_cond(env, cond, variables)
+            for cond in branch["conditions"]
+        )
+
+    def test_unavailable_opened_contact_keeps_ventilation(self, blueprint):
+        # The reported scenario: window tilted (contact alive), opened contact
+        # unavailable at the latest-closing-time trigger. The vent-hold branch
+        # must match so the run does not fall through to "Normal closing".
+        assert self._closing_branch_matches(blueprint, "unavailable", "on")
+        assert self._closing_branch_matches(blueprint, "unknown", "on")
+
+    def test_explicitly_closed_opened_contact_keeps_ventilation(self, blueprint):
+        assert self._closing_branch_matches(blueprint, "off", "on")
+
+    def test_open_window_still_excluded(self, blueprint):
+        # Invariant 5: an actively 'on' opened contact must keep the tilted
+        # branch out (lockout handles it).
+        assert not self._closing_branch_matches(blueprint, "on", "on")
+
+    def test_no_tilt_no_match(self, blueprint):
+        assert not self._closing_branch_matches(blueprint, "off", "off")
+
+    def test_window_opened_clear_removed(self, blueprint):
+        # The stricter idiom must not come back: no branch may demand an
+        # explicit 'off' reading before holding the ventilation floor.
+        assert "window_opened_clear" not in _blueprint_text(), (
+            "window_opened_clear reintroduced — vent-hold branches must gate "
+            "on 'not window_opened_now' (Pattern AT, #650)"
+        )
+
+    def test_vent_hold_branches_gate_on_not_window_opened_now(self, blueprint):
+        for alias in (TILTED_CLOSE_ALIAS, SHADING_END_VENT_ALIAS):
+            branch = _find_branch_by_alias(blueprint, alias)
+            assert branch is not None, f"branch not found: {alias!r}"
+            flat = " ".join(str(c) for c in branch["conditions"])
+            assert "not window_opened_now" in flat, (
+                f"{alias!r} must gate on 'not window_opened_now' (Pattern AT)"
+            )

--- a/tests/test_recovery_live_parity.py
+++ b/tests/test_recovery_live_parity.py
@@ -247,8 +247,7 @@ def _context(s: dict, trigger_id: str) -> tuple[dict, dict]:
     ctx["manual_allows_event"] = Runner(ctx, entities, {}).render(
         _top_var("manual_allows_event")
     )
-    for name in ("window_opened_now", "window_tilted_now", "window_any_now",
-                 "window_opened_clear"):
+    for name in ("window_opened_now", "window_tilted_now", "window_any_now"):
         ctx[name] = Runner(ctx, entities, {}).render(_action_var(name))
     for name in ("in_open_position", "in_close_position", "in_shading_position",
                  "in_ventilate_position", "in_lockout_position",

--- a/tests/test_shading_end_priority.py
+++ b/tests/test_shading_end_priority.py
@@ -160,7 +160,6 @@ def _base_execution_vars(entity_states: dict) -> dict:
         # post-forecast variables block), derived from the mocked states.
         "window_opened_now": entity_states.get("binary_sensor.window_opened") in ("on", "true"),
         "window_tilted_now": entity_states.get("binary_sensor.window_tilted") in ("on", "true"),
-        "window_opened_clear": entity_states.get("binary_sensor.window_opened") in ("off", "false", None),
         "lockout_now": {
             "shading_end": entity_states.get("binary_sensor.window_opened") in ("on", "true"),
         },
@@ -226,6 +225,20 @@ class TestShadingEndBranchSelection:
         # of keeping the shading position with slats at the open tilt.
         entity_states = {
             "binary_sensor.window_opened": "off",
+            "binary_sensor.window_tilted": "on",
+        }
+        variables = _base_execution_vars(entity_states)
+        alias = _first_matching_alias(_env(entity_states), choose, variables)
+        assert alias == "Ventilation after shading ends"
+
+    def test_issue_650_unavailable_opened_contact_still_selects_ventilation(self, choose):
+        # Pattern AT (#650): a battery opened-contact that reads 'unavailable'
+        # must count as "not open" (AN premise: an invalid contact reads as
+        # 'off' in every handler). The vent branch used to demand an explicit
+        # 'off' via window_opened_clear and fell through to a branch that
+        # drives past the tilted window.
+        entity_states = {
+            "binary_sensor.window_opened": "unavailable",
             "binary_sensor.window_tilted": "on",
         }
         variables = _base_execution_vars(entity_states)


### PR DESCRIPTION
the closing and shading-end vent-hold branches demanded an explicit 'off' reading from the opened contact (window_opened_clear) and fell through to a full close past the live tilted contact whenever a battery handle read unavailable/unknown. both branches now read an invalid contact as "not open" (not window_opened_now), matching effective_state, shading_end_state, the contact handler and the #622 gate premise. the now-unused window_opened_clear variable is removed (#650, Bug Pattern AT)


Claude-Session: https://claude.ai/code/session_01CYsNDW9bqUzssd4DTAmJ9D