### PR TITLE
docs: explain elevation-based evening retract for awnings

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,6 +14,7 @@ This comprehensive FAQ covers the most common questions about Cover Control Auto
 4. [Time & Schedule Control](#time--schedule-control)
 5. [Position Settings](#position-settings)
 6. [Cover Types (Blinds vs. Awnings)](#cover-types-blinds-vs-awnings)
+   - [How do I retract my awning in the evening based on sun elevation?](#q-how-do-i-retract-my-awning-in-the-evening-based-on-sun-elevation)
 7. [Sun Shading & Sun Protection](#sun-shading--sun-protection)
 8. [Ventilation & Contact Sensors](#ventilation--contact-sensors)
    - [Which window sensor has higher priority — opened or tilted?](#q-which-window-sensor-has-higher-priority--opened-or-tilted)
@@ -526,6 +527,33 @@ Open Position: 0%     # Retracted
 Shading Position: 75% # Extended for shade
 Close Position: 100%  # Fully extended
 ```
+
+---
+
+### Q: How do I retract my awning in the evening based on sun elevation?
+
+**A:** Not with *Evening Closing* — closing always drives to the **Close Position**, and for an awning that means *extending* it. Enabling ☀️ Sun Elevation Control together with 🔻 Evening Closing therefore extends the awning around sunset instead of retracting it. There is no combination of the opening/closing options that maps a falling sun to the Open Position — that job belongs to the **shading end**:
+
+**Recommended setup (pure sun-driven awning):**
+
+1. In *What should CCA control?* enable only **🥵 Sun Protection / Shading**. Leave Morning Opening, Evening Closing and Time Control unchecked — the base state then stays "open" (= retracted) permanently, and shading is the only thing that ever extends the awning.
+2. Configure the shading start conditions as usual (azimuth, elevation, brightness, …).
+3. Set the **Sun Shading Elevation minimum** to your evening threshold (e.g. `10°`). Once the sun drops below it, the shading END triggers fire and the awning returns to the Open Position — retracted, purely elevation-based, no fixed time involved.
+
+If shading ended earlier for another reason (brightness, azimuth out of range), the awning is already retracted by then — there is nothing left to do in the evening.
+
+**Guaranteed retract, independent of everything (recommended for wind-sensitive awnings):**
+
+A manually extended awning is protected by the manual override, so the shading end will not touch it. If the awning must be retracted below a certain elevation *no matter what*, use the **Force Open** entity with a template sensor:
+
+```yaml
+template:
+  - binary_sensor:
+      - name: "Awning night retract"
+        state: "{{ state_attr('sun.sun', 'elevation') | float(0) < 10 }}"
+```
+
+Configure it as *Force Opening* (`auto_up_force`). Force sits at the top of the priority cascade: when the sensor turns `on`, the awning retracts — regardless of shading state or manual override — and stays retracted all night. In the morning the sensor turns `off` and (with force recovery enabled) CCA resumes normal control.
 
 ---
 

--- a/docs/handbook/positions.md
+++ b/docs/handbook/positions.md
@@ -66,6 +66,10 @@ Select the type of cover you want to control. <br /><br /> <strong>Blind/Roller 
 
 <strong>For Blinds/Shutters:</strong><br /> - Open Position: 100% (fully up)<br /> - Shading Position: 25% (partially down for sun protection)<br /> - Ventilate Position: 30% (slightly down for air flow)<br /> - Close Position: 0% (fully down)<br /> <br /> <strong>For Awnings:</strong><br /> - Open Position: 0% (retracted/closed)<br /> - Shading Position: 75% (extended for sun protection)<br /> - Close Position: 100% (fully extended)<br /> <br /> <em>Note: Ventilate Position is not used for awnings.</em>
 
+### Evening behavior for awnings
+
+*Closing* always drives to the Close Position — for an awning that means **extending** it. Do not enable 🔻 *Evening Closing* together with ☀️ *Sun Elevation Control* to retract an awning at sunset: it will extend instead. To retract the awning when the sun gets low, use the **shading end conditions** (sun shading elevation minimum) — shading end returns the awning to the Open Position (retracted) — or a *Force Opening* entity for a guaranteed retract that also overrides a manual extension. Full recipe: [FAQ: How do I retract my awning in the evening based on sun elevation?](https://hvorragend.github.io/ha-blueprints/FAQ#q-how-do-i-retract-my-awning-in-the-evening-based-on-sun-elevation)
+
 ---
 
 <a id="open_position"></a>

--- a/docs/validator/validator.js
+++ b/docs/validator/validator.js
@@ -516,6 +516,10 @@ class CCAValidator {
 
         if (isAwning) {
             this.addInfo('☂️ Awning mode detected (0%=retracted, 100%=extended)');
+            const awningAutoOptions = c.auto_options || [];
+            if (awningAutoOptions.includes('auto_down_enabled')) {
+                this.addInfo('☂️ Awning + Evening Closing: closing always drives to close_position, which for an awning means EXTENDING it (also with Sun Elevation Control: falling sun → extend). To retract the awning when the sun gets low, use the shading END conditions (sun elevation minimum) or a Force Opening entity instead. See FAQ: "How do I retract my awning in the evening based on sun elevation?"');
+            }
             this.checkPositionOrder('open_position', 'close_position', '<', 'For awnings: open_position must be lower than close_position');
             if (c.shading_position !== undefined) {
                 this.checkPositionOrder('shading_position', 'close_position', '<', 'For awnings: shading_position must be lower than close_position');


### PR DESCRIPTION
evening closing always drives to close_position, which extends an awning;
document the shading-end (elevation minimum) and force-open recipes in the
FAQ and handbook, and add a validator info for awning + auto_down_enabled

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PwFLqeby2ZakHzpettNiLH